### PR TITLE
Return updated alert from SDK

### DIFF
--- a/packages/notifi-axios-adapter/lib/fragments/index.ts
+++ b/packages/notifi-axios-adapter/lib/fragments/index.ts
@@ -5,7 +5,6 @@ export * from './filterFragment';
 export * from './smsTargetFragment';
 export * from './sourceFragment';
 export * from './sourceGroupFragment';
-export * from './supportedTargetTypesFragment';
 export * from './targetGroupFragment';
 export * from './telegramTargetFragment';
 export * from './userFragment';

--- a/packages/notifi-axios-adapter/lib/fragments/supportedTargetTypesFragment.ts
+++ b/packages/notifi-axios-adapter/lib/fragments/supportedTargetTypesFragment.ts
@@ -1,7 +1,0 @@
-export const supportedTargetTypesFragment = `
-fragment supportedTargetTypesFragment on SupportedTargetTypesForDapp {
-  
-}
-`.trim();
-
-export const supportedTargetTypesFragmentDependencies = [];

--- a/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
+++ b/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
@@ -407,7 +407,7 @@ const useNotifiClient = (
         newData.alerts.push(newAlert);
 
         setInternalData({ ...newData });
-        return alert;
+        return newAlert;
       } catch (e: unknown) {
         if (e instanceof Error) {
           setError(e);

--- a/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
+++ b/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
@@ -283,15 +283,16 @@ const useNotifiClient = (
         );
 
         const alertIndex = newData.alerts.indexOf(existingAlert);
-        newData.alerts[alertIndex] = {
+        const newAlert: Alert = {
           ...existingAlert,
           targetGroup,
         };
+        newData.alerts[alertIndex] = newAlert;
 
         setInternalData({
           ...newData,
         });
-        return existingAlert;
+        return newAlert;
       } catch (e: unknown) {
         if (e instanceof Error) {
           setError(e);


### PR DESCRIPTION
For some reason we were returning the in-memory (non-altered) copy.
