### PR TITLE
MVP-813: Allow users to edit targets when all alerts are disabled

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "editor.tabSize": 2
+  "editor.tabSize": 2,
+  "editor.formatOnSave": true,
 }

--- a/packages/notifi-axios-utils/lib/utils/axiosRequest.ts
+++ b/packages/notifi-axios-utils/lib/utils/axiosRequest.ts
@@ -14,10 +14,6 @@ const makeRequestInternal = async <Input, Result>(
   variables: Input,
   config?: AxiosRequestConfig<Input>,
 ): Promise<Result> => {
-  console.log('### test', {
-    encoded: encodeURIComponent(resultKey),
-    resultKey,
-  });
   const { data } = await axiosInstance.post<PostResponse<Result>>(
     `/${encodeURIComponent(resultKey)}`,
     {

--- a/packages/notifi-axios-utils/lib/utils/axiosRequest.ts
+++ b/packages/notifi-axios-utils/lib/utils/axiosRequest.ts
@@ -14,6 +14,10 @@ const makeRequestInternal = async <Input, Result>(
   variables: Input,
   config?: AxiosRequestConfig<Input>,
 ): Promise<Result> => {
+  console.log('### test', {
+    encoded: encodeURIComponent(resultKey),
+    resultKey,
+  });
   const { data } = await axiosInstance.post<PostResponse<Result>>(
     `/${encodeURIComponent(resultKey)}`,
     {

--- a/packages/notifi-axios-utils/lib/utils/axiosRequest.ts
+++ b/packages/notifi-axios-utils/lib/utils/axiosRequest.ts
@@ -14,9 +14,8 @@ const makeRequestInternal = async <Input, Result>(
   variables: Input,
   config?: AxiosRequestConfig<Input>,
 ): Promise<Result> => {
-  console.log("### makeRequestInternal", {resultKey});
   const { data } = await axiosInstance.post<PostResponse<Result>>(
-    `/${resultKey}`,
+    `/${encodeURIComponent(resultKey)}`,
     {
       query,
       variables,

--- a/packages/notifi-axios-utils/lib/utils/axiosRequest.ts
+++ b/packages/notifi-axios-utils/lib/utils/axiosRequest.ts
@@ -14,8 +14,9 @@ const makeRequestInternal = async <Input, Result>(
   variables: Input,
   config?: AxiosRequestConfig<Input>,
 ): Promise<Result> => {
+  console.log("### makeRequestInternal", {resultKey});
   const { data } = await axiosInstance.post<PostResponse<Result>>(
-    '/',
+    `/${resultKey}`,
     {
       query,
       variables,

--- a/packages/notifi-core/lib/NotifiClient.ts
+++ b/packages/notifi-core/lib/NotifiClient.ts
@@ -38,7 +38,7 @@ export type FilterOptions = Partial<{
 
 /**
  * Object containing information to continue the login process
- * 
+ *
  * @property nonce - String value to place in transaction logs
  */
 export type BeginLoginViaTransactionResult = Readonly<{
@@ -47,7 +47,7 @@ export type BeginLoginViaTransactionResult = Readonly<{
 
 /**
  * Object containing information to complete the login process
- * 
+ *
  * @property transactionSignature - Signature of the transaction that contains the log message
  */
 export type CompleteLoginViaTransactionInput = Readonly<{
@@ -56,7 +56,7 @@ export type CompleteLoginViaTransactionInput = Readonly<{
 
 /**
  * Completed authentication response
- * 
+ *
  */
 export type CompleteLoginViaTransactionResult = Readonly<User>;
 
@@ -136,6 +136,26 @@ export type ClientDeleteAlertInput = Readonly<{
   keepSourceGroup?: boolean;
 }>;
 
+/**
+ * TODO
+ *
+ * @remarks
+ * This describes the Alert to be updated based on id, emailAddress, phoneNumber and/or telegramId
+ *
+ * @property name - The name of the target group
+ * @property emailAddress - The emailAddress to be used
+ * @property phoneNumber - The phone number to be used
+ * @property telegramId - The Telegram account username to be used
+ * <br>
+ * <br>
+ */
+export type ClientEnsureTargetGroupInput = Readonly<{
+  name: string;
+  emailAddress: string | null;
+  phoneNumber: string | null;
+  telegramId: string | null;
+}>;
+
 export type MessageSigner = Readonly<{
   signMessage: (message: Uint8Array) => Promise<Uint8Array>;
 }>;
@@ -168,4 +188,7 @@ export type NotifiClient = Readonly<{
   getConfiguration: () => Promise<ClientConfiguration>;
   getTopics: () => Promise<ReadonlyArray<UserTopic>>;
   updateAlert: (input: ClientUpdateAlertInput) => Promise<Alert>;
+  ensureTargetGroup: (
+    input: ClientEnsureTargetGroupInput,
+  ) => Promise<TargetGroup>;
 }>;

--- a/packages/notifi-core/lib/NotifiClient.ts
+++ b/packages/notifi-core/lib/NotifiClient.ts
@@ -137,12 +137,9 @@ export type ClientDeleteAlertInput = Readonly<{
 }>;
 
 /**
- * TODO
+ * Input params for creating or updating a TargetGroup by name
  *
- * @remarks
- * This describes the Alert to be updated based on id, emailAddress, phoneNumber and/or telegramId
- *
- * @property name - The name of the target group
+ * @property name - The name of the TargetGroup
  * @property emailAddress - The emailAddress to be used
  * @property phoneNumber - The phone number to be used
  * @property telegramId - The Telegram account username to be used

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -46,6 +46,7 @@ export const useNotifiSubscribe: () => Readonly<{
     isInitialized,
     logIn: clientLogIn,
     updateAlert,
+    ensureTargetGroup,
   } = useNotifiClient({
     dappAddress,
     env,
@@ -216,15 +217,6 @@ export const useNotifiSubscribe: () => Readonly<{
           filter.id === null
         ) {
           console.log('case 2');
-          if (keepSubscriptionData && existingAlert?.id != null) {
-            // Update the alert before deleting it so that we save the changes made to the targets
-            await updateAlert({
-              alertId: existingAlert.id,
-              emailAddress: finalEmail,
-              phoneNumber: finalPhoneNumber,
-              telegramId: finalTelegramId,
-            });
-          }
           await deleteThisAlert();
         } else if (existingAlert !== undefined && existingAlert.id !== null) {
           console.log('case 3');
@@ -254,6 +246,20 @@ export const useNotifiSubscribe: () => Readonly<{
         }
       }
     }
+
+    if (
+      Object.getOwnPropertyNames(newResults).length === 0 &&
+      keepSubscriptionData
+    ) {
+      // We didn't create or update any alert, manually update the targets
+      await ensureTargetGroup({
+        name: 'Default',
+        emailAddress: finalEmail,
+        phoneNumber: finalPhoneNumber,
+        telegramId: finalTelegramId,
+      });
+    }
+
     console.log('last fetchData called');
 
     const newData = await fetchData();

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -216,6 +216,15 @@ export const useNotifiSubscribe: () => Readonly<{
           filter.id === null
         ) {
           console.log('case 2');
+          if (keepSubscriptionData && existingAlert?.id != null) {
+            // Update the alert before deleting it so that we save the changes made to the targets
+            await updateAlert({
+              alertId: existingAlert.id,
+              emailAddress: finalEmail,
+              phoneNumber: finalPhoneNumber,
+              telegramId: finalTelegramId,
+            });
+          }
           await deleteThisAlert();
         } else if (existingAlert !== undefined && existingAlert.id !== null) {
           console.log('case 3');

--- a/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
+++ b/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
@@ -457,6 +457,16 @@ const useNotifiClient = (
     [service, dappAddress, clientRandomUuid],
   );
 
+  /**
+   * Creates or updates a TargetGroup by name
+   *
+   * @remarks
+   * In most cases the TargetGroups are updated when creating or updating Alerts @see createAlert and @see updateAlert
+   * @self should be used only when it's necessary to update the targets without creating Alerts
+   *
+   * @param {ClientEnsureTargetGroupInput} input - Input params for the TargetGroup
+   * @returns {TargetGroup}
+   */
   const ensureTargetGroup = useCallback(
     async (input: ClientEnsureTargetGroupInput): Promise<TargetGroup> => {
       setLoading(true);


### PR DESCRIPTION
Changes:
* Add `ensureTargetGroup` to `NotifiClient`
* When `subscribe` is called use `ensureTargetGroup` to update targets when all alerts are disabled
* Append `resultKey` to GQL path to improve dev experience when troubleshooting network requests