### PR TITLE
[MVP-1570] refactor react card context

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCard.tsx
@@ -1,17 +1,15 @@
-import clsx from 'clsx';
 import React from 'react';
 
-import { useNotifiSubscriptionContext } from '../../context';
-import { useNotifiSubscribe, useSubscriptionCard } from '../../hooks';
+import {
+  NotifiSubscriptionContextProvider,
+  useNotifiClientContext,
+} from '../../context';
 import type { NotifiFooterProps } from '../NotifiFooter';
-import { NotifiFooter } from '../NotifiFooter';
 import type { ErrorStateCardProps } from './ErrorStateCard';
-import { ErrorStateCard } from './ErrorStateCard';
 import type { FetchedStateCardProps } from './FetchedStateCard';
-import { FetchedStateCard } from './FetchedStateCard';
 import type { LoadingStateCardProps } from './LoadingStateCard';
-import { LoadingStateCard } from './LoadingStateCard';
 import type { NotifiSubscribeButtonProps } from './NotifiSubscribeButton';
+import { NotifiSubscriptionCardContainer } from './NotifiSubscriptionCardContainer';
 
 export type NotifiInputSeparators = {
   emailSeparator?: {
@@ -61,61 +59,12 @@ export type NotifiSubscriptionCardProps = Readonly<{
 
 export const NotifiSubscriptionCard: React.FC<
   React.PropsWithChildren<NotifiSubscriptionCardProps>
-> = ({
-  classNames,
-  cardId,
-  darkMode,
-  inputLabels,
-  inputs = {},
-  inputSeparators,
-  children,
-}: React.PropsWithChildren<NotifiSubscriptionCardProps>) => {
-  const { isInitialized } = useNotifiSubscribe();
-  const { loading } = useNotifiSubscriptionContext();
-  const inputDisabled = loading || !isInitialized;
-
-  const card = useSubscriptionCard(cardId);
-  let contents: React.ReactNode = null;
-
-  switch (card.state) {
-    case 'loading':
-      contents = (
-        <LoadingStateCard
-          classNames={classNames?.LoadingStateCard}
-          card={card}
-        />
-      );
-      break;
-    case 'error':
-      contents = (
-        <ErrorStateCard classNames={classNames?.ErrorStateCard} card={card} />
-      );
-      break;
-    case 'fetched':
-      contents = (
-        <FetchedStateCard
-          classNames={classNames?.FetchedStateCard}
-          card={card}
-          inputs={inputs}
-          inputDisabled={inputDisabled}
-          inputLabels={inputLabels}
-          inputSeparators={inputSeparators}
-        />
-      );
-      break;
-  }
+> = (props: React.PropsWithChildren<NotifiSubscriptionCardProps>) => {
+  const { params } = useNotifiClientContext();
 
   return (
-    <div
-      className={clsx(
-        darkMode ? 'notifi__dark' : 'notifi__light',
-        'NotifiSubscriptionCard__container',
-        classNames?.container,
-      )}
-    >
-      {children}
-      {contents}
-      <NotifiFooter classNames={classNames?.NotifiFooter} />
-    </div>
+    <NotifiSubscriptionContextProvider {...params}>
+      <NotifiSubscriptionCardContainer {...props} />
+    </NotifiSubscriptionContextProvider>
   );
 };

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCardContainer.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCardContainer.tsx
@@ -1,0 +1,95 @@
+import clsx from 'clsx';
+import React from 'react';
+
+import { useNotifiSubscriptionContext } from '../../context';
+import { useNotifiSubscribe, useSubscriptionCard } from '../../hooks';
+import type { NotifiFooterProps } from '../NotifiFooter';
+import { NotifiFooter } from '../NotifiFooter';
+import type { ErrorStateCardProps } from './ErrorStateCard';
+import { ErrorStateCard } from './ErrorStateCard';
+import type { FetchedStateCardProps } from './FetchedStateCard';
+import { FetchedStateCard } from './FetchedStateCard';
+import type { LoadingStateCardProps } from './LoadingStateCard';
+import { LoadingStateCard } from './LoadingStateCard';
+import type { NotifiSubscribeButtonProps } from './NotifiSubscribeButton';
+import {
+  NotifiInputLabels,
+  NotifiInputSeparators,
+} from './NotifiSubscriptionCard';
+
+export type NotifiSubscriptionCardProps = Readonly<{
+  classNames?: Readonly<{
+    container?: string;
+    ErrorStateCard?: ErrorStateCardProps['classNames'];
+    FetchedStateCard?: FetchedStateCardProps['classNames'];
+    LoadingStateCard?: LoadingStateCardProps['classNames'];
+    NotifiSubscribeButton?: NotifiSubscribeButtonProps['classNames'];
+    NotifiFooter?: NotifiFooterProps['classNames'];
+  }>;
+  inputLabels?: NotifiInputLabels;
+  darkMode?: boolean;
+  cardId: string;
+  inputs?: Record<string, string | undefined>;
+  inputSeparators?: NotifiInputSeparators;
+}>;
+
+export const NotifiSubscriptionCardContainer: React.FC<
+  React.PropsWithChildren<NotifiSubscriptionCardProps>
+> = ({
+  classNames,
+  cardId,
+  darkMode,
+  inputLabels,
+  inputs = {},
+  inputSeparators,
+  children,
+}: React.PropsWithChildren<NotifiSubscriptionCardProps>) => {
+  const { isInitialized } = useNotifiSubscribe();
+  const { loading } = useNotifiSubscriptionContext();
+  const inputDisabled = loading || !isInitialized;
+
+  const card = useSubscriptionCard(cardId);
+  let contents: React.ReactNode = null;
+
+  switch (card.state) {
+    case 'loading':
+      contents = (
+        <LoadingStateCard
+          classNames={classNames?.LoadingStateCard}
+          card={card}
+        />
+      );
+      break;
+    case 'error':
+      contents = (
+        <ErrorStateCard classNames={classNames?.ErrorStateCard} card={card} />
+      );
+      break;
+    case 'fetched':
+      contents = (
+        <FetchedStateCard
+          classNames={classNames?.FetchedStateCard}
+          card={card}
+          inputs={inputs}
+          inputDisabled={inputDisabled}
+          inputLabels={inputLabels}
+          inputSeparators={inputSeparators}
+        />
+      );
+      break;
+  }
+
+  return (
+    <div
+      className={clsx(
+        darkMode ? 'notifi__dark' : 'notifi__light',
+        'NotifiSubscriptionCard__container',
+        classNames?.container,
+      )}
+    >
+      {children}
+      {contents}
+      <NotifiFooter classNames={classNames?.NotifiFooter} />
+    </div>
+  );
+};

--- a/packages/notifi-react-card/lib/context/NotifiContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiContext.tsx
@@ -67,9 +67,7 @@ export const NotifiContext: React.FC<React.PropsWithChildren<NotifiParams>> = ({
 }: React.PropsWithChildren<NotifiParams>) => {
   return (
     <NotifiClientContextProvider {...params}>
-      <NotifiSubscriptionContextProvider {...params}>
-        {children}
-      </NotifiSubscriptionContextProvider>
+      {children}
     </NotifiClientContextProvider>
   );
 };


### PR DESCRIPTION
as subscription card and intercom card have it's own target group, instead of using `NotifiSubscriptionContextProvider` on the entire React Card, we need to wrap this provider on subscription card and intercom card individually. 

this PR has the context refactor on the subscription card and will have the `NotifiSubscriptionContextProvider` added for intercom card in another PR(intercom FTU)

Test:
![Untitled](https://user-images.githubusercontent.com/26240001/199847809-9086865c-99ea-4a0c-9b2a-9c5ca6b643e1.gif)
