### PR TITLE
Dedupe fetch in fetchDataImpl

### DIFF
--- a/packages/notifi-react-hooks/lib/utils/fetchDataImpl.spec.ts
+++ b/packages/notifi-react-hooks/lib/utils/fetchDataImpl.spec.ts
@@ -1,0 +1,116 @@
+import fetchDataImpl, { FetchDataState } from './fetchDataImpl';
+
+describe('fetchDataImpl', () => {
+  const service = {
+    getAlerts: jest.fn().mockResolvedValue([]),
+    getSources: jest.fn().mockResolvedValue([]),
+    getSourceGroups: jest.fn().mockResolvedValue([]),
+    getTargetGroups: jest.fn().mockResolvedValue([]),
+    getEmailTargets: jest.fn().mockResolvedValue([]),
+    getSmsTargets: jest.fn().mockResolvedValue([]),
+    getTelegramTargets: jest.fn().mockResolvedValue([]),
+  };
+
+  const timeProvider = {
+    now: jest.fn().mockReturnValue(2000),
+  };
+
+  beforeEach(() => {
+    service.getAlerts.mockClear();
+    service.getSources.mockClear();
+    service.getSourceGroups.mockClear();
+    service.getTargetGroups.mockClear();
+    service.getEmailTargets.mockClear();
+    service.getSmsTargets.mockClear();
+    service.getTelegramTargets.mockClear();
+    timeProvider.now.mockClear();
+  });
+
+  const expectServiceCalls = (count: number) => {
+    expect(service.getAlerts).toHaveBeenCalledTimes(count);
+    expect(service.getSources).toHaveBeenCalledTimes(count);
+    expect(service.getSourceGroups).toHaveBeenCalledTimes(count);
+    expect(service.getTargetGroups).toHaveBeenCalledTimes(count);
+    expect(service.getEmailTargets).toHaveBeenCalledTimes(count);
+    expect(service.getSmsTargets).toHaveBeenCalledTimes(count);
+    expect(service.getTelegramTargets).toHaveBeenCalledTimes(count);
+  };
+
+  it('calls services once for multiple invocations', () => {
+    let count = 0;
+    const state: FetchDataState = {};
+    const first = fetchDataImpl(service, timeProvider, state).then((_r) => {
+      // First invocation will be called first
+      expect(count).toEqual(0);
+      count++;
+    });
+    const second = fetchDataImpl(service, timeProvider, state).then((_r) => {
+      // Second invocation will be called second
+      expect(count).toEqual(1);
+      count++;
+    });
+    const third = fetchDataImpl(service, timeProvider, state).then((_r) => {
+      // Third invocation will be called third
+      expect(count).toEqual(2);
+      count++;
+    });
+
+    return Promise.all([first, second, third]).then(() => {
+      expectServiceCalls(1);
+    });
+  });
+
+  it('returns cached data when cache is fresh', async () => {
+    timeProvider.now.mockReturnValueOnce(4000);
+    const state: FetchDataState = {};
+    await fetchDataImpl(service, timeProvider, state);
+
+    timeProvider.now.mockReturnValueOnce(4500); // Soon after finish
+    await fetchDataImpl(service, timeProvider, state);
+
+    expect(timeProvider.now).toHaveBeenCalledTimes(2);
+    expectServiceCalls(1);
+  });
+
+  it('returns makes another request when cache is expired', async () => {
+    timeProvider.now.mockReturnValueOnce(4000);
+    const state: FetchDataState = {};
+    await fetchDataImpl(service, timeProvider, state);
+
+    timeProvider.now
+      .mockReturnValueOnce(6000) // Compare against cache
+      .mockReturnValueOnce(7000); // Set new success time
+    await fetchDataImpl(service, timeProvider, state);
+
+    expect(timeProvider.now).toHaveBeenCalledTimes(3);
+    expectServiceCalls(2);
+    expect(state.lastSuccessTime).toEqual(7000);
+  });
+
+  it('returns the applicableFilters from the sources', async () => {
+    service.getSources.mockResolvedValueOnce([
+      {
+        id: 'some-source-id',
+        name: 'A random source',
+        type: 'SOLANA_WALLET',
+        applicableFilters: [
+          {
+            id: 'some-filter-id',
+            name: 'A filter',
+            filterType: 'BALANCE',
+          },
+        ],
+      },
+    ]);
+
+    const state: FetchDataState = {};
+    const results = await fetchDataImpl(service, timeProvider, state);
+    expect(results.filters).toStrictEqual([
+      {
+        id: 'some-filter-id',
+        name: 'A filter',
+        filterType: 'BALANCE',
+      },
+    ]);
+  });
+});

--- a/packages/notifi-react-hooks/lib/utils/fetchDataImpl.ts
+++ b/packages/notifi-react-hooks/lib/utils/fetchDataImpl.ts
@@ -1,0 +1,120 @@
+import {
+  Alert,
+  EmailTarget,
+  Filter,
+  GetAlertsService,
+  GetEmailTargetsService,
+  GetSmsTargetsService,
+  GetSourceGroupsService,
+  GetSourcesService,
+  GetTargetGroupsService,
+  GetTelegramTargetsService,
+  SmsTarget,
+  Source,
+  SourceGroup,
+  TargetGroup,
+  TelegramTarget,
+} from '@notifi-network/notifi-core';
+
+export type InternalData = {
+  alerts: Alert[];
+  filters: Filter[];
+  sources: Source[];
+  sourceGroups: SourceGroup[];
+  targetGroups: TargetGroup[];
+  emailTargets: EmailTarget[];
+  smsTargets: SmsTarget[];
+  telegramTargets: TelegramTarget[];
+};
+
+export type FetchDataState = {
+  pendingPromise?: Promise<InternalData>;
+  lastSuccessTime?: number;
+  lastSuccessData?: InternalData;
+};
+
+export type TimeProvider = Readonly<{
+  now(): number;
+}>;
+
+type Service = GetAlertsService &
+  GetSourcesService &
+  GetSourceGroupsService &
+  GetTargetGroupsService &
+  GetEmailTargetsService &
+  GetSmsTargetsService &
+  GetTelegramTargetsService;
+
+const doFetchData = async (service: Service): Promise<InternalData> => {
+  const [
+    alerts,
+    sources,
+    sourceGroups,
+    targetGroups,
+    emailTargets,
+    smsTargets,
+    telegramTargets,
+  ] = await Promise.all([
+    service.getAlerts(),
+    service.getSources(),
+    service.getSourceGroups(),
+    service.getTargetGroups(),
+    service.getEmailTargets(),
+    service.getSmsTargets(),
+    service.getTelegramTargets(),
+  ]);
+
+  const filterIds = new Set<string | null>();
+  const filters: Filter[] = [];
+  sources.forEach((source) => {
+    source.applicableFilters.forEach((filter) => {
+      if (!filterIds.has(filter.id)) {
+        filters.push(filter);
+        filterIds.add(filter.id);
+      }
+    });
+  });
+
+  return {
+    alerts: [...alerts],
+    filters,
+    sources: [...sources],
+    sourceGroups: [...sourceGroups],
+    targetGroups: [...targetGroups],
+    emailTargets: [...emailTargets],
+    smsTargets: [...smsTargets],
+    telegramTargets: [...telegramTargets],
+  };
+};
+
+const DataTtlMs = 1000;
+
+const fetchDataImpl = async (
+  service: Service,
+  timeProvider: TimeProvider,
+  state: FetchDataState,
+): Promise<InternalData> => {
+  if (state.pendingPromise !== undefined) {
+    return await state.pendingPromise;
+  }
+
+  if (
+    state.lastSuccessTime !== undefined &&
+    state.lastSuccessData !== undefined
+  ) {
+    const currentTime = timeProvider.now();
+    if (currentTime <= state.lastSuccessTime + DataTtlMs) {
+      return state.lastSuccessData;
+    }
+  }
+
+  const promise = doFetchData(service);
+  state.pendingPromise = promise;
+  const results = await promise;
+  state.pendingPromise = undefined;
+  state.lastSuccessTime = timeProvider.now();
+  state.lastSuccessData = results;
+  return results;
+};
+
+export default fetchDataImpl;


### PR DESCRIPTION
There are some client usage patterns which would result in massive
overfetching. Dedupe if there are pending requests.

Also, there's a high likelihood that clients are using async / await
patterns. To solve for these cases, implement a cache TTL of 1000ms.