### PR TITLE
Add extra variables to broadcast

### DIFF
--- a/packages/notifi-core/lib/NotifiClient.ts
+++ b/packages/notifi-core/lib/NotifiClient.ts
@@ -162,6 +162,7 @@ export type ClientBroadcastMessageInput = Readonly<{
   subject: string;
   message: string;
   isHolderOnly: boolean;
+  variables?: Readonly<Record<string, string>>;
 }>;
 
 export type NotifiClient = Readonly<{

--- a/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
+++ b/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
@@ -945,7 +945,13 @@ const useNotifiClient = (
 
   const broadcastMessage = useCallback(
     async (
-      { topic, subject, message, isHolderOnly }: ClientBroadcastMessageInput,
+      {
+        topic,
+        subject,
+        message,
+        isHolderOnly,
+        variables: extraVariables,
+      }: ClientBroadcastMessageInput,
       signer: MessageSigner,
     ): Promise<string | null> => {
       setLoading(true);
@@ -990,6 +996,22 @@ const useNotifiClient = (
           variables.push({
             key: 'TargetCollection',
             value: JSON.stringify(topic.targetCollections),
+          });
+        }
+
+        if (extraVariables !== undefined) {
+          Object.keys(extraVariables).forEach((key) => {
+            if (
+              key === 'message' ||
+              key === 'subject' ||
+              key === 'TargetCollection'
+            ) {
+              return; // forEach
+            }
+            variables.push({
+              key,
+              value: extraVariables[key],
+            });
           });
         }
 


### PR DESCRIPTION
Allow clients to describe additional variables through the broadcast
method

before:
```
broadcastMessage({
  topic,
  subject: 'Hello World',
  message: 'This is my body',
  isHolderOnly: false,
});
```

after:
```
broadcastMessage({
  topic,
  subject: 'Hello World',
  message: 'This is my body',
  isHolderOnly: false,
  variables: {
    foo: 'bar',
    baz: 'bat',
  },
});
```