### PR TITLE
Remove libPhonenumber-JS

### DIFF
--- a/packages/notifi-react-card/package.json
+++ b/packages/notifi-react-card/package.json
@@ -28,8 +28,7 @@
     "url": "https://github.com/notifi-network/notifi-sdk-ts/issues"
   },
   "dependencies": {
-    "@notifi-network/notifi-react-hooks": "^0.18.0",
-    "libphonenumber-js": "^1.9.51"
+    "@notifi-network/notifi-react-hooks": "^0.18.0"
   },
   "devDependencies": {
     "@notifi-network/notifi-core": "^0.18.0"

--- a/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
+++ b/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
@@ -290,9 +290,11 @@ const useNotifiClient = (
           fetchDataRef.current,
         );
         setInternalData(newData);
+        setIsAuthenticated(true);
 
         return result;
       } catch (e: unknown) {
+        setIsAuthenticated(false);
         if (e instanceof Error) {
           setError(e);
         } else {


### PR DESCRIPTION
Hyperspace was saying our bundle is too big

I agree, and it should really be an optional plugin

Until we can fix the ESM (from tsc) so that we can get nice tree shaking, let's remove it for now and default to USA

Clients can still implement stronger validation by passing the full string, including `+CountryCode`