### PR TITLE
Alert History Empty State Default Card Size / Shows With Empty Nodes

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/defaults.css
+++ b/packages/notifi-react-card/lib/components/subscription/defaults.css
@@ -87,7 +87,7 @@
   justify-content: space-between;
   width: 100%;
   overflow: hidden;
-  margin: 20px 0;
+  padding: 15px 0;
 }
 
 .NotifiAlertHistory__content {

--- a/packages/notifi-react-card/lib/components/subscription/defaults.css
+++ b/packages/notifi-react-card/lib/components/subscription/defaults.css
@@ -39,6 +39,8 @@
   background-color: var(--notifi-card-background);
   border-radius: 5px;
   padding: 20px 20px 5px 20px;
+  height: 600px;
+  justify-content: space-between;
 }
 
 .NotifiSubscriptionCard__container *:not(:last-child) {
@@ -51,6 +53,7 @@
   align-items: baseline;
   font-size: 12px;
   line-height: 14px;
+  flex-grow: 1;
 }
 
 .NotifiFooter__logoSvg {
@@ -103,6 +106,11 @@
   border-radius: 5px;
 }
 
+.NotifiAlertHistory__headerSection {
+  display: flex;
+  flex-direction: column;
+}
+
 .NotifiAlertHistory__header {
   display: flex;
   flex-direction: row;
@@ -149,8 +157,6 @@
   line-height: 14px;
   color: var(--notifi-secondary-font-color);
   text-align: center;
-  height: 400px;
-  line-height: 400px;
 }
 
 .NotifiAlertHistory__manageAlertLink {
@@ -158,6 +164,10 @@
   line-height: 14px;
   color: var(--notifi-link-color);
   cursor: pointer;
+}
+
+.NotifiEditCard__container {
+  display: flex;
 }
 
 .NotifiEmailInput__container,

--- a/packages/notifi-react-card/lib/components/subscription/defaults.css
+++ b/packages/notifi-react-card/lib/components/subscription/defaults.css
@@ -40,7 +40,7 @@
   border-radius: 5px;
   padding: 20px 20px 5px 20px;
   height: 450px;
-  width: 300px;
+  width: 350px;
   justify-content: space-between;
 }
 
@@ -85,10 +85,9 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  padding: 10px 15px 0 10px;
   width: 100%;
   overflow: hidden;
-  margin: 10px 0;
+  margin: 20px 0;
 }
 
 .NotifiAlertHistory__content {

--- a/packages/notifi-react-card/lib/components/subscription/defaults.css
+++ b/packages/notifi-react-card/lib/components/subscription/defaults.css
@@ -146,8 +146,8 @@
 }
 
 .NotifiAlertHistory__notificationImage {
-  width: 18px;
-  height: 18px;
+  min-width: 18px;
+  min-height: 18px;
   padding-right: 10px;
 }
 

--- a/packages/notifi-react-card/lib/components/subscription/defaults.css
+++ b/packages/notifi-react-card/lib/components/subscription/defaults.css
@@ -122,7 +122,7 @@
   line-height: 12px;
   color: var(--notifi-font-color);
   opacity: 60%;
-  padding-right: 25px;
+  padding-right: 20px;
 }
 
 .NotifiAlertHistory__notificationMessage {

--- a/packages/notifi-react-card/lib/components/subscription/defaults.css
+++ b/packages/notifi-react-card/lib/components/subscription/defaults.css
@@ -39,7 +39,8 @@
   background-color: var(--notifi-card-background);
   border-radius: 5px;
   padding: 20px 20px 5px 20px;
-  height: 600px;
+  height: 450px;
+  width: 300px;
   justify-content: space-between;
 }
 
@@ -53,7 +54,6 @@
   align-items: baseline;
   font-size: 12px;
   line-height: 14px;
-  flex-grow: 1;
 }
 
 .NotifiFooter__logoSvg {
@@ -168,6 +168,15 @@
 
 .NotifiEditCard__container {
   display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  flex-grow: 1;
+}
+
+.NotifiEditCard__inputsSection {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 0.5;
 }
 
 .NotifiEmailInput__container,

--- a/packages/notifi-react-card/lib/components/subscription/defaults.css
+++ b/packages/notifi-react-card/lib/components/subscription/defaults.css
@@ -87,7 +87,7 @@
   justify-content: space-between;
   width: 100%;
   overflow: hidden;
-  padding: 15px 0;
+  padding: 10px 0;
 }
 
 .NotifiAlertHistory__content {

--- a/packages/notifi-react-card/lib/components/subscription/defaults.css
+++ b/packages/notifi-react-card/lib/components/subscription/defaults.css
@@ -149,6 +149,8 @@
   line-height: 14px;
   color: var(--notifi-secondary-font-color);
   text-align: center;
+  height: 400px;
+  line-height: 400px;
 }
 
 .NotifiAlertHistory__manageAlertLink {

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/EditCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/EditCardView.tsx
@@ -24,6 +24,7 @@ export type EditCardViewProps = Readonly<{
   data: CardConfigItemV1;
   inputDisabled: boolean;
   classNames?: Readonly<{
+    container?: string;
     NotifiEmailInput?: NotifiEmailInputProps['classNames'];
     NotifiSmsInput?: NotifiSmsInputProps['classNames'];
     NotifiTelegramInput?: NotifiTelegramInputProps['classNames'];
@@ -42,16 +43,20 @@ export const EditCardView: React.FC<EditCardViewProps> = ({
   inputLabels,
   allowedCountryCodes,
 }) => {
+  const emailInputActive = data.contactInfo.email.active;
+  const smsInputActive = data.contactInfo.sms.active;
+  const telegramInputActive = data.contactInfo.telegram.active;
+
   return (
-    <>
-      {data.contactInfo.email.active ? (
+    <div className={clsx('NotifiEditCard__container', classNames?.container)}>
+      {emailInputActive ? (
         <NotifiEmailInput
           disabled={inputDisabled}
           classNames={classNames?.NotifiEmailInput}
           copy={{ label: inputLabels?.email }}
         />
       ) : null}
-      {inputSeparators?.emailSeparator?.content ? (
+      {smsInputActive && inputSeparators?.emailSeparator?.content ? (
         <div
           className={clsx(
             'NotifiInputSeparator__container',
@@ -68,7 +73,7 @@ export const EditCardView: React.FC<EditCardViewProps> = ({
           </div>
         </div>
       ) : null}
-      {data.contactInfo.sms.active ? (
+      {smsInputActive ? (
         <NotifiSmsInput
           disabled={inputDisabled}
           classNames={classNames?.NotifiSmsInput}
@@ -76,7 +81,7 @@ export const EditCardView: React.FC<EditCardViewProps> = ({
           copy={{ label: inputLabels?.sms }}
         />
       ) : null}
-      {inputSeparators?.smsSeparator?.content ? (
+      {telegramInputActive && inputSeparators?.smsSeparator?.content ? (
         <div
           className={clsx(
             'NotifiInputSeparator__container',
@@ -93,7 +98,7 @@ export const EditCardView: React.FC<EditCardViewProps> = ({
           </div>
         </div>
       ) : null}
-      {data.contactInfo.telegram.active ? (
+      {telegramInputActive ? (
         <NotifiTelegramInput
           disabled={inputDisabled}
           classNames={classNames?.NotifiTelegramInput}
@@ -121,6 +126,6 @@ export const EditCardView: React.FC<EditCardViewProps> = ({
         data={data}
         classNames={classNames?.NotifiSubscribeButton}
       />
-    </>
+    </div>
   );
 };

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/EditCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/EditCardView.tsx
@@ -25,6 +25,7 @@ export type EditCardViewProps = Readonly<{
   inputDisabled: boolean;
   classNames?: Readonly<{
     container?: string;
+    inputsSection?: string;
     NotifiEmailInput?: NotifiEmailInputProps['classNames'];
     NotifiSmsInput?: NotifiSmsInputProps['classNames'];
     NotifiTelegramInput?: NotifiTelegramInputProps['classNames'];
@@ -49,79 +50,86 @@ export const EditCardView: React.FC<EditCardViewProps> = ({
 
   return (
     <div className={clsx('NotifiEditCard__container', classNames?.container)}>
-      {emailInputActive ? (
-        <NotifiEmailInput
-          disabled={inputDisabled}
-          classNames={classNames?.NotifiEmailInput}
-          copy={{ label: inputLabels?.email }}
-        />
-      ) : null}
-      {smsInputActive && inputSeparators?.emailSeparator?.content ? (
-        <div
-          className={clsx(
-            'NotifiInputSeparator__container',
-            inputSeparators?.emailSeparator?.classNames?.container,
-          )}
-        >
+      <div
+        className={clsx(
+          'NotifiEditCard__inputsSection',
+          classNames?.inputsSection,
+        )}
+      >
+        {emailInputActive ? (
+          <NotifiEmailInput
+            disabled={inputDisabled}
+            classNames={classNames?.NotifiEmailInput}
+            copy={{ label: inputLabels?.email }}
+          />
+        ) : null}
+        {smsInputActive && inputSeparators?.emailSeparator?.content ? (
           <div
             className={clsx(
-              'NotifiInputSeparator__content',
-              inputSeparators.emailSeparator.classNames?.content,
+              'NotifiInputSeparator__container',
+              inputSeparators?.emailSeparator?.classNames?.container,
             )}
           >
-            {inputSeparators?.emailSeparator?.content}
+            <div
+              className={clsx(
+                'NotifiInputSeparator__content',
+                inputSeparators.emailSeparator.classNames?.content,
+              )}
+            >
+              {inputSeparators?.emailSeparator?.content}
+            </div>
           </div>
-        </div>
-      ) : null}
-      {smsInputActive ? (
-        <NotifiSmsInput
-          disabled={inputDisabled}
-          classNames={classNames?.NotifiSmsInput}
-          allowedCountryCodes={allowedCountryCodes}
-          copy={{ label: inputLabels?.sms }}
-        />
-      ) : null}
-      {telegramInputActive && inputSeparators?.smsSeparator?.content ? (
-        <div
-          className={clsx(
-            'NotifiInputSeparator__container',
-            inputSeparators?.smsSeparator?.classNames?.container,
-          )}
-        >
+        ) : null}
+        {smsInputActive ? (
+          <NotifiSmsInput
+            disabled={inputDisabled}
+            classNames={classNames?.NotifiSmsInput}
+            allowedCountryCodes={allowedCountryCodes}
+            copy={{ label: inputLabels?.sms }}
+          />
+        ) : null}
+        {telegramInputActive && inputSeparators?.smsSeparator?.content ? (
           <div
             className={clsx(
-              'NotifiInputSeparator__content',
-              inputSeparators.smsSeparator.classNames?.content,
+              'NotifiInputSeparator__container',
+              inputSeparators?.smsSeparator?.classNames?.container,
             )}
           >
-            {inputSeparators?.smsSeparator?.content}
+            <div
+              className={clsx(
+                'NotifiInputSeparator__content',
+                inputSeparators.smsSeparator.classNames?.content,
+              )}
+            >
+              {inputSeparators?.smsSeparator?.content}
+            </div>
           </div>
-        </div>
-      ) : null}
-      {telegramInputActive ? (
-        <NotifiTelegramInput
-          disabled={inputDisabled}
-          classNames={classNames?.NotifiTelegramInput}
-          copy={{ label: inputLabels?.telegram }}
-        />
-      ) : null}
-      {inputSeparators?.telegramSeparator?.content ? (
-        <div
-          className={clsx(
-            'NotifiInputSeparator__container',
-            inputSeparators?.smsSeparator?.classNames?.container,
-          )}
-        >
+        ) : null}
+        {telegramInputActive ? (
+          <NotifiTelegramInput
+            disabled={inputDisabled}
+            classNames={classNames?.NotifiTelegramInput}
+            copy={{ label: inputLabels?.telegram }}
+          />
+        ) : null}
+        {inputSeparators?.telegramSeparator?.content ? (
           <div
             className={clsx(
-              'NotifiInputSeparator__content',
-              inputSeparators.telegramSeparator.classNames?.content,
+              'NotifiInputSeparator__container',
+              inputSeparators?.smsSeparator?.classNames?.container,
             )}
           >
-            {inputSeparators?.telegramSeparator?.content}
+            <div
+              className={clsx(
+                'NotifiInputSeparator__content',
+                inputSeparators.telegramSeparator.classNames?.content,
+              )}
+            >
+              {inputSeparators?.telegramSeparator?.content}
+            </div>
           </div>
-        </div>
-      ) : null}
+        ) : null}
+      </div>
       <NotifiSubscribeButton
         data={data}
         classNames={classNames?.NotifiSubscribeButton}

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
@@ -58,7 +58,6 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
   alertHistoryTitle,
   classNames,
   noAlertDescription,
-  notificationListHeight,
 }) => {
   alertHistoryTitle = alertHistoryTitle ? alertHistoryTitle : 'Alert History';
   noAlertDescription = noAlertDescription
@@ -161,23 +160,24 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
         />
       </div>
       {nodeLength > 0 ? (
-        <Virtuoso
-          style={{
-            height: notificationListHeight || '400px',
-            marginBottom: '25px',
-          }}
-          isScrolling={setIsScrolling}
-          rangeChanged={setVisibleRange}
-          data={allNodes.filter(
-            (notification) => notification.detail != undefined,
-          )}
-          itemContent={(index, notification) => {
-            setCurrentIndex(index);
-            return (
-              <AlertCard key={notification.id} notification={notification} />
-            );
-          }}
-        />
+        <div style={{ flexGrow: 1 }}>
+          <Virtuoso
+            style={{
+              marginBottom: '25px',
+            }}
+            isScrolling={setIsScrolling}
+            rangeChanged={setVisibleRange}
+            data={allNodes.filter(
+              (notification) => notification.detail != undefined,
+            )}
+            itemContent={(index, notification) => {
+              setCurrentIndex(index);
+              return (
+                <AlertCard key={notification.id} notification={notification} />
+              );
+            }}
+          />
+        </div>
       ) : (
         <span
           className={clsx(

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
@@ -148,7 +148,7 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
           classNames?.dividerLine,
         )}
       />
-      {alertHistoryData?.nodes ? (
+      {alertHistoryData?.nodes && alertHistoryData?.nodes?.length > 0 ? (
         <Virtuoso
           style={{
             height: notificationListHeight || '400px',

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
@@ -21,6 +21,7 @@ export type AlertHistoryViewProps = Readonly<{
   classNames?: Readonly<{
     title?: string;
     header?: string;
+    headerSection?: string;
     dividerLine?: string;
     manageAlertLink?: string;
     noAlertDescription?: string;
@@ -126,29 +127,40 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
     }
   }, [currentIndex, visibleRange, hasNextPage, endCursor]);
 
+  const nodeLength = alertHistoryData?.nodes?.length ?? 0;
+
   return (
     <>
-      <div className={clsx('NotifiAlertHistory__header', classNames?.header)}>
-        <span className={clsx('NotifiAlertHistory__label', classNames?.title)}>
-          {alertHistoryTitle}
-        </span>
-        <div
-          className={clsx(
-            'NotifiAlertHistory__manageAlertLink',
-            classNames?.manageAlertLink,
-          )}
-          onClick={handleBackClick}
-        >
-          Manage Alerts
-        </div>
-      </div>
       <div
         className={clsx(
-          'NotifiAlertHistory__dividerLine',
-          classNames?.dividerLine,
+          'NotifiAlertHistory__headerSection',
+          classNames?.headerSection,
         )}
-      />
-      {alertHistoryData?.nodes && alertHistoryData?.nodes?.length > 0 ? (
+      >
+        <div className={clsx('NotifiAlertHistory__header', classNames?.header)}>
+          <span
+            className={clsx('NotifiAlertHistory__label', classNames?.title)}
+          >
+            {alertHistoryTitle}
+          </span>
+          <div
+            className={clsx(
+              'NotifiAlertHistory__manageAlertLink',
+              classNames?.manageAlertLink,
+            )}
+            onClick={handleBackClick}
+          >
+            Manage Alerts
+          </div>
+        </div>
+        <div
+          className={clsx(
+            'NotifiAlertHistory__dividerLine',
+            classNames?.dividerLine,
+          )}
+        />
+      </div>
+      {nodeLength > 0 ? (
         <Virtuoso
           style={{
             height: notificationListHeight || '400px',


### PR DESCRIPTION
- If nodes does not exist OR length is zero, show empty card state
- Subscription Card default height size is 450px, width is 300px
- Fix - If no telegram or text message, do not show an extra separator

Configuration with no alert history (and two out of three inputs):

<img width="404" alt="Screen Shot 2022-11-16 at 10 49 57 AM" src="https://user-images.githubusercontent.com/108922885/202267423-04ccbeae-74a8-46b0-a0f3-a92b8ec013b7.png">

<img width="398" alt="Screen Shot 2022-11-16 at 10 50 52 AM" src="https://user-images.githubusercontent.com/108922885/202267631-d7817fe6-812d-44bc-bda4-15291644efca.png">

<img width="409" alt="Screen Shot 2022-11-16 at 10 51 07 AM" src="https://user-images.githubusercontent.com/108922885/202267677-f5d3ff5f-1a35-4271-b396-0318f10b1497.png">

Configuration with alert history (and all inputs):

<img width="386" alt="Screen Shot 2022-11-16 at 10 54 43 AM" src="https://user-images.githubusercontent.com/108922885/202268513-c16f185a-4a19-42e5-85bf-65f693857474.png">

<img width="391" alt="Screen Shot 2022-11-16 at 10 55 33 AM" src="https://user-images.githubusercontent.com/108922885/202268553-12e29fd6-d7d9-47fe-80e1-b784bbe9d18d.png">

<img width="436" alt="Screen Shot 2022-11-16 at 2 25 51 PM" src="https://user-images.githubusercontent.com/108922885/202307850-dd3bb6bb-82a5-454b-bc37-c2e842641400.png">

Alert History Icons and Date Padding preserved even on narrow screens:
<img width="322" alt="Screen Shot 2022-11-18 at 9 43 12 AM" src="https://user-images.githubusercontent.com/108922885/202768504-314fa26c-34f6-45de-b882-fcc15a0b8ff4.png">


