### PR TITLE
creates a new card to split up state

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
@@ -1,4 +1,3 @@
-import clsx from 'clsx';
 import React from 'react';
 
 import type {
@@ -6,17 +5,15 @@ import type {
   NotifiSmsInputProps,
   NotifiTelegramInputProps,
 } from '..';
-import { NotifiEmailInput, NotifiSmsInput, NotifiTelegramInput } from '..';
 import { CardConfigItemV1 } from '../../hooks';
+import { useFetchedCardState } from '../../hooks/useFetchedCardState';
 import type { EventTypeBroadcastRowProps } from './EventTypeBroadcastRow';
-import { EventTypeBroadcastRow } from './EventTypeBroadcastRow';
-import { EventTypeDirectPushRow } from './EventTypeDirectPushRow';
 import type { EventTypeUnsupportedRowProps } from './EventTypeUnsupportedRow';
-import { EventTypeUnsupportedRow } from './EventTypeUnsupportedRow';
 import {
   NotifiInputLabels,
   NotifiInputSeparators,
 } from './NotifiSubscriptionCard';
+import { EditCardView } from './subscription card views/EditCardView';
 
 export type SubscriptionCardV1Props = Readonly<{
   classNames?: Readonly<{
@@ -42,113 +39,24 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
   inputSeparators,
 }) => {
   const allowedCountryCodes = [...data.contactInfo.sms.supportedCountryCodes];
+  const { cardView } = useFetchedCardState();
 
-  return (
-    <>
-      {data.contactInfo.email.active ? (
-        <NotifiEmailInput
-          disabled={inputDisabled}
-          classNames={classNames?.NotifiEmailInput}
-          copy={{ label: inputLabels?.email }}
-        />
-      ) : null}
-      {inputSeparators?.emailSeparator?.content ? (
-        <div
-          className={clsx(
-            'NotifiInputSeparator__container',
-            inputSeparators?.emailSeparator?.classNames?.container,
-          )}
-        >
-          <div
-            className={clsx(
-              'NotifiInputSeparator__content',
-              inputSeparators.emailSeparator.classNames?.content,
-            )}
-          >
-            {inputSeparators?.emailSeparator?.content}
-          </div>
-        </div>
-      ) : null}
-      {data.contactInfo.sms.active ? (
-        <NotifiSmsInput
-          disabled={inputDisabled}
-          classNames={classNames?.NotifiSmsInput}
+  let view = null;
+
+  switch (cardView.state) {
+    case 'edit':
+      view = (
+        <EditCardView
+          data={data}
+          classNames={classNames}
+          inputDisabled={inputDisabled}
+          inputs={inputs}
+          inputLabels={inputLabels}
+          inputSeparators={inputSeparators}
           allowedCountryCodes={allowedCountryCodes}
-          copy={{ label: inputLabels?.sms }}
         />
-      ) : null}
-      {inputSeparators?.smsSeparator?.content ? (
-        <div
-          className={clsx(
-            'NotifiInputSeparator__container',
-            inputSeparators?.smsSeparator?.classNames?.container,
-          )}
-        >
-          <div
-            className={clsx(
-              'NotifiInputSeparator__content',
-              inputSeparators.smsSeparator.classNames?.content,
-            )}
-          >
-            {inputSeparators?.smsSeparator?.content}
-          </div>
-        </div>
-      ) : null}
-      {data.contactInfo.telegram.active ? (
-        <NotifiTelegramInput
-          disabled={inputDisabled}
-          classNames={classNames?.NotifiTelegramInput}
-          copy={{ label: inputLabels?.telegram }}
-        />
-      ) : null}
-      {inputSeparators?.telegramSeparator?.content ? (
-        <div
-          className={clsx(
-            'NotifiInputSeparator__container',
-            inputSeparators?.smsSeparator?.classNames?.container,
-          )}
-        >
-          <div
-            className={clsx(
-              'NotifiInputSeparator__content',
-              inputSeparators.telegramSeparator.classNames?.content,
-            )}
-          >
-            {inputSeparators?.telegramSeparator?.content}
-          </div>
-        </div>
-      ) : null}
-      {data.eventTypes?.map((eventType) => {
-        switch (eventType.type) {
-          case 'broadcast':
-            return (
-              <EventTypeBroadcastRow
-                key={eventType.name}
-                classNames={classNames?.EventTypeBroadcastRow}
-                disabled={inputDisabled}
-                config={eventType}
-                inputs={inputs}
-              />
-            );
-          case 'directPush':
-            return (
-              <EventTypeDirectPushRow
-                key={eventType.name}
-                classNames={classNames?.EventTypeBroadcastRow}
-                disabled={inputDisabled}
-                config={eventType}
-                inputs={inputs}
-              />
-            );
-          default:
-            return (
-              <EventTypeUnsupportedRow
-                key={JSON.stringify(eventType)}
-                classNames={classNames?.EventTypeUnsupportedRow}
-              />
-            );
-        }
-      })}
-    </>
-  );
+      );
+      break;
+  }
+  return <>{view}</>;
 };

--- a/packages/notifi-react-card/lib/components/subscription/subscription card views/EditCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription card views/EditCardView.tsx
@@ -1,0 +1,161 @@
+import { CardConfigItemV1 } from '@notifi-network/notifi-react-card';
+import clsx from 'clsx';
+import React from 'react';
+
+import {
+  NotifiEmailInput,
+  NotifiEmailInputProps,
+} from '../../NotifiEmailInput';
+import { NotifiSmsInput, NotifiSmsInputProps } from '../../NotifiSmsInput';
+import {
+  NotifiTelegramInput,
+  NotifiTelegramInputProps,
+} from '../../NotifiTelegramInput';
+import {
+  EventTypeBroadcastRow,
+  EventTypeBroadcastRowProps,
+} from '../EventTypeBroadcastRow';
+import { EventTypeDirectPushRow } from '../EventTypeDirectPushRow';
+import {
+  EventTypeUnsupportedRow,
+  EventTypeUnsupportedRowProps,
+} from '../EventTypeUnsupportedRow';
+import {
+  NotifiInputLabels,
+  NotifiInputSeparators,
+} from '../NotifiSubscriptionCard';
+
+export type EditCardViewProps = Readonly<{
+  data: CardConfigItemV1;
+  inputDisabled: boolean;
+  classNames?: Readonly<{
+    NotifiEmailInput?: NotifiEmailInputProps['classNames'];
+    NotifiSmsInput?: NotifiSmsInputProps['classNames'];
+    NotifiTelegramInput?: NotifiTelegramInputProps['classNames'];
+    EventTypeBroadcastRow?: EventTypeBroadcastRowProps['classNames'];
+    EventTypeUnsupportedRow?: EventTypeUnsupportedRowProps['classNames'];
+  }>;
+  inputs: Record<string, string | undefined>;
+  inputSeparators?: NotifiInputSeparators;
+  inputLabels?: NotifiInputLabels;
+  allowedCountryCodes: string[];
+}>;
+
+export const EditCardView: React.FC<EditCardViewProps> = ({
+  data,
+  inputDisabled,
+  classNames,
+  inputSeparators,
+  inputLabels,
+  allowedCountryCodes,
+  inputs,
+}) => {
+  return (
+    <>
+      {data.contactInfo.email.active ? (
+        <NotifiEmailInput
+          disabled={inputDisabled}
+          classNames={classNames?.NotifiEmailInput}
+          copy={{ label: inputLabels?.email }}
+        />
+      ) : null}
+      {inputSeparators?.emailSeparator?.content ? (
+        <div
+          className={clsx(
+            'NotifiInputSeparator__container',
+            inputSeparators?.emailSeparator?.classNames?.container,
+          )}
+        >
+          <div
+            className={clsx(
+              'NotifiInputSeparator__content',
+              inputSeparators.emailSeparator.classNames?.content,
+            )}
+          >
+            {inputSeparators?.emailSeparator?.content}
+          </div>
+        </div>
+      ) : null}
+      {data.contactInfo.sms.active ? (
+        <NotifiSmsInput
+          disabled={inputDisabled}
+          classNames={classNames?.NotifiSmsInput}
+          allowedCountryCodes={allowedCountryCodes}
+          copy={{ label: inputLabels?.sms }}
+        />
+      ) : null}
+      {inputSeparators?.smsSeparator?.content ? (
+        <div
+          className={clsx(
+            'NotifiInputSeparator__container',
+            inputSeparators?.smsSeparator?.classNames?.container,
+          )}
+        >
+          <div
+            className={clsx(
+              'NotifiInputSeparator__content',
+              inputSeparators.smsSeparator.classNames?.content,
+            )}
+          >
+            {inputSeparators?.smsSeparator?.content}
+          </div>
+        </div>
+      ) : null}
+      {data.contactInfo.telegram.active ? (
+        <NotifiTelegramInput
+          disabled={inputDisabled}
+          classNames={classNames?.NotifiTelegramInput}
+          copy={{ label: inputLabels?.telegram }}
+        />
+      ) : null}
+      {inputSeparators?.telegramSeparator?.content ? (
+        <div
+          className={clsx(
+            'NotifiInputSeparator__container',
+            inputSeparators?.smsSeparator?.classNames?.container,
+          )}
+        >
+          <div
+            className={clsx(
+              'NotifiInputSeparator__content',
+              inputSeparators.telegramSeparator.classNames?.content,
+            )}
+          >
+            {inputSeparators?.telegramSeparator?.content}
+          </div>
+        </div>
+      ) : null}
+      {data.eventTypes?.map((eventType) => {
+        switch (eventType.type) {
+          case 'broadcast':
+            return (
+              <EventTypeBroadcastRow
+                key={eventType.name}
+                classNames={classNames?.EventTypeBroadcastRow}
+                disabled={inputDisabled}
+                config={eventType}
+                inputs={inputs}
+              />
+            );
+          case 'directPush':
+            return (
+              <EventTypeDirectPushRow
+                key={eventType.name}
+                classNames={classNames?.EventTypeBroadcastRow}
+                disabled={inputDisabled}
+                config={eventType}
+                inputs={inputs}
+              />
+            );
+          default:
+            return (
+              <EventTypeUnsupportedRow
+                key={JSON.stringify(eventType)}
+                classNames={classNames?.EventTypeUnsupportedRow}
+              />
+            );
+        }
+      })}
+    </>
+  );
+};

--- a/packages/notifi-react-card/lib/components/subscription/subscription card views/HistoryCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription card views/HistoryCardView.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const HistoryCardView = () => {
+  return <div> History Card View</div>;
+};

--- a/packages/notifi-react-card/lib/hooks/useFetchedCardState.ts
+++ b/packages/notifi-react-card/lib/hooks/useFetchedCardState.ts
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+
+export type AlertsView = Readonly<{
+  state: 'alerts';
+}>;
+export type HistoryView = Readonly<{
+  state: 'history';
+}>;
+export type EditInfoView = Readonly<{
+  state: 'edit';
+}>;
+
+export type FetchedCardView = AlertsView | HistoryView | EditInfoView;
+
+export const useFetchedCardState = () => {
+  const [cardView] = useState<FetchedCardView>({
+    state: 'edit',
+  });
+
+  return {
+    cardView,
+  };
+};


### PR DESCRIPTION
the current card will need different presentational views after the data has fetched. my plan of attack is to start with the edit view and based off the presence of target group data from the useNotifiSubscriptionContext, update the state on first load