### PR TITLE
Expose targets on NotifiClient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15369,13 +15369,13 @@
     },
     "packages/notifi-axios-adapter": {
       "name": "@notifi-network/notifi-axios-adapter",
-      "version": "0.16.5",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
-        "@notifi-network/notifi-axios-utils": "^0.16.5"
+        "@notifi-network/notifi-axios-utils": "^0.17.1"
       },
       "devDependencies": {
-        "@notifi-network/notifi-core": "^0.16.5"
+        "@notifi-network/notifi-core": "^0.17.1"
       },
       "peerDependencies": {
         "axios": "^0.26.0"
@@ -15383,7 +15383,7 @@
     },
     "packages/notifi-axios-utils": {
       "name": "@notifi-network/notifi-axios-utils",
-      "version": "0.16.5",
+      "version": "0.17.1",
       "license": "MIT",
       "peerDependencies": {
         "axios": "^0.26.1"
@@ -15391,7 +15391,7 @@
     },
     "packages/notifi-core": {
       "name": "@notifi-network/notifi-core",
-      "version": "0.16.5",
+      "version": "0.17.1",
       "license": "MIT",
       "devDependencies": {
         "rimraf": "^3.0.2"
@@ -15399,11 +15399,11 @@
     },
     "packages/notifi-node": {
       "name": "@notifi-network/notifi-node",
-      "version": "0.16.5",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
-        "@notifi-network/notifi-axios-utils": "^0.16.5",
-        "@notifi-network/notifi-core": "^0.16.5"
+        "@notifi-network/notifi-axios-utils": "^0.17.1",
+        "@notifi-network/notifi-core": "^0.17.1"
       },
       "peerDependencies": {
         "axios": "^0.26.1"
@@ -15411,7 +15411,7 @@
     },
     "packages/notifi-node-sample": {
       "name": "@notifi-network/notifi-node-sample",
-      "version": "0.16.5",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.26.1",
@@ -15431,7 +15431,7 @@
     },
     "packages/notifi-react-card": {
       "name": "@notifi-network/notifi-react-card",
-      "version": "0.16.5",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
         "libphonenumber-js": "^1.9.51"
@@ -15439,7 +15439,7 @@
     },
     "packages/notifi-react-hooks": {
       "name": "@notifi-network/notifi-react-hooks",
-      "version": "0.16.5",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.26.0",
@@ -17735,8 +17735,8 @@
     "@notifi-network/notifi-axios-adapter": {
       "version": "file:packages/notifi-axios-adapter",
       "requires": {
-        "@notifi-network/notifi-axios-utils": "^0.16.5",
-        "@notifi-network/notifi-core": "^0.16.5"
+        "@notifi-network/notifi-axios-utils": "^0.17.1",
+        "@notifi-network/notifi-core": "^0.17.1"
       }
     },
     "@notifi-network/notifi-axios-utils": {
@@ -17752,8 +17752,8 @@
     "@notifi-network/notifi-node": {
       "version": "file:packages/notifi-node",
       "requires": {
-        "@notifi-network/notifi-axios-utils": "^0.16.5",
-        "@notifi-network/notifi-core": "^0.16.5"
+        "@notifi-network/notifi-axios-utils": "^0.17.1",
+        "@notifi-network/notifi-core": "^0.17.1"
       }
     },
     "@notifi-network/notifi-node-sample": {

--- a/packages/notifi-core/lib/NotifiClient.ts
+++ b/packages/notifi-core/lib/NotifiClient.ts
@@ -1,18 +1,24 @@
 import {
   Alert,
   ClientConfiguration,
+  EmailTarget,
   Filter,
+  SmsTarget,
   Source,
   TargetGroup,
+  TelegramTarget,
   User,
 } from './models';
 import { CreateSourceInput } from './operations';
 
 export type ClientData = Readonly<{
   alerts: ReadonlyArray<Alert>;
+  emailTargets: ReadonlyArray<EmailTarget>;
   filters: ReadonlyArray<Filter>;
+  smsTargets: ReadonlyArray<SmsTarget>;
   sources: ReadonlyArray<Source>;
   targetGroups: ReadonlyArray<TargetGroup>;
+  telegramTargets: ReadonlyArray<TelegramTarget>;
 }>;
 
 export type AlertFrequency =

--- a/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
+++ b/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
@@ -58,13 +58,24 @@ const projectData = (internalData: InternalData | null): ClientData | null => {
     return null;
   }
 
-  const { alerts, filters, sources, targetGroups } = internalData;
+  const {
+    alerts,
+    emailTargets,
+    filters,
+    smsTargets,
+    sources,
+    targetGroups,
+    telegramTargets,
+  } = internalData;
 
   return {
     alerts,
+    emailTargets,
     filters,
+    smsTargets,
     sources,
     targetGroups,
+    telegramTargets,
   };
 };
 


### PR DESCRIPTION
In order to improve flexibility as well as enable rendering of existing
targets, expose these targets on the Notifi Client.