### PR TITLE
Allow users to specify target group name

### DIFF
--- a/packages/notifi-core/lib/NotifiClient.ts
+++ b/packages/notifi-core/lib/NotifiClient.ts
@@ -106,6 +106,7 @@ export type ClientCreateAlertInput = Readonly<{
   phoneNumber: string | null;
   telegramId: string | null;
   groupName?: string;
+  targetGroupName?: string;
 }>;
 
 /**

--- a/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
+++ b/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
@@ -611,6 +611,7 @@ const useNotifiClient = (
         filterOptions,
         sourceId,
         groupName = 'default',
+        targetGroupName,
       } = input;
 
       setLoading(true);
@@ -654,7 +655,7 @@ const useNotifiClient = (
           service,
           newData.targetGroups,
           {
-            name,
+            name: targetGroupName ?? name,
             emailTargetIds,
             smsTargetIds,
             telegramTargetIds,


### PR DESCRIPTION
Right now, it's not possible to re-use the same target group across
multiple alerts that use the client. Allow the input to specify the
target group name (optionally, falling back to name) to override the
target behavior.