### PR TITLE
Render the new data from ensureTargetGroup

### DIFF
--- a/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
+++ b/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
@@ -500,12 +500,19 @@ const useNotifiClient = (
         const { emailTargetIds, smsTargetIds, telegramTargetIds } =
           await ensureTargetIds(service, newData, input);
 
-        return ensureTargetGroupImpl(service, newData.targetGroups, {
-          name: input.name,
-          emailTargetIds,
-          smsTargetIds,
-          telegramTargetIds,
-        });
+        const targetGroup = await ensureTargetGroupImpl(
+          service,
+          newData.targetGroups,
+          {
+            name: input.name,
+            emailTargetIds,
+            smsTargetIds,
+            telegramTargetIds,
+          },
+        );
+
+        setInternalData(newData);
+        return targetGroup;
       } catch (e: unknown) {
         if (e instanceof Error) {
           setError(e);


### PR DESCRIPTION
When calling ensureTargetGroup, it doesn't update the data properly.
Call setInternalData in order to return the result to subscribers of
`client.data`