### PR TITLE
Add params to keep Source/TargetGroup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15351,13 +15351,13 @@
     },
     "packages/notifi-axios-adapter": {
       "name": "@notifi-network/notifi-axios-adapter",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@notifi-network/notifi-axios-utils": "^0.9.0"
+        "@notifi-network/notifi-axios-utils": "^0.10.0"
       },
       "devDependencies": {
-        "@notifi-network/notifi-core": "^0.9.0"
+        "@notifi-network/notifi-core": "^0.10.0"
       },
       "peerDependencies": {
         "axios": "^0.26.0"
@@ -15365,7 +15365,7 @@
     },
     "packages/notifi-axios-utils": {
       "name": "@notifi-network/notifi-axios-utils",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "peerDependencies": {
         "axios": "^0.26.1"
@@ -15373,7 +15373,7 @@
     },
     "packages/notifi-core": {
       "name": "@notifi-network/notifi-core",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "devDependencies": {
         "rimraf": "^3.0.2"
@@ -15381,11 +15381,11 @@
     },
     "packages/notifi-node": {
       "name": "@notifi-network/notifi-node",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@notifi-network/notifi-axios-utils": "^0.9.0",
-        "@notifi-network/notifi-core": "^0.9.0"
+        "@notifi-network/notifi-axios-utils": "^0.10.0",
+        "@notifi-network/notifi-core": "^0.10.0"
       },
       "peerDependencies": {
         "axios": "^0.26.1"
@@ -15393,10 +15393,10 @@
     },
     "packages/notifi-node-sample": {
       "name": "@notifi-network/notifi-node-sample",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@notifi-network/notifi-node": "^0.9.0",
+        "@notifi-network/notifi-node": "^0.10.0",
         "axios": "^0.26.1",
         "axios-logger": "^2.6.0",
         "express": "^4.17.3",
@@ -15414,18 +15414,18 @@
     },
     "packages/notifi-react-hooks": {
       "name": "@notifi-network/notifi-react-hooks",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@notifi-network/notifi-axios-adapter": "^0.9.0",
-        "@notifi-network/notifi-axios-utils": "^0.9.0",
+        "@notifi-network/notifi-axios-adapter": "^0.10.0",
+        "@notifi-network/notifi-axios-utils": "^0.10.0",
         "axios": "^0.26.0",
         "typedoc-plugin-missing-exports": "^0.22.6",
         "typescript": "^4.5.5",
         "use-local-storage-state": "^15.0.0"
       },
       "devDependencies": {
-        "@notifi-network/notifi-core": "^0.9.0",
+        "@notifi-network/notifi-core": "^0.10.0",
         "@types/node": "^17.0.21",
         "@types/react": "^17.0.39"
       },
@@ -17713,8 +17713,8 @@
     "@notifi-network/notifi-axios-adapter": {
       "version": "file:packages/notifi-axios-adapter",
       "requires": {
-        "@notifi-network/notifi-axios-utils": "^0.9.0",
-        "@notifi-network/notifi-core": "^0.9.0"
+        "@notifi-network/notifi-axios-utils": "^0.10.0",
+        "@notifi-network/notifi-core": "^0.10.0"
       }
     },
     "@notifi-network/notifi-axios-utils": {
@@ -17730,14 +17730,14 @@
     "@notifi-network/notifi-node": {
       "version": "file:packages/notifi-node",
       "requires": {
-        "@notifi-network/notifi-axios-utils": "^0.9.0",
-        "@notifi-network/notifi-core": "^0.9.0"
+        "@notifi-network/notifi-axios-utils": "^0.10.0",
+        "@notifi-network/notifi-core": "^0.10.0"
       }
     },
     "@notifi-network/notifi-node-sample": {
       "version": "file:packages/notifi-node-sample",
       "requires": {
-        "@notifi-network/notifi-node": "^0.9.0",
+        "@notifi-network/notifi-node": "^0.10.0",
         "@types/express": "^4.17.13",
         "@types/morgan": "^1.9.3",
         "@types/morgan-json": "^1.1.0",
@@ -17754,9 +17754,9 @@
     "@notifi-network/notifi-react-hooks": {
       "version": "file:packages/notifi-react-hooks",
       "requires": {
-        "@notifi-network/notifi-axios-adapter": "^0.9.0",
-        "@notifi-network/notifi-axios-utils": "^0.9.0",
-        "@notifi-network/notifi-core": "^0.9.0",
+        "@notifi-network/notifi-axios-adapter": "^0.10.0",
+        "@notifi-network/notifi-axios-utils": "^0.10.0",
+        "@notifi-network/notifi-core": "^0.10.0",
         "@types/node": "^17.0.21",
         "@types/react": "^17.0.39",
         "axios": "^0.26.0",

--- a/packages/notifi-core/lib/NotifiClient.ts
+++ b/packages/notifi-core/lib/NotifiClient.ts
@@ -76,8 +76,19 @@ export type ClientCreateMetaplexAuctionSourceInput = Readonly<{
   auctionWebUrl: string;
 }>;
 
+/**
+ * Input param for deleting an Alert
+ *
+ * @property alertId - The ID of the Alert to delete
+ * @property keepTargetGroup - Whether to keep the target group on this Alert or to delete it
+ * @property keepSourceGroup - Whether to keep the source group on this Alert or to delete it
+ *
+ * See [Alert Creation Guide]{@link https://docs.notifi.network} for more information on creating Alerts
+ */
 export type ClientDeleteAlertInput = Readonly<{
   alertId: string;
+  keepTargetGroup?: boolean;
+  keepSourceGroup?: boolean;
 }>;
 
 export type MessageSigner = Readonly<{

--- a/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
+++ b/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
@@ -287,7 +287,9 @@ const useNotifiClient = (
           targetGroup,
         };
 
-        setInternalData(newData);
+        setInternalData({
+          ...newData,
+        });
         return existingAlert;
       } catch (e: unknown) {
         if (e instanceof Error) {
@@ -354,18 +356,24 @@ const useNotifiClient = (
           throw new Error(`Invalid filter id ${filterId}`);
         }
 
-        const [sourceGroup, targetGroup] = await Promise.all([
-          ensureSourceGroup(service, newData.sourceGroups, {
+        const sourceGroup = await ensureSourceGroup(
+          service,
+          newData.sourceGroups,
+          {
             name,
             sourceIds: [sourceId],
-          }),
-          ensureTargetGroup(service, newData.targetGroups, {
+          },
+        );
+        const targetGroup = await ensureTargetGroup(
+          service,
+          newData.targetGroups,
+          {
             name,
             emailTargetIds,
             smsTargetIds,
             telegramTargetIds,
-          }),
-        ]);
+          },
+        );
 
         const sourceGroupId = sourceGroup.id;
         if (sourceGroupId === null) {
@@ -396,7 +404,7 @@ const useNotifiClient = (
 
         newData.alerts.push(newAlert);
 
-        setInternalData(newData);
+        setInternalData({ ...newData });
         return alert;
       } catch (e: unknown) {
         if (e instanceof Error) {
@@ -451,9 +459,8 @@ const useNotifiClient = (
 
         newData.alerts = newData.alerts.filter((a) => a !== alertToDelete);
 
-        let deleteTargetGroupPromise = Promise.resolve();
         if (targetGroupId !== null && !keepTargetGroup) {
-          deleteTargetGroupPromise = service
+          await service
             .deleteTargetGroup({
               id: targetGroupId,
             })
@@ -464,9 +471,8 @@ const useNotifiClient = (
             });
         }
 
-        let deleteSourceGroupPromise = Promise.resolve();
         if (sourceGroupId !== null && !keepSourceGroup) {
-          deleteSourceGroupPromise = service
+          await service
             .deleteSourceGroup({
               id: sourceGroupId,
             })
@@ -477,8 +483,7 @@ const useNotifiClient = (
             });
         }
 
-        await Promise.all([deleteTargetGroupPromise, deleteSourceGroupPromise]);
-        setInternalData(newData);
+        setInternalData({ ...newData });
 
         return alertId;
       } catch (e: unknown) {

--- a/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
+++ b/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
@@ -426,7 +426,11 @@ const useNotifiClient = (
    */
   const deleteAlert = useCallback(
     async (input: ClientDeleteAlertInput) => {
-      const { alertId } = input;
+      const {
+        alertId,
+        keepSourceGroup = false,
+        keepTargetGroup = false,
+      } = input;
       try {
         const newData = await fetchDataImpl(
           service,
@@ -448,7 +452,7 @@ const useNotifiClient = (
         newData.alerts = newData.alerts.filter((a) => a !== alertToDelete);
 
         let deleteTargetGroupPromise = Promise.resolve();
-        if (targetGroupId !== null) {
+        if (targetGroupId !== null && !keepTargetGroup) {
           deleteTargetGroupPromise = service
             .deleteTargetGroup({
               id: targetGroupId,
@@ -461,7 +465,7 @@ const useNotifiClient = (
         }
 
         let deleteSourceGroupPromise = Promise.resolve();
-        if (sourceGroupId !== null) {
+        if (sourceGroupId !== null && !keepSourceGroup) {
           deleteSourceGroupPromise = service
             .deleteSourceGroup({
               id: sourceGroupId,
@@ -505,14 +509,13 @@ const useNotifiClient = (
    */
   const createMetaplexAuctionSource = useCallback(
     async (input: ClientCreateMetaplexAuctionSourceInput): Promise<Source> => {
-      const { auctionAddressBase58, auctionWebUrl } = input;
-
       setLoading(true);
       try {
         const newData = await fetchDataImpl(
           service,
           Date,
-          fetchDataRef.current);
+          fetchDataRef.current,
+        );
         const source = await ensureMetaplexAuctionSource(
           service,
           newData.sources,


### PR DESCRIPTION
When deleting an Alert, we previously had always cleaned up the attached SourceGroup / TargetGroup. Allow the client to control this behavior by exposing some parameters to deleteAlert.

Also, remove parallel calls in the SDK. I think there are some undefined behaviors since both of the parallel calls are modifying the same object. In the future, refactor those calls to be without side-effect.