### PR TITLE
Add Read Value to Notification History Fragment

### DIFF
--- a/packages/notifi-graphql/lib/gql/fragments/NotificationHistoryEntryFragment.gql.ts
+++ b/packages/notifi-graphql/lib/gql/fragments/NotificationHistoryEntryFragment.gql.ts
@@ -5,6 +5,7 @@ export const NotificationHistoryEntryFragment = gql`
     id
     category
     createdDate
+    read
     detail {
       __typename
       ... on BroadcastMessageEventDetails {


### PR DESCRIPTION
We need read history for Pontem notification alert history.

This adds the read value to Notification History fragment in GraphQL and as a result will update the node value from `getNotificationHistory` function in the frontend client. 