### PR TITLE
Add DeleteUserAlert to node sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3433,6 +3433,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/dateformat": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dateformat/-/dateformat-3.0.1.tgz",
+      "integrity": "sha512-KlPPdikagvL6ELjWsljbyDIPzNCeliYkqRpI+zea99vBBbCIA5JNshZAwQKTON139c87y9qvTFVgkFd14rtS4g=="
+    },
     "node_modules/@types/express": {
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
@@ -4190,6 +4195,80 @@
       "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
       "dependencies": {
         "follow-redirects": "^1.14.8"
+      }
+    },
+    "node_modules/axios-logger": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/axios-logger/-/axios-logger-2.6.0.tgz",
+      "integrity": "sha512-ogDepYNCul91KWf+BV8tweB3gm4n2apA69L9aY5fUO2Pvck/gIK4Q+zs7avduyxaOn88ZzSWv0PeMZaxBt+YOw==",
+      "dependencies": {
+        "@types/dateformat": "^3.0.1",
+        "chalk": "^4.1.0",
+        "dateformat": "^3.0.3"
+      }
+    },
+    "node_modules/axios-logger/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/axios-logger/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/axios-logger/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/axios-logger/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/axios-logger/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/axios-logger/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/babel-jest": {
@@ -5492,7 +5571,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -15273,13 +15351,13 @@
     },
     "packages/notifi-axios-adapter": {
       "name": "@notifi-network/notifi-axios-adapter",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@notifi-network/notifi-axios-utils": "^0.4.0"
+        "@notifi-network/notifi-axios-utils": "^0.5.0"
       },
       "devDependencies": {
-        "@notifi-network/notifi-core": "^0.4.0"
+        "@notifi-network/notifi-core": "^0.5.0"
       },
       "peerDependencies": {
         "axios": "^0.26.0"
@@ -15287,7 +15365,7 @@
     },
     "packages/notifi-axios-utils": {
       "name": "@notifi-network/notifi-axios-utils",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "peerDependencies": {
         "axios": "^0.26.1"
@@ -15295,7 +15373,7 @@
     },
     "packages/notifi-core": {
       "name": "@notifi-network/notifi-core",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "rimraf": "^3.0.2"
@@ -15303,10 +15381,10 @@
     },
     "packages/notifi-node": {
       "name": "@notifi-network/notifi-node",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@notifi-network/notifi-axios-utils": "^0.4.0"
+        "@notifi-network/notifi-axios-utils": "^0.5.0"
       },
       "peerDependencies": {
         "axios": "^0.26.1"
@@ -15314,9 +15392,11 @@
     },
     "packages/notifi-node-sample": {
       "name": "@notifi-network/notifi-node-sample",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.26.1",
+        "axios-logger": "^2.6.0",
         "express": "^4.17.3",
         "morgan": "^1.10.0",
         "morgan-json": "^1.1.0"
@@ -15332,7 +15412,7 @@
     },
     "packages/notifi-react-hooks": {
       "name": "@notifi-network/notifi-react-hooks",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.26.0",
@@ -17628,8 +17708,8 @@
     "@notifi-network/notifi-axios-adapter": {
       "version": "file:packages/notifi-axios-adapter",
       "requires": {
-        "@notifi-network/notifi-axios-utils": "^0.4.0",
-        "@notifi-network/notifi-core": "^0.4.0"
+        "@notifi-network/notifi-axios-utils": "^0.5.0",
+        "@notifi-network/notifi-core": "^0.5.0"
       }
     },
     "@notifi-network/notifi-axios-utils": {
@@ -17645,7 +17725,7 @@
     "@notifi-network/notifi-node": {
       "version": "file:packages/notifi-node",
       "requires": {
-        "@notifi-network/notifi-axios-utils": "^0.4.0"
+        "@notifi-network/notifi-axios-utils": "^0.5.0"
       }
     },
     "@notifi-network/notifi-node-sample": {
@@ -17656,6 +17736,7 @@
         "@types/morgan-json": "^1.1.0",
         "@types/node": "^17.0.21",
         "axios": "^0.26.1",
+        "axios-logger": "^2.6.0",
         "express": "^4.17.3",
         "morgan": "^1.10.0",
         "morgan-json": "^1.1.0",
@@ -18080,6 +18161,11 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/dateformat": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dateformat/-/dateformat-3.0.1.tgz",
+      "integrity": "sha512-KlPPdikagvL6ELjWsljbyDIPzNCeliYkqRpI+zea99vBBbCIA5JNshZAwQKTON139c87y9qvTFVgkFd14rtS4g=="
     },
     "@types/express": {
       "version": "4.17.13",
@@ -18679,6 +18765,61 @@
       "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
       "requires": {
         "follow-redirects": "^1.14.8"
+      }
+    },
+    "axios-logger": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/axios-logger/-/axios-logger-2.6.0.tgz",
+      "integrity": "sha512-ogDepYNCul91KWf+BV8tweB3gm4n2apA69L9aY5fUO2Pvck/gIK4Q+zs7avduyxaOn88ZzSWv0PeMZaxBt+YOw==",
+      "requires": {
+        "@types/dateformat": "^3.0.1",
+        "chalk": "^4.1.0",
+        "dateformat": "^3.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "babel-jest": {
@@ -19693,8 +19834,7 @@
     "dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-      "dev": true
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
     },
     "debug": {
       "version": "4.3.3",

--- a/packages/notifi-node-sample/package.json
+++ b/packages/notifi-node-sample/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@notifi-network/notifi-node": "^0.5.0",
     "axios": "^0.26.1",
+    "axios-logger": "^2.6.0",
     "express": "^4.17.3",
     "morgan": "^1.10.0",
     "morgan-json": "^1.1.0"

--- a/packages/notifi-node/lib/client/NotifiClient.spec.ts
+++ b/packages/notifi-node/lib/client/NotifiClient.spec.ts
@@ -238,4 +238,90 @@ describe('NotifiClient', () => {
       ).resolves.not.toThrow();
     });
   });
+
+  describe('deleteUserAlert', () => {
+    it('calls post with the right parameters', async () => {
+      postSpy.mockResolvedValueOnce({
+        data: {
+          data: {
+            deleteUserAlert: {
+              id: 'some-id',
+            },
+          },
+        },
+      });
+
+      await subject.deleteUserAlert('some-jwt', {
+        alertId: 'some-id',
+      });
+
+      expect(postSpy).toHaveBeenCalledTimes(1);
+      expect(postSpy).toHaveBeenCalledWith(
+        expect.stringMatching('/'),
+        {
+          query: expect.stringContaining('deleteUserAlert'),
+          variables: {
+            alertId: 'some-id',
+          },
+        },
+        {
+          headers: {
+            Authorization: `Bearer some-jwt`,
+          },
+        },
+      );
+    });
+
+    it('throws when underlying request throws', async () => {
+      postSpy.mockRejectedValueOnce(new Error('Some network error'));
+      await expect(
+        subject.deleteUserAlert('some-jwt', {
+          alertId: 'some-id',
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('throws when query succeeds with errors', async () => {
+      postSpy.mockResolvedValueOnce({
+        data: {
+          errors: [{ message: 'Some graphQL error' }],
+        },
+      });
+
+      await expect(
+        subject.deleteUserAlert('some-jwt', {
+          alertId: 'some-id',
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('throws when query succeeds with no data', async () => {
+      postSpy.mockResolvedValueOnce({
+        data: {},
+      });
+      await expect(
+        subject.deleteUserAlert('some-jwt', {
+          alertId: 'some-id',
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('does not throw when query has both data and errors', async () => {
+      postSpy.mockResolvedValueOnce({
+        data: {
+          data: {
+            deleteUserAlert: {
+              id: 'some-id',
+            },
+          },
+          errors: [{ message: 'Some graphQL error' }],
+        },
+      });
+      await expect(
+        subject.deleteUserAlert('some-jwt', {
+          alertId: 'some-id',
+        }),
+      ).resolves.not.toThrow();
+    });
+  });
 });

--- a/packages/notifi-node/lib/client/NotifiClient.spec.ts
+++ b/packages/notifi-node/lib/client/NotifiClient.spec.ts
@@ -126,6 +126,13 @@ describe('NotifiClient', () => {
   });
 
   describe('sendSimpleHealthThreshold', () => {
+    const params: Parameters<NotifiClient['sendSimpleHealthThreshold']>[1] = {
+      key: 'some-message-key',
+      walletPublicKey: 'base58string',
+      walletBlockchain: 'SOLANA',
+      value: 0.5,
+    };
+
     it('calls post with the right parameters', async () => {
       postSpy.mockResolvedValueOnce({
         data: {
@@ -135,11 +142,7 @@ describe('NotifiClient', () => {
         },
       });
 
-      await subject.sendSimpleHealthThreshold('some-jwt', {
-        walletPublicKey: 'base58string',
-        walletBlockchain: 'SOLANA',
-        value: 0,
-      });
+      await subject.sendSimpleHealthThreshold('some-jwt', params);
 
       expect(postSpy).toHaveBeenCalledTimes(1);
       expect(postSpy).toHaveBeenCalledWith(
@@ -148,7 +151,8 @@ describe('NotifiClient', () => {
           query: expect.stringContaining('sendMessage'),
           variables: {
             input: {
-              message: JSON.stringify({ value: 0 }),
+              message: JSON.stringify({ value: 0.5 }),
+              messageKey: 'some-message-key',
               messageType: 'SIMPLE_HEALTH_THRESHOLD',
               walletBlockchain: 'SOLANA',
               walletPublicKey: 'base58string',
@@ -173,22 +177,14 @@ describe('NotifiClient', () => {
       });
 
       await expect(
-        subject.sendSimpleHealthThreshold('some-jwt', {
-          walletPublicKey: 'base58string',
-          walletBlockchain: 'SOLANA',
-          value: 0,
-        }),
+        subject.sendSimpleHealthThreshold('some-jwt', params),
       ).rejects.toThrow();
     });
 
     it('throws when underlying request throws', async () => {
       postSpy.mockRejectedValueOnce(new Error('Some network error'));
       await expect(
-        subject.sendSimpleHealthThreshold('some-jwt', {
-          walletPublicKey: 'base58string',
-          walletBlockchain: 'SOLANA',
-          value: 0,
-        }),
+        subject.sendSimpleHealthThreshold('some-jwt', params),
       ).rejects.toThrow();
     });
 
@@ -199,11 +195,7 @@ describe('NotifiClient', () => {
         },
       });
       await expect(
-        subject.sendSimpleHealthThreshold('some-jwt', {
-          walletPublicKey: 'base58string',
-          walletBlockchain: 'SOLANA',
-          value: 0,
-        }),
+        subject.sendSimpleHealthThreshold('some-jwt', params),
       ).rejects.toThrow();
     });
 
@@ -212,11 +204,7 @@ describe('NotifiClient', () => {
         data: {},
       });
       await expect(
-        subject.sendSimpleHealthThreshold('some-jwt', {
-          walletPublicKey: 'base58string',
-          walletBlockchain: 'SOLANA',
-          value: 0,
-        }),
+        subject.sendSimpleHealthThreshold('some-jwt', params),
       ).rejects.toThrow();
     });
 
@@ -230,11 +218,7 @@ describe('NotifiClient', () => {
         },
       });
       await expect(
-        subject.sendSimpleHealthThreshold('some-jwt', {
-          walletPublicKey: 'base58string',
-          walletBlockchain: 'SOLANA',
-          value: 0,
-        }),
+        subject.sendSimpleHealthThreshold('some-jwt', params),
       ).resolves.not.toThrow();
     });
   });

--- a/packages/notifi-node/lib/client/NotifiClient.ts
+++ b/packages/notifi-node/lib/client/NotifiClient.ts
@@ -1,4 +1,8 @@
-import { logInFromServiceImpl, sendMessageImpl } from '../mutations';
+import {
+  deleteUserAlertImpl,
+  logInFromServiceImpl,
+  sendMessageImpl,
+} from '../mutations';
 import { Authorization, newSimpleHealthThresholdMessage } from '../types';
 import type { AxiosPost } from '@notifi-network/notifi-axios-utils';
 
@@ -37,6 +41,16 @@ class NotifiClient {
     if (!result) {
       throw new Error('Send message failed');
     }
+  };
+
+  deleteUserAlert: (
+    jwt: string,
+    params: Readonly<{
+      alertId: string;
+    }>,
+  ) => Promise<string /* AlertID */> = async (jwt, { alertId }) => {
+    await deleteUserAlertImpl(this.a, jwt, { alertId });
+    return alertId;
   };
 }
 

--- a/packages/notifi-node/lib/client/NotifiClient.ts
+++ b/packages/notifi-node/lib/client/NotifiClient.ts
@@ -22,18 +22,20 @@ class NotifiClient {
   sendSimpleHealthThreshold: (
     jwt: string,
     params: Readonly<{
+      key: string;
       walletPublicKey: string;
       walletBlockchain: 'SOLANA';
       value: number;
     }>,
   ) => Promise<void> = async (
     jwt,
-    { walletPublicKey, walletBlockchain, value },
+    { key, walletPublicKey, walletBlockchain, value },
   ) => {
     const message = newSimpleHealthThresholdMessage({ value });
     const input = {
       walletPublicKey,
       walletBlockchain,
+      messageKey: key,
       messageType: message.type,
       message: JSON.stringify(message.payload),
     };

--- a/packages/notifi-node/lib/client/index.ts
+++ b/packages/notifi-node/lib/client/index.ts
@@ -1,5 +1,5 @@
+import NotifiClient from './NotifiClient';
 import createAxiosInstance from './createAxiosInstance';
-import NotifiClient from './notifiClient';
 import type { NotifiEnvironment } from '@notifi-network/notifi-axios-utils';
 
 export type { NotifiEnvironment };

--- a/packages/notifi-node/lib/mutations/deleteUserAlertImpl.ts
+++ b/packages/notifi-node/lib/mutations/deleteUserAlertImpl.ts
@@ -1,0 +1,30 @@
+import {
+  collectDependencies,
+  makeAuthenticatedRequest,
+} from '@notifi-network/notifi-axios-utils';
+
+export type DeleteUserAlertInput = Readonly<{
+  alertId: string;
+}>;
+
+export type DeleteUserAlertResult = Readonly<{
+  id: string;
+}>;
+
+const DEPENDENCIES: string[] = [];
+
+const MUTATION = `
+mutation deleteUserAlert($alertId: String!) {
+  deleteUserAlert(alertId: $alertId) {
+    id
+  }
+}
+
+`.trim();
+
+const deleteUserAlertImpl = makeAuthenticatedRequest<
+  DeleteUserAlertInput,
+  DeleteUserAlertResult
+>(collectDependencies(...DEPENDENCIES, MUTATION), 'deleteUserAlert');
+
+export default deleteUserAlertImpl;

--- a/packages/notifi-node/lib/mutations/index.ts
+++ b/packages/notifi-node/lib/mutations/index.ts
@@ -1,4 +1,5 @@
+import deleteUserAlertImpl from './deleteUserAlertImpl';
 import logInFromServiceImpl from './logInFromServiceImpl';
 import sendMessageImpl from './sendMessageImpl';
 
-export { logInFromServiceImpl, sendMessageImpl };
+export { deleteUserAlertImpl, logInFromServiceImpl, sendMessageImpl };

--- a/packages/notifi-node/lib/mutations/sendMessageImpl.ts
+++ b/packages/notifi-node/lib/mutations/sendMessageImpl.ts
@@ -7,6 +7,7 @@ export type SendMessageInput = Readonly<{
   input: Readonly<{
     walletPublicKey: string;
     walletBlockchain: 'SOLANA';
+    messageKey: string;
     message: string;
     messageType: 'SIMPLE_HEALTH_THRESHOLD';
   }>;


### PR DESCRIPTION
This mutation allows the service user to, on behalf of a user, delete an
alert which is owned by a user on the tenant.

This enables the use case for Mango to minimize integration footprint.

I've updated the sample
- Add new example for deleteUserAlert
- dedupe some logic via refactor to middleware