### PR TITLE
Minor bugfixes for createSource flow

### DIFF
--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -167,7 +167,6 @@ export const useNotifiSubscribe: () => Readonly<{
           const existing = data.sources.find(
             (s) =>
               s.type === sourceType &&
-              s.name === name &&
               s.blockchainAddress === createSourceParam.address,
           );
           if (existing !== undefined) {
@@ -177,7 +176,7 @@ export const useNotifiSubscribe: () => Readonly<{
             );
           } else {
             source = await createSource({
-              name,
+              name: createSourceParam.address,
               blockchainAddress: createSourceParam.address,
               type: sourceType,
             });

--- a/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
+++ b/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
@@ -583,6 +583,16 @@ const useNotifiClient = (
           fetchDataRef.current,
         );
         const source = await ensureSource(service, newData.sources, input);
+
+        source.applicableFilters.forEach((applicableFilter) => {
+          const existing = newData.filters.find(
+            (existingFilter) => applicableFilter.id === existingFilter.id,
+          );
+          if (existing !== undefined) {
+            newData.filters.push(applicableFilter);
+          }
+        });
+
         setInternalData(newData);
         return source;
       } catch (e: unknown) {


### PR DESCRIPTION
When the source is created, we should add its applicableFilters to the data filters
When we create a source for the Alert, we may need to re-use it for other alerts, so we shouldn't filter on the name when matching to an existing one.