### PR TITLE
Add Broadcast Message configuration

### DIFF
--- a/packages/notifi-react-card/README.md
+++ b/packages/notifi-react-card/README.md
@@ -12,13 +12,13 @@ npm install --save-dev @notifi-network/notifi-core
 ```tsx
 import React, { useEffect, useState } from 'react';
 import {
-  directMessageConfiguration,
+  broadcastMessageConfiguration,
   useNotifiSubscriptionContext
 } from '@notifi-network/notifi-card';
 
-const ALERT_NAME = 'MyMarketingAlert';
-const ALERT_CONFIGURATION = directMessageConfiguration({
-  type: 'MARKETING',
+const ALERT_NAME = 'My Marketing Updates';
+const ALERT_CONFIGURATION: AlertConfiguration = broadcastMessageConfiguration({
+  topicName: `TALK_TO_NOTIFI_TO_GET_THIS_VALUE`,
 });
 
 type Props = Readonly<{

--- a/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
+++ b/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
@@ -12,6 +12,21 @@ export type AlertConfiguration = Readonly<{
   filterOptions: FilterOptions | null;
 }>;
 
+export const broadcastMessageConfiguration = ({
+  topicName,
+}: Readonly<{
+  topicName: string;
+}>): AlertConfiguration => {
+  return {
+    filterType: 'BROADCAST_MESSAGES',
+    filterOptions: {},
+    sourceType: 'BROADCAST',
+    createSource: {
+      address: topicName,
+    },
+  };
+};
+
 export const directMessageConfiguration = (
   params?: Readonly<{
     type?: string;


### PR DESCRIPTION
This is a utility method to subscribe to "Broadcast" sources on the
provided "topicName".

For now, integrators should speak with Notifi to receive a topic name to
use.