### PR TITLE
Support broadcastMessage from Node SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23340,13 +23340,13 @@
     },
     "packages/notifi-axios-adapter": {
       "name": "@notifi-network/notifi-axios-adapter",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "MIT",
       "dependencies": {
         "@notifi-network/notifi-axios-utils": "^0.29.0"
       },
       "devDependencies": {
-        "@notifi-network/notifi-core": "^0.29.1"
+        "@notifi-network/notifi-core": "^0.29.2"
       },
       "peerDependencies": {
         "axios": "^0.26.0"
@@ -23362,7 +23362,7 @@
     },
     "packages/notifi-core": {
       "name": "@notifi-network/notifi-core",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "MIT",
       "devDependencies": {
         "rimraf": "^3.0.2"
@@ -23370,11 +23370,11 @@
     },
     "packages/notifi-node": {
       "name": "@notifi-network/notifi-node",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "MIT",
       "dependencies": {
         "@notifi-network/notifi-axios-utils": "^0.29.0",
-        "@notifi-network/notifi-core": "^0.29.1"
+        "@notifi-network/notifi-core": "^0.29.2"
       },
       "peerDependencies": {
         "axios": "^0.26.1"
@@ -23382,10 +23382,10 @@
     },
     "packages/notifi-node-sample": {
       "name": "@notifi-network/notifi-node-sample",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "MIT",
       "dependencies": {
-        "@notifi-network/notifi-node": "^0.29.1",
+        "@notifi-network/notifi-node": "^0.29.2",
         "axios": "^0.26.1",
         "axios-logger": "^2.6.0",
         "express": "^4.17.3",
@@ -23403,13 +23403,13 @@
     },
     "packages/notifi-react-card": {
       "name": "@notifi-network/notifi-react-card",
-      "version": "0.29.1",
+      "version": "0.29.3",
       "license": "MIT",
       "dependencies": {
-        "@notifi-network/notifi-react-hooks": "^0.29.1"
+        "@notifi-network/notifi-react-hooks": "^0.29.3"
       },
       "devDependencies": {
-        "@notifi-network/notifi-core": "^0.29.1"
+        "@notifi-network/notifi-core": "^0.29.2"
       },
       "peerDependencies": {
         "@solana/wallet-adapter-react": "^0.15.8",
@@ -23418,10 +23418,10 @@
     },
     "packages/notifi-react-hooks": {
       "name": "@notifi-network/notifi-react-hooks",
-      "version": "0.29.1",
+      "version": "0.29.3",
       "license": "MIT",
       "dependencies": {
-        "@notifi-network/notifi-axios-adapter": "^0.29.1",
+        "@notifi-network/notifi-axios-adapter": "^0.29.2",
         "@notifi-network/notifi-axios-utils": "^0.29.0",
         "axios": "^0.26.0",
         "localforage": "^1.10.0",
@@ -23429,7 +23429,7 @@
         "typescript": "^4.5.5"
       },
       "devDependencies": {
-        "@notifi-network/notifi-core": "^0.29.1",
+        "@notifi-network/notifi-core": "^0.29.2",
         "@types/node": "^17.0.21",
         "@types/react": "^17.0.39"
       },
@@ -26902,7 +26902,7 @@
       "version": "file:packages/notifi-axios-adapter",
       "requires": {
         "@notifi-network/notifi-axios-utils": "^0.29.0",
-        "@notifi-network/notifi-core": "^0.29.1"
+        "@notifi-network/notifi-core": "^0.29.2"
       }
     },
     "@notifi-network/notifi-axios-utils": {
@@ -26919,13 +26919,13 @@
       "version": "file:packages/notifi-node",
       "requires": {
         "@notifi-network/notifi-axios-utils": "^0.29.0",
-        "@notifi-network/notifi-core": "^0.29.1"
+        "@notifi-network/notifi-core": "^0.29.2"
       }
     },
     "@notifi-network/notifi-node-sample": {
       "version": "file:packages/notifi-node-sample",
       "requires": {
-        "@notifi-network/notifi-node": "^0.29.1",
+        "@notifi-network/notifi-node": "^0.29.2",
         "@types/express": "^4.17.13",
         "@types/morgan": "^1.9.3",
         "@types/morgan-json": "^1.1.0",
@@ -26942,16 +26942,16 @@
     "@notifi-network/notifi-react-card": {
       "version": "file:packages/notifi-react-card",
       "requires": {
-        "@notifi-network/notifi-core": "^0.29.1",
-        "@notifi-network/notifi-react-hooks": "^0.29.1"
+        "@notifi-network/notifi-core": "^0.29.2",
+        "@notifi-network/notifi-react-hooks": "^0.29.3"
       }
     },
     "@notifi-network/notifi-react-hooks": {
       "version": "file:packages/notifi-react-hooks",
       "requires": {
-        "@notifi-network/notifi-axios-adapter": "^0.29.1",
+        "@notifi-network/notifi-axios-adapter": "^0.29.2",
         "@notifi-network/notifi-axios-utils": "^0.29.0",
-        "@notifi-network/notifi-core": "^0.29.1",
+        "@notifi-network/notifi-core": "^0.29.2",
         "@types/node": "^17.0.21",
         "@types/react": "^17.0.39",
         "axios": "^0.26.0",

--- a/packages/notifi-node/lib/client/NotifiClient.ts
+++ b/packages/notifi-node/lib/client/NotifiClient.ts
@@ -6,6 +6,9 @@ import {
   logInFromServiceImpl,
   sendMessageImpl,
 } from '../mutations';
+import broadcastMessageImpl, {
+  BroadcastMessageInput,
+} from '../mutations/broadcastMessageImpl';
 import { getTenantConnectedWalletImpl } from '../queries';
 import {
   GetTenantConnectedWalletInput,
@@ -59,6 +62,16 @@ class NotifiClient {
     const result = await sendMessageImpl(this.a, jwt, { input });
     if (!result) {
       throw new Error('Send message failed');
+    }
+  };
+
+  sendBroadcastMessage: (
+    jwt: string,
+    params: BroadcastMessageInput,
+  ) => Promise<void> = async (jwt, params) => {
+    const result = await broadcastMessageImpl(this.a, jwt, params);
+    if (result.id === null) {
+      throw new Error('broadcast message failed');
     }
   };
 

--- a/packages/notifi-node/lib/mutations/broadcastMessageImpl.ts
+++ b/packages/notifi-node/lib/mutations/broadcastMessageImpl.ts
@@ -1,0 +1,51 @@
+import {
+  collectDependencies,
+  makeAuthenticatedRequest,
+} from '@notifi-network/notifi-axios-utils';
+
+type KeyValuePair<TKey, TValue> = Readonly<{
+  key: TKey;
+  value: TValue;
+}>;
+
+type TargetType = 'SMS' | 'EMAIL' | 'TELEGRAM';
+
+export type BroadcastMessageInput = Readonly<{
+  topicName: string;
+  idempotencyKey?: string;
+  targetTemplates?: ReadonlyArray<KeyValuePair<TargetType, string>>;
+  variables?: ReadonlyArray<KeyValuePair<string, string>>;
+}>;
+
+export type BroadcastMessageResult = Readonly<{
+  id: string | null;
+}>;
+
+const DEPENDENCIES: string[] = [];
+
+const MUTATION = `
+mutation broadcastMessage(
+  $idempotencyKey: String
+  $topicName: String!
+  $targetTemplates: [KeyValuePairOfTargetTypeAndStringInput!]
+  $variables: [KeyValuePairOfStringAndStringInput!]
+) {
+  broadcastMessage(broadcastMessageInput: {
+    idempotencyKey: $idempotencyKey
+    sourceAddress: $topicName
+    targetTemplates: $targetTemplates
+    variables: $variables
+    timestamp: 0
+    walletBlockchain: OFF_CHAIN
+  }, signature: "") {
+    id
+  }
+}
+`.trim();
+
+const broadcastMessageImpl = makeAuthenticatedRequest<
+  BroadcastMessageInput,
+  BroadcastMessageResult
+>(collectDependencies(...DEPENDENCIES, MUTATION), 'broadcastMessage');
+
+export default broadcastMessageImpl;


### PR DESCRIPTION
Now that TenantUsers are able to send broadcast messages, expose the functionality through the Node SDK.