### PR TITLE
Add Create Source

### DIFF
--- a/packages/notifi-core/lib/NotifiClient.ts
+++ b/packages/notifi-core/lib/NotifiClient.ts
@@ -6,6 +6,7 @@ import {
   TargetGroup,
   User,
 } from './models';
+import { CreateSourceInput } from './operations';
 
 export type ClientData = Readonly<{
   alerts: ReadonlyArray<Alert>;
@@ -112,6 +113,7 @@ export type NotifiClient = Readonly<{
   fetchData: () => Promise<ClientData>;
   logIn: (signer: MessageSigner) => Promise<User>;
   createAlert: (input: ClientCreateAlertInput) => Promise<Alert>;
+  createSource: (input: CreateSourceInput) => Promise<Source>;
   createMetaplexAuctionSource: (
     input: ClientCreateMetaplexAuctionSourceInput,
   ) => Promise<Source>;

--- a/packages/notifi-core/lib/operations/CreateSource.ts
+++ b/packages/notifi-core/lib/operations/CreateSource.ts
@@ -23,7 +23,10 @@ export type CreateSourceInput = Readonly<{
     | 'TRIBECA_PROPOSALS'
     | 'REALM_PROPOSALS'
     | 'DIRECT_PUSH'
-    | 'SOLANA_METAPLEX_AUCTION';
+    | 'SOLANA_METAPLEX_AUCTION'
+    | 'SOLANA_BONFIDA_AUCTION'
+    | 'DIRECT_PUBLISH'
+    | 'BROADCAST';
 }>;
 
 export type CreateSourceResult = Source;

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -3,6 +3,7 @@ import type {
   Alert,
   ClientData,
   FilterOptions,
+  Source,
 } from '@notifi-network/notifi-core';
 import { useNotifiClient } from '@notifi-network/notifi-react-hooks';
 import parsePhoneNumber from 'libphonenumber-js';
@@ -53,6 +54,7 @@ export const useNotifiSubscribe: () => Readonly<{
   const {
     loading,
     createAlert,
+    createSource,
     deleteAlert,
     fetchData,
     isAuthenticated,
@@ -151,8 +153,34 @@ export const useNotifiSubscribe: () => Readonly<{
       if (config === undefined) {
         await deleteThisAlert();
       } else {
-        const { filterType, filterOptions, sourceType } = config;
-        const source = data.sources.find((s) => s.type === sourceType);
+        const {
+          filterType,
+          filterOptions,
+          createSource: createSourceParam,
+          sourceType,
+        } = config;
+
+        let source: Source | undefined;
+        if (createSourceParam !== undefined) {
+          const existing = data.sources.find(
+            (s) =>
+              s.type === sourceType &&
+              s.name === name &&
+              s.blockchainAddress === createSourceParam.address,
+          );
+          if (existing !== undefined) {
+            source = existing;
+          } else {
+            source = await createSource({
+              name,
+              blockchainAddress: createSourceParam.address,
+              type: sourceType,
+            });
+          }
+        } else {
+          source = data.sources.find((s) => s.type === sourceType);
+        }
+
         const filter = data.filters.find((f) => f.filterType === filterType);
         if (
           source === undefined ||

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -112,7 +112,7 @@ export const useNotifiSubscribe: () => Readonly<{
       await logIn(signer);
     }
 
-    const data = await fetchData();
+    let data = await fetchData();
 
     const configurations = getAlertConfigurations();
     const names = Object.keys(configurations);
@@ -176,6 +176,8 @@ export const useNotifiSubscribe: () => Readonly<{
               blockchainAddress: createSourceParam.address,
               type: sourceType,
             });
+            // Refresh for source filters
+            data = await fetchData();
           }
         } else {
           source = data.sources.find((s) => s.type === sourceType);

--- a/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
+++ b/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
@@ -1,14 +1,10 @@
-import type { FilterOptions } from '@notifi-network/notifi-core';
+import type {
+  CreateSourceInput,
+  FilterOptions,
+} from '@notifi-network/notifi-core';
 
 export type AlertConfiguration = Readonly<{
-  sourceType:
-    | 'SOLANA_WALLET'
-    | 'TERRA_WALLET'
-    | 'ETHEREUM_WALLET'
-    | 'TRIBECA_PROPOSALS'
-    | 'REALM_PROPOSALS'
-    | 'DIRECT_PUSH'
-    | 'SOLANA_METAPLEX_AUCTION';
+  sourceType: CreateSourceInput['type'];
   createSource?: Readonly<{
     address: string;
   }>;

--- a/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
+++ b/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
@@ -1,7 +1,17 @@
 import type { FilterOptions } from '@notifi-network/notifi-core';
 
 export type AlertConfiguration = Readonly<{
-  sourceType: string;
+  sourceType:
+    | 'SOLANA_WALLET'
+    | 'TERRA_WALLET'
+    | 'ETHEREUM_WALLET'
+    | 'TRIBECA_PROPOSALS'
+    | 'REALM_PROPOSALS'
+    | 'DIRECT_PUSH'
+    | 'SOLANA_METAPLEX_AUCTION';
+  createSource?: Readonly<{
+    address: string;
+  }>;
   filterType: string;
   filterOptions: FilterOptions | null;
 }>;

--- a/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
+++ b/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
@@ -1,4 +1,6 @@
-import { ensureMetaplexAuctionSource } from '../utils/ensureSource';
+import ensureSource, {
+  ensureMetaplexAuctionSource,
+} from '../utils/ensureSource';
 import ensureSourceGroup from '../utils/ensureSourceGroup';
 import ensureTargetGroup from '../utils/ensureTargetGroup';
 import ensureTargetIds from '../utils/ensureTargetIds';
@@ -19,6 +21,7 @@ import {
   ClientData,
   ClientDeleteAlertInput,
   ClientUpdateAlertInput,
+  CreateSourceInput,
   MessageSigner,
   NotifiClient,
   Source,
@@ -559,6 +562,44 @@ const useNotifiClient = (
   );
 
   /**
+   * Create a new Source
+   *
+   * @remarks
+   * Use this to allow the user to create a Source object that emits events
+   *
+   * @param {CreateSourceInput} input - Input params for creating a Source
+   * @returns {Source} A Source object that can be used to create an Alert
+   * <br>
+   * <br>
+   * See [Alert Creation Guide]{@link https://docs.notifi.network} for more information on creating Alerts
+   */
+  const createSource = useCallback(
+    async (input: CreateSourceInput): Promise<Source> => {
+      setLoading(true);
+      try {
+        const newData = await fetchDataImpl(
+          service,
+          Date,
+          fetchDataRef.current,
+        );
+        const source = await ensureSource(service, newData.sources, input);
+        setInternalData(newData);
+        return source;
+      } catch (e: unknown) {
+        if (e instanceof Error) {
+          setError(e);
+        } else {
+          setError(new NotifiClientError(e));
+        }
+        throw e;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [service],
+  );
+
+  /**
    * Create a Metaplex Auction Source
    *
    * @remarks
@@ -635,6 +676,7 @@ const useNotifiClient = (
     logIn,
     createAlert,
     createMetaplexAuctionSource,
+    createSource,
     deleteAlert,
     fetchData,
     getConfiguration,


### PR DESCRIPTION
Some Alert configurations need to create Sources before they can subscribe

Add a `createSource` configuration for this.

This will be a minor release, as it is non-breaking new functionality