### PR TITLE
[MVP-1599] - [2/2] render of Intercom conversation messages - without polling

### DIFF
--- a/packages/notifi-axios-adapter/lib/fragments/convMessagePageInfoFragment.ts
+++ b/packages/notifi-axios-adapter/lib/fragments/convMessagePageInfoFragment.ts
@@ -1,0 +1,6 @@
+export const ConvMessagePageInfoFragment = `
+fragment ConvMessagePageInfo on PageInfo {
+  hasNextPage
+  endCursor
+}
+`.trim();

--- a/packages/notifi-axios-adapter/lib/fragments/conversationMessagePageInfoFragment.ts
+++ b/packages/notifi-axios-adapter/lib/fragments/conversationMessagePageInfoFragment.ts
@@ -1,6 +1,0 @@
-export const conversationMessagePageInfoFragment = `
-fragment ConversationMessagePageInfo on PageInfo {
-  hasNextPage
-  endCursor
-}
-`.trim();

--- a/packages/notifi-axios-adapter/lib/queries/getConversationMessagesImpl.ts
+++ b/packages/notifi-axios-adapter/lib/queries/getConversationMessagesImpl.ts
@@ -7,9 +7,9 @@ import {
   GetConversationMessagesResult,
 } from '@notifi-network/notifi-core';
 
-import { conversationMessagePageInfoFragment } from '../fragments/conversationMessagePageInfoFragment';
+import { ConvMessagePageInfoFragment } from '../fragments/convMessagePageInfoFragment';
 
-const DEPENDENCIES = [conversationMessagePageInfoFragment];
+const DEPENDENCIES = [ConvMessagePageInfoFragment];
 
 const QUERY = `query conversationMessages(
   $getConversationMessagesInput: GetConversationMessagesInput!

--- a/packages/notifi-react-card/lib/components/intercom/ChatMessageDate.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/ChatMessageDate.tsx
@@ -1,17 +1,24 @@
 import clsx from 'clsx';
 import React from 'react';
 
+import {
+  formatConversationDateTimestamp,
+  formatConversationStartTimestamp,
+} from '../../utils/datetimeUtils';
+
 export type ChatMessageDateProps = Readonly<{
   classNames?: Readonly<{
     container: string;
     content: string;
   }>;
-  date?: string;
+  createdDate: string;
+  isStartDate?: boolean;
 }>;
 
 export const ChatMessageDate: React.FC<ChatMessageDateProps> = ({
   classNames,
-  date = 'August 1',
+  createdDate,
+  isStartDate = true,
 }) => {
   return (
     <div
@@ -26,7 +33,9 @@ export const ChatMessageDate: React.FC<ChatMessageDateProps> = ({
           classNames?.content,
         )}
       >
-        {date}
+        {isStartDate
+          ? formatConversationStartTimestamp(createdDate)
+          : formatConversationDateTimestamp(createdDate)}
       </div>
     </div>
   );

--- a/packages/notifi-react-card/lib/components/intercom/ChatMessageSection.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/ChatMessageSection.tsx
@@ -1,40 +1,96 @@
-import clsx from 'clsx';
 import React from 'react';
+import { Virtuoso } from 'react-virtuoso';
 
-import { ChatMessageDate, ChatMessageDateProps } from './ChatMessageData';
+import { useIntercomChat } from '../../hooks/useIntercomChat';
+import { ChatMessageDate, ChatMessageDateProps } from './ChatMessageDate';
+import {
+  ChatWindowIntroSection,
+  ChatWindowIntroSectionProps,
+} from './ChatWindowIntroSection';
 import { MessageList, MessageListProps } from './MessageList';
 
 export type ChatMessageSectionProps = Readonly<{
   classNames?: Readonly<{
-    container: string;
-    content: string;
-    date: ChatMessageDateProps['classNames'];
+    chatWindowIntro: ChatWindowIntroSectionProps['classNames'];
     messageList: MessageListProps['classNames'];
+    date: ChatMessageDateProps['classNames'];
   }>;
   chatMessageSectionIntroContent?: string;
 }>;
 
 export const ChatMessageSection: React.FC<ChatMessageSectionProps> = ({
   classNames,
-  chatMessageSectionIntroContent = 'What can we help you with today?',
+  chatMessageSectionIntroContent,
 }) => {
+  const {
+    conversation,
+    setIsScrolling,
+    setVisibleRange,
+    setAtTop,
+    isLoading,
+    hasNextPage,
+  } = useIntercomChat({
+    conversationId: '8c5ccf41d93c4bb9b5e1e1014002e923',
+  });
+
   return (
-    <div
-      className={clsx(
-        'NotifiIntercomChatMessageSection__container',
-        classNames?.container,
+    <>
+      {conversation.feed.length === 0 ? (
+        <ChatWindowIntroSection
+          classNames={classNames?.chatWindowIntro}
+          startDate={conversation.createdDate}
+          chatMessageSectionIntroContent={chatMessageSectionIntroContent}
+        />
+      ) : null}
+
+      {conversation.feed.length === 0 ? null : (
+        <Virtuoso
+          atTopStateChange={setAtTop}
+          className="virtual-container"
+          data={conversation.feed}
+          followOutput="auto"
+          isScrolling={setIsScrolling}
+          rangeChanged={setVisibleRange}
+          itemContent={(index, feed) => {
+            return (
+              <div key={index}>
+                {isLoading ? (
+                  <div
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'center',
+                      padding: '10px',
+                    }}
+                  >
+                    Loading...
+                  </div>
+                ) : null}
+                {index === 0 && !hasNextPage && (
+                  <ChatWindowIntroSection
+                    classNames={classNames?.chatWindowIntro}
+                    startDate={conversation.createdDate}
+                    chatMessageSectionIntroContent={
+                      chatMessageSectionIntroContent
+                    }
+                    inVirtualContainerStyle={
+                      'ChatWindowIntro__virtualContainer'
+                    }
+                  />
+                )}
+                {index != 0 && (
+                  <ChatMessageDate
+                    classNames={classNames?.date}
+                    createdDate={feed.timestamp}
+                    isStartDate={false}
+                  />
+                )}
+                <MessageList classNames={classNames?.messageList} feed={feed} />
+              </div>
+            );
+          }}
+          style={{ width: '364px', height: '290px' }}
+        />
       )}
-    >
-      <ChatMessageDate classNames={classNames?.date} />
-      <div
-        className={clsx(
-          'NotifiIntercomChatMessageSectionIntro__content',
-          classNames?.content,
-        )}
-      >
-        {chatMessageSectionIntroContent}
-      </div>
-      <MessageList classNames={classNames?.messageList} />
-    </div>
+    </>
   );
 };

--- a/packages/notifi-react-card/lib/components/intercom/ChatMessageSection.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/ChatMessageSection.tsx
@@ -16,11 +16,15 @@ export type ChatMessageSectionProps = Readonly<{
     date: ChatMessageDateProps['classNames'];
   }>;
   chatMessageSectionIntroContent?: string;
+  messageListWidth?: string;
+  messageListHeight?: string;
 }>;
 
 export const ChatMessageSection: React.FC<ChatMessageSectionProps> = ({
   classNames,
   chatMessageSectionIntroContent,
+  messageListWidth,
+  messageListHeight,
 }) => {
   const {
     conversation,
@@ -88,7 +92,10 @@ export const ChatMessageSection: React.FC<ChatMessageSectionProps> = ({
               </div>
             );
           }}
-          style={{ width: '364px', height: '290px' }}
+          style={{
+            width: messageListWidth || '364px',
+            height: messageListHeight || '290px',
+          }}
         />
       )}
     </>

--- a/packages/notifi-react-card/lib/components/intercom/ChatMessageSection.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/ChatMessageSection.tsx
@@ -47,6 +47,8 @@ export const ChatMessageSection: React.FC<ChatMessageSectionProps> = ({
         />
       ) : (
         <Virtuoso
+          //TODO: improvement to add the scrollSeekConfiguration property
+          //to render a placeholder element instead of the actual item if the user scrolls too fast
           atTopStateChange={setAtTop}
           className="virtual-container"
           data={conversation.feed}

--- a/packages/notifi-react-card/lib/components/intercom/ChatMessageSection.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/ChatMessageSection.tsx
@@ -56,6 +56,8 @@ export const ChatMessageSection: React.FC<ChatMessageSectionProps> = ({
           isScrolling={setIsScrolling}
           rangeChanged={setVisibleRange}
           itemContent={(index, feed) => {
+            const isFirstIndexOnLastPage = index === 0 && !hasNextPage;
+
             return (
               <div key={index}>
                 {isLoading ? (
@@ -69,7 +71,7 @@ export const ChatMessageSection: React.FC<ChatMessageSectionProps> = ({
                     Loading...
                   </div>
                 ) : null}
-                {index === 0 && !hasNextPage && (
+                {isFirstIndexOnLastPage && (
                   <ChatWindowIntroSection
                     classNames={classNames?.chatWindowIntro}
                     startDate={conversation.createdDate}

--- a/packages/notifi-react-card/lib/components/intercom/ChatMessageSection.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/ChatMessageSection.tsx
@@ -45,9 +45,7 @@ export const ChatMessageSection: React.FC<ChatMessageSectionProps> = ({
           startDate={conversation.createdDate}
           chatMessageSectionIntroContent={chatMessageSectionIntroContent}
         />
-      ) : null}
-
-      {conversation.feed.length === 0 ? null : (
+      ) : (
         <Virtuoso
           atTopStateChange={setAtTop}
           className="virtual-container"

--- a/packages/notifi-react-card/lib/components/intercom/ChatWindowIntroSection.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/ChatWindowIntroSection.tsx
@@ -1,0 +1,46 @@
+import clsx from 'clsx';
+import React from 'react';
+
+import { ChatMessageDate, ChatMessageDateProps } from './ChatMessageDate';
+
+export type ChatWindowIntroSectionProps = Readonly<{
+  classNames?: Readonly<{
+    container: string;
+    content: string;
+    date: ChatMessageDateProps['classNames'];
+  }>;
+  chatMessageSectionIntroContent?: string;
+  startDate: string;
+  inVirtualContainerStyle?: string;
+}>;
+
+export const ChatWindowIntroSection: React.FC<
+  React.PropsWithChildren<ChatWindowIntroSectionProps>
+> = ({
+  classNames,
+  startDate,
+  chatMessageSectionIntroContent = 'What can we help you with today?',
+  children,
+  inVirtualContainerStyle,
+}) => {
+  return (
+    <div
+      className={clsx(
+        'NotifiIntercomChatMessageSection__container',
+        inVirtualContainerStyle,
+        classNames?.container,
+      )}
+    >
+      <ChatMessageDate classNames={classNames?.date} createdDate={startDate} />
+      <div
+        className={clsx(
+          'NotifiIntercomChatMessageSectionIntro__content',
+          classNames?.content,
+        )}
+      >
+        {chatMessageSectionIntroContent}
+      </div>
+      {children}
+    </div>
+  );
+};

--- a/packages/notifi-react-card/lib/components/intercom/MessageGroup.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/MessageGroup.tsx
@@ -1,12 +1,8 @@
 import clsx from 'clsx';
 import React from 'react';
 
-type Message = {
-  body: string;
-  timeStamp: string;
-  sender: string;
-  avatar: string;
-};
+import { ChatMessage } from '../../hooks/useIntercomChat';
+import { formatHourTimestamp } from '../../utils/datetimeUtils';
 
 export type MessageGroupProps = Readonly<{
   classNames?: Readonly<{
@@ -16,7 +12,7 @@ export type MessageGroupProps = Readonly<{
     timeStamp: string;
     sender: string;
   }>;
-  messages: Message[];
+  messages: ChatMessage[];
   direction: string;
 }>;
 
@@ -43,12 +39,13 @@ export const MessageGroup: React.FC<MessageGroupProps> = ({
               : 'NotifiIntercomChatOutgoingMessage__container',
             classNames?.messageContainer,
           )}
+          key={index}
         >
-          {isIncoming ? (
+          {/* {isIncoming ? (
             <div>
               <img height={34} src={message.avatar} />
             </div>
-          ) : null}
+          ) : null} */}
           <div
             key={index}
             className={clsx(
@@ -65,17 +62,17 @@ export const MessageGroup: React.FC<MessageGroupProps> = ({
                   classNames?.sender,
                 )}
               >
-                {message.sender}
+                {/* {message.sender} */}
               </div>
             ) : null}
-            <div key={index}>{message.body}</div>
+            <div key={index}>{message.message}</div>
             <div
               className={clsx(
                 'NotifiIntercomChatOutgoingMessage__timeStamp',
                 classNames?.timeStamp,
               )}
             >
-              {message.timeStamp}
+              {formatHourTimestamp(message.createdDate)}
             </div>
           </div>
         </div>

--- a/packages/notifi-react-card/lib/components/intercom/MessageList.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/MessageList.tsx
@@ -1,60 +1,21 @@
 import clsx from 'clsx';
 import React from 'react';
-import { Virtuoso } from 'react-virtuoso';
 
+import { FeedEntry } from '../../hooks/useIntercomChat';
 import { MessageGroup, MessageGroupProps } from './MessageGroup';
-
-const mockConversation = [
-  {
-    direction: 'INCOMING',
-    messages: [
-      {
-        body: 'Good morning! What can we help you with today?',
-        timeStamp: '11:19 AM',
-        sender: 'Gwen',
-        avatar: 'https://i.postimg.cc/K8c0KDpZ/img-alert-transaction.png',
-      },
-    ],
-  },
-  {
-    direction: 'OUTGOING',
-    messages: [
-      {
-        body: 'I’m having an issue',
-        timeStamp: '11:20 AM',
-        sender: '',
-        avatar: '',
-      },
-      {
-        body: 'Where when I connect a wallet',
-        timeStamp: '11:21 AM',
-        sender: '',
-        avatar: '',
-      },
-      {
-        body: 'I’m having an issue',
-        timeStamp: '11:20 AM',
-        sender: '',
-        avatar: '',
-      },
-      {
-        body: 'Where when I connect a wallet',
-        timeStamp: '11:21 AM',
-        sender: '',
-        avatar: '',
-      },
-    ],
-  },
-];
 
 export type MessageListProps = Readonly<{
   classNames?: Readonly<{
     container: string;
     messageGroup: MessageGroupProps['classNames'];
   }>;
+  feed: FeedEntry;
 }>;
 
-export const MessageList: React.FC<MessageListProps> = ({ classNames }) => {
+export const MessageList: React.FC<MessageListProps> = ({
+  classNames,
+  feed,
+}) => {
   return (
     <div
       className={clsx(
@@ -62,21 +23,10 @@ export const MessageList: React.FC<MessageListProps> = ({ classNames }) => {
         classNames?.container,
       )}
     >
-      <Virtuoso
-        className="virtual-container"
-        data={mockConversation}
-        followOutput="auto"
-        itemContent={(index, feed) => {
-          return (
-            <MessageGroup
-              classNames={classNames?.messageGroup}
-              messages={feed.messages}
-              direction={feed.direction}
-              key={index}
-            />
-          );
-        }}
-        style={{ height: '290px', width: '364px' }}
+      <MessageGroup
+        classNames={classNames?.messageGroup}
+        messages={feed.messages}
+        direction={feed.direction}
       />
     </div>
   );

--- a/packages/notifi-react-card/lib/components/intercom/NotifiIntercomChatWindowContainer.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/NotifiIntercomChatWindowContainer.tsx
@@ -12,6 +12,7 @@ import {
 
 export type NotifiIntercomChatWindowContainerProps = Readonly<{
   classNames?: Readonly<{
+    container: string;
     header?: ChatWindowHeaderProps['classNames'];
     chatMessageSection?: ChatMessageSectionProps['classNames'];
     sendMessageSection?: SendMessageSectionProps['classNames'];

--- a/packages/notifi-react-card/lib/components/subscription/defaults.css
+++ b/packages/notifi-react-card/lib/components/subscription/defaults.css
@@ -646,6 +646,10 @@
   overflow-y:auto;
 }
 
+.ChatWindowIntro__virtualContainer {
+  height: 80px;
+}
+
 .NotifiIntercomChatMessageSectionIntro__content {
   font-size: 16px;
   font-weight: 800;
@@ -654,6 +658,7 @@
 }
 
 .NotifiIntercomChatMessageDate__container {
+  display: inline-block;
   width: 64px;
   padding: 5px;
   background: #F5F6FB;
@@ -756,7 +761,7 @@
   font-weight: 600;
   line-height: 12px;
   color: #80829D;
-  min-width: 50px;
+  min-width: 35px;
   bottom: 8px;
   right: 7px;
 }

--- a/packages/notifi-react-card/lib/hooks/useIntercomChat.ts
+++ b/packages/notifi-react-card/lib/hooks/useIntercomChat.ts
@@ -83,6 +83,7 @@ export const useIntercomChat = ({
   }, [hasNextPage, atTop, isScrolling, visibleRange.startIndex]);
 
   const conversation = useMemo(() => {
+    //put the conversation into message group
     const getFeed = () => {
       const messageGroups: ChatMessage[][] = [];
 
@@ -90,14 +91,13 @@ export const useIntercomChat = ({
 
       chatMessages?.forEach((message, index) => {
         const nextMessage = chatMessages[index + 1];
-
+        const isSameUserId = message?.userId === nextMessage?.userId;
+        const isSameDate =
+          formatConversationDateTimestamp(message?.createdDate) ===
+          formatConversationDateTimestamp(nextMessage?.createdDate);
         /// timestamp logic
         messages.unshift(message);
-        if (
-          message?.userId !== nextMessage?.userId ||
-          formatConversationDateTimestamp(message?.createdDate) !=
-            formatConversationDateTimestamp(nextMessage?.createdDate)
-        ) {
+        if (!isSameUserId || !isSameDate) {
           messageGroups.unshift(messages);
           messages = [];
         }

--- a/packages/notifi-react-card/lib/hooks/useIntercomChat.ts
+++ b/packages/notifi-react-card/lib/hooks/useIntercomChat.ts
@@ -1,32 +1,148 @@
-import { useCallback } from 'react';
+import { ConversationMessagesEntry } from '@notifi-network/notifi-core/dist/models/ConversationMessages';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ListRange } from 'react-virtuoso';
 
 import { useNotifiClientContext } from '../context';
+import { formatConversationDateTimestamp } from '../utils/datetimeUtils';
 
-type GetConversationMessagesInputProps = Readonly<{
-  first?: number;
-  after?: string;
+export type ChatConversation = FeedEntry &
+  Readonly<{
+    feed: FeedEntry[];
+    createdDate: string | undefined;
+    lastMessage: ChatMessage | undefined;
+  }>;
+
+export type ChatMessage = Readonly<{
+  id: string;
+  message: string;
+  userId: string;
+  createdDate: string;
+  updatedDate: string;
   conversationId: string;
 }>;
 
-export const useConversationMessages = ({
-  first,
-  after,
+export type MessageDirection = 'INCOMING' | 'OUTGOING';
+
+export type MessagesBlockFeedEntry = Readonly<{
+  type: 'MESSAGES_BLOCK';
+  direction: MessageDirection;
+  messages: ChatMessage[];
+}>;
+
+export type FeedEntry = {
+  id: string;
+  timestamp: string;
+} & MessagesBlockFeedEntry;
+
+type GetConversationMessagesInputProps = Readonly<{
+  first?: number;
+  conversationId: string;
+}>;
+
+export const useIntercomChat = ({
+  first = 5,
   conversationId,
 }: GetConversationMessagesInputProps) => {
+  const [chatMessages, setChatMessages] = useState<ConversationMessagesEntry[]>(
+    [],
+  );
+  const [endCursor, setEndCursor] = useState<string | undefined>();
+  const [hasNextPage, setHasNextPage] = useState<boolean | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [atTop, setAtTop] = useState<boolean>(false);
+  const [visibleRange, setVisibleRange] = useState<ListRange>({
+    startIndex: 0,
+    endIndex: 0,
+  });
+  const [isScrolling, setIsScrolling] = useState<boolean | null>();
   const { client } = useNotifiClientContext();
 
-  const input = {
-    first: first,
-    after: after,
-    getConversationMessagesInput: { conversationId },
-  };
+  const getConversationMessages = useCallback(() => {
+    setIsLoading(true);
+    client
+      .getConversationMessages({
+        first,
+        after: endCursor,
+        getConversationMessagesInput: { conversationId },
+      })
+      .then((response) => {
+        if (Array.isArray(response.nodes)) {
+          setChatMessages([...chatMessages, ...response.nodes]);
+        }
+        if (response.pageInfo) {
+          setEndCursor(response.pageInfo.endCursor);
+          setHasNextPage(response.pageInfo.hasNextPage);
+        }
+        setIsLoading(false);
+      });
+  }, [conversationId, endCursor, chatMessages]);
 
-  const getConversationMessages = useCallback(async () => {
-    const response = await client.getConversationMessages(input);
-    return response;
+  // initialization - load first batch of messages
+  useEffect(() => {
+    getConversationMessages();
   }, []);
 
+  // load more messages when scrolling to the top
+  useEffect(() => {
+    if (hasNextPage && atTop && isScrolling && visibleRange.startIndex === 0) {
+      getConversationMessages();
+    }
+  }, [hasNextPage, atTop, isScrolling, visibleRange.startIndex]);
+
+  const conversation = useMemo(() => {
+    const getFeed = () => {
+      const messageGroups: ChatMessage[][] = [];
+
+      let messages: ChatMessage[] = [];
+
+      chatMessages?.forEach((message, index) => {
+        const nextMessage = chatMessages[index + 1];
+
+        /// timestamp logic
+        messages.unshift(message);
+        if (
+          message?.userId !== nextMessage?.userId ||
+          formatConversationDateTimestamp(message?.createdDate) !=
+            formatConversationDateTimestamp(nextMessage?.createdDate)
+        ) {
+          messageGroups.unshift(messages);
+          messages = [];
+        }
+      });
+
+      const feedEntries = messageGroups.map((messageGroup): FeedEntry => {
+        const firstMessage = messageGroup[0];
+
+        return {
+          direction:
+            firstMessage?.userId === 'c85e8969-10df-43c6-aa4d-402c068e0159'
+              ? 'OUTGOING'
+              : 'INCOMING',
+          id: firstMessage?.id,
+          messages: [...messageGroup],
+          timestamp: firstMessage?.createdDate,
+          type: 'MESSAGES_BLOCK',
+        };
+      });
+
+      return feedEntries;
+    };
+    return {
+      feed: getFeed(),
+      createdDate:
+        chatMessages?.[chatMessages.length - 1]?.createdDate ??
+        new Date().toISOString(),
+      lastMessage: chatMessages?.[0],
+    };
+  }, [chatMessages, conversationId]);
+
   return {
+    conversation,
     getConversationMessages,
+    setIsScrolling,
+    setVisibleRange,
+    setAtTop,
+    hasNextPage,
+    isLoading,
   };
 };

--- a/packages/notifi-react-card/lib/hooks/useIntercomChat.ts
+++ b/packages/notifi-react-card/lib/hooks/useIntercomChat.ts
@@ -5,13 +5,6 @@ import { ListRange } from 'react-virtuoso';
 import { useNotifiClientContext } from '../context';
 import { formatConversationDateTimestamp } from '../utils/datetimeUtils';
 
-export type ChatConversation = FeedEntry &
-  Readonly<{
-    feed: FeedEntry[];
-    createdDate: string | undefined;
-    lastMessage: ChatMessage | undefined;
-  }>;
-
 export type ChatMessage = Readonly<{
   id: string;
   message: string;
@@ -21,9 +14,9 @@ export type ChatMessage = Readonly<{
   conversationId: string;
 }>;
 
-export type MessageDirection = 'INCOMING' | 'OUTGOING';
+type MessageDirection = 'INCOMING' | 'OUTGOING';
 
-export type MessagesBlockFeedEntry = Readonly<{
+type MessagesBlockFeedEntry = Readonly<{
   type: 'MESSAGES_BLOCK';
   direction: MessageDirection;
   messages: ChatMessage[];

--- a/packages/notifi-react-card/lib/utils/datetimeUtils.ts
+++ b/packages/notifi-react-card/lib/utils/datetimeUtils.ts
@@ -1,0 +1,41 @@
+import { format, parseISO } from 'date-fns';
+
+export const formatConversationDateTimestamp = (date: string): string => {
+  try {
+    const parsedDate = parseISO(date);
+    const month = parsedDate.toLocaleString('default', { month: 'short' });
+    const day = format(parsedDate, 'd');
+
+    return `${month} ${day}`;
+  } catch {
+    return '';
+  }
+};
+
+export const formatHourTimestamp = (date: string): string => {
+  const parsedDate = parseISO(date);
+  return format(parsedDate, 'H:mm');
+};
+
+export const formatConversationStartTimestamp = (date: string): string => {
+  try {
+    const parsedDate = parseISO(date);
+    const month = parsedDate.toLocaleString('default', { month: 'short' });
+    const day = format(parsedDate, 'd');
+
+    const finalTimestamp = isToday(parsedDate) ? 'Today' : `${month} ${day}`;
+    return finalTimestamp;
+  } catch {
+    return '';
+  }
+};
+
+export const isToday = (date: Date) => {
+  const today = new Date();
+
+  return (
+    date.getDate() == today.getDate() &&
+    date.getMonth() == today.getMonth() &&
+    date.getFullYear() == today.getFullYear()
+  );
+};


### PR DESCRIPTION
hard coding(used existing conversation id to get one conversation thread) a conversation messages
updated logics in useIntercomChat to get the correct data structure to render messages
implement pagination

hide sender name and sender avatar component until we have the correct field exposed in the future.
need to ask Sam with a design of loading message state but using wording "Loading..." for now as the state.
will implement polling or apollo subscriptions in another PR.

Test:
![Untitled](https://user-images.githubusercontent.com/26240001/202404013-be2cd314-157f-4568-b6da-501f22aa079c.gif)


Story:
https://notifi.atlassian.net/browse/MVP-1599