### PR TITLE
Add `values` key to filterOptions

### DIFF
--- a/packages/notifi-core/lib/NotifiClient.ts
+++ b/packages/notifi-core/lib/NotifiClient.ts
@@ -29,11 +29,21 @@ export type AlertFrequency =
   | 'HOURLY'
   | 'DAILY';
 
+export type ValueItemConfig = Readonly<{
+  key: string;
+  op: 'lt' | 'lte' | 'eq' | 'gt' | 'gte';
+  value: string;
+}>;
+
 export type FilterOptions = Partial<{
   alertFrequency: AlertFrequency;
   directMessageType: string;
   threshold: number;
   delayProcessingUntil: string;
+  values: Readonly<
+    | { and: ReadonlyArray<ValueItemConfig> }
+    | { or: ReadonlyArray<ValueItemConfig> }
+  >;
 }>;
 
 /**

--- a/packages/notifi-react-hooks/lib/utils/packFilterOptions.ts
+++ b/packages/notifi-react-hooks/lib/utils/packFilterOptions.ts
@@ -3,25 +3,11 @@ import type { FilterOptions } from '@notifi-network/notifi-core';
 const packFilterOptions = (
   clientOptions: Readonly<FilterOptions> | undefined,
 ): string => {
-  const record: Record<string, string> = {};
-
-  if (clientOptions !== undefined) {
-    const { alertFrequency, directMessageType, threshold } = clientOptions;
-
-    if (alertFrequency !== undefined) {
-      record.alertFrequency = alertFrequency;
-    }
-
-    if (directMessageType !== undefined) {
-      record.directMessageType = directMessageType;
-    }
-
-    if (threshold !== undefined) {
-      record.threshold = threshold.toString();
-    }
+  if (clientOptions === undefined) {
+    return '{}';
   }
 
-  return JSON.stringify(record);
+  return JSON.stringify(clientOptions);
 };
 
 export default packFilterOptions;


### PR DESCRIPTION
This key allows us to configure with either an `and` or `or` to evaluate
some values. Each item has a `key` `op` and `value`.

example:

```
const filterOptions = {
  values: {
    and: [
      { key: "foo", op: "eq", value: "A" },
      { key: "price", op: "gt", value: "0" },
      { key: "price", op: "lte", value: "1" },
    ],
  }
}
```