### PR TITLE
[MVP-1583] Enable subscribe to chat alerts 

### DIFF
--- a/packages/notifi-core/lib/NotifiClient.ts
+++ b/packages/notifi-core/lib/NotifiClient.ts
@@ -39,7 +39,8 @@ export type AlertFrequency =
   | 'SINGLE'
   | 'QUARTER_HOUR'
   | 'HOURLY'
-  | 'DAILY';
+  | 'DAILY'
+  | 'THREE_MINUTES';
 
 export type ValueItemConfig = Readonly<{
   key: string;

--- a/packages/notifi-core/lib/operations/CreateSource.ts
+++ b/packages/notifi-core/lib/operations/CreateSource.ts
@@ -35,7 +35,8 @@ export type CreateSourceInput = Readonly<{
     | 'BONFIDA_NAME_OFFERS'
     | 'BONFIDA_NAME_AUCTIONING'
     | 'TOPAZ'
-    | 'SOLANA_SNOWFLAKE';
+    | 'SOLANA_SNOWFLAKE'
+    | 'NOTIFI_CHAT';
 }>;
 
 export type CreateSourceResult = Source;

--- a/packages/notifi-react-card/lib/components/NotifiEmailInput.tsx
+++ b/packages/notifi-react-card/lib/components/NotifiEmailInput.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { EmailIcon } from '../assets/EmailIcon';
 import { useNotifiSubscriptionContext } from '../context';
+import { useNotifiSubscribe } from '../hooks';
 import type { DeepPartialReadonly } from '../utils';
 
 export type NotifiEmailInputProps = Readonly<{
@@ -21,6 +22,7 @@ export type NotifiEmailInputProps = Readonly<{
   intercomEmailInputStyle?: string;
   intercomEmailInputContainerStyle?: string;
   intercomView?: boolean;
+  hasChatAlert?: boolean;
 }>;
 
 export const NotifiEmailInput: React.FC<NotifiEmailInputProps> = ({
@@ -30,15 +32,19 @@ export const NotifiEmailInput: React.FC<NotifiEmailInputProps> = ({
   intercomEmailInputStyle,
   intercomEmailInputContainerStyle,
   intercomView,
+  hasChatAlert = false,
 }: NotifiEmailInputProps) => {
   const {
-    intercomCardView,
     email,
     setEmail,
     setEmailErrorMessage,
     emailErrorMessage,
     emailIdThatNeedsConfirmation,
   } = useNotifiSubscriptionContext();
+
+  const { resendEmailVerificationLink } = useNotifiSubscribe({
+    targetGroupName: 'Intercom',
+  });
 
   const validateEmail = () => {
     if (email === '') {
@@ -55,12 +61,16 @@ export const NotifiEmailInput: React.FC<NotifiEmailInputProps> = ({
     }
   };
 
+  const handleClick = () => {
+    resendEmailVerificationLink();
+  };
+
   return (
     <>
       {intercomView ? (
-        intercomCardView.state === 'settingView' &&
-        emailIdThatNeedsConfirmation != '' ? (
+        email && hasChatAlert && emailIdThatNeedsConfirmation != '' ? (
           <div
+            onClick={handleClick}
             className={clsx(
               'NotifiEmailVerification__button',
               classNames?.button,

--- a/packages/notifi-react-card/lib/components/NotifiTelegramInput.tsx
+++ b/packages/notifi-react-card/lib/components/NotifiTelegramInput.tsx
@@ -11,6 +11,7 @@ export type NotifiTelegramInputProps = Readonly<{
     input: string;
     label: string;
     button: string;
+    errorMessage: string;
   }>;
   copy?: DeepPartialReadonly<{
     placeholder: string;
@@ -32,13 +33,31 @@ export const NotifiTelegramInput: React.FC<NotifiTelegramInputProps> = ({
   intercomView,
   hasChatAlert = false,
 }: NotifiTelegramInputProps) => {
-  const { telegramId, setTelegramId, telegramConfirmationUrl } =
-    useNotifiSubscriptionContext();
+  const {
+    telegramId,
+    setTelegramId,
+    telegramConfirmationUrl,
+    setTelegramErrorMessage,
+    telegramErrorMessage,
+  } = useNotifiSubscriptionContext();
+
+  const validateTelegram = () => {
+    if (telegramId === '') {
+      return;
+    }
+
+    const TelegramRegex =
+      /^@?(?=\w{5,32}\b)[a-zA-Z0-9]+(?:[a-zA-Z0-9_ ]+[a-zA-Z0-9])*$/;
+
+    if (TelegramRegex.test(telegramId)) {
+      setTelegramErrorMessage('');
+    } else {
+      setTelegramErrorMessage('The telegram is invalid. Please try again.');
+    }
+  };
 
   const handleClick = () => {
-    if (telegramConfirmationUrl != null) {
-      window.open(telegramConfirmationUrl, '_blank');
-    }
+    window.open(telegramConfirmationUrl, '_blank');
   };
 
   return (
@@ -69,6 +88,7 @@ export const NotifiTelegramInput: React.FC<NotifiTelegramInputProps> = ({
       >
         <TelegramIcon className={'NotifiInput__icon'} />
         <input
+          onBlur={validateTelegram}
           className={clsx(
             'NotifiTelegramInput__input',
             intercomTelegramInputStyle,
@@ -78,12 +98,21 @@ export const NotifiTelegramInput: React.FC<NotifiTelegramInputProps> = ({
           name="notifi-telegram"
           type="text"
           value={telegramId}
+          onFocus={() => setTelegramErrorMessage('')}
           onChange={(e) => {
             setTelegramId(e.target.value ?? '');
           }}
           placeholder={copy?.placeholder ?? 'Telegram ID'}
         />
       </div>
+      <label
+        className={clsx(
+          'NotifiTelegramInput__errorMessage',
+          classNames?.errorMessage,
+        )}
+      >
+        {telegramErrorMessage}
+      </label>
     </>
   );
 };

--- a/packages/notifi-react-card/lib/components/NotifiTelegramInput.tsx
+++ b/packages/notifi-react-card/lib/components/NotifiTelegramInput.tsx
@@ -20,6 +20,7 @@ export type NotifiTelegramInputProps = Readonly<{
   intercomTelegramInputStyle?: string;
   intercomTelegramInputContainerStyle?: string;
   intercomView?: boolean;
+  hasChatAlert?: boolean;
 }>;
 
 export const NotifiTelegramInput: React.FC<NotifiTelegramInputProps> = ({
@@ -29,20 +30,23 @@ export const NotifiTelegramInput: React.FC<NotifiTelegramInputProps> = ({
   intercomTelegramInputStyle,
   intercomTelegramInputContainerStyle,
   intercomView,
+  hasChatAlert = false,
 }: NotifiTelegramInputProps) => {
-  const {
-    intercomCardView,
-    telegramId,
-    setTelegramId,
-    telegramConfirmationUrl,
-  } = useNotifiSubscriptionContext();
+  const { telegramId, setTelegramId, telegramConfirmationUrl } =
+    useNotifiSubscriptionContext();
+
+  const handleClick = () => {
+    if (telegramConfirmationUrl != null) {
+      window.open(telegramConfirmationUrl, '_blank');
+    }
+  };
 
   return (
     <>
       {intercomView ? (
-        intercomCardView.state === 'settingView' &&
-        telegramConfirmationUrl != null ? (
+        hasChatAlert && telegramId && telegramConfirmationUrl != null ? (
           <div
+            onClick={handleClick}
             className={clsx(
               'NotifiTelegramVerification__button',
               classNames?.button,

--- a/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
@@ -1,8 +1,9 @@
 import clsx from 'clsx';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { useNotifiSubscriptionContext } from '../../context/NotifiSubscriptionContext';
-import { CardConfigItemV1 } from '../../hooks';
+import { CardConfigItemV1, useNotifiSubscribe } from '../../hooks';
+import { chatConfiguration } from '../../utils/AlertConfiguration';
 import {
   NotifiInputLabels,
   NotifiInputSeparators,
@@ -27,6 +28,7 @@ export type IntercomCardProps = Readonly<{
     NotifiStartChatButton?: NotifiStartChatButtonProps['classNames'];
     NotifiIntercomChatWindowContainer?: NotifiIntercomChatWindowContainerProps['classNames'];
     NotifiIntercomSettingHeader: SettingHeaderProps['classNames'];
+    errorMessage: string;
   }>;
   companySupportTitle?: string;
   companySupportSubtitle?: string;
@@ -49,8 +51,15 @@ export const IntercomCard: React.FC<
   inputSeparators,
   data,
 }: React.PropsWithChildren<IntercomCardProps>) => {
-  const [checked, setChecked] = useState<boolean>(true);
+  const [hasChatAlert, setHasChatAlert] = useState<boolean>(false);
+  const [chatAlertErrorMessage, setChatAlertErrorMessage] =
+    useState<string>('');
+  const { instantSubscribe } = useNotifiSubscribe({
+    targetGroupName: 'Intercom',
+  });
   const {
+    alerts,
+    loading,
     intercomCardView,
     setIntercomCardView,
     email,
@@ -60,10 +69,19 @@ export const IntercomCard: React.FC<
     telegramId,
   } = useNotifiSubscriptionContext();
 
+  const alertName = 'NOTIFI_CHAT_MESSAGES';
+
+  useEffect(() => {
+    if (loading) {
+      return;
+    }
+    const hasAlert = alerts[alertName] !== undefined;
+    setHasChatAlert(hasAlert);
+  }, [loading, alerts]);
+
   const hasErrors = emailErrorMessage !== '' || smsErrorMessage !== '';
   const disabled =
-    (email === '' && phoneNumber === '' && telegramId === '' && !checked) ||
-    hasErrors;
+    (email === '' && phoneNumber === '' && telegramId === '') || hasErrors;
 
   companySupportTitle = companySupportTitle || 'Your Company Support';
   companySupportSubtitle =
@@ -73,7 +91,19 @@ export const IntercomCard: React.FC<
     companySupportDescription || 'Get notifications for your support request';
 
   const handleStartChatClick = () => {
-    setIntercomCardView({ state: 'chatWindowView' });
+    if (loading) {
+      return;
+    }
+    try {
+      instantSubscribe({
+        alertConfiguration: chatConfiguration(),
+        alertName: alertName,
+      });
+
+      setIntercomCardView({ state: 'chatWindowView' });
+    } catch (e) {
+      setChatAlertErrorMessage('Error to subscribe, please try again');
+    }
   };
 
   let view = null;
@@ -102,14 +132,22 @@ export const IntercomCard: React.FC<
             {companySupportDescription}
           </div>
           <NotifiIntercomFTUNotificationTargetSection
-            checked={checked}
-            setChecked={setChecked}
+            hasChatAlert={hasChatAlert}
             data={data}
             inputs={inputs}
             inputLabels={inputLabels}
             inputSeparators={inputSeparators}
           />
+          <label
+            className={clsx(
+              'NotifiEmailInput__errorMessage',
+              classNames?.errorMessage,
+            )}
+          >
+            {chatAlertErrorMessage}
+          </label>
           <NotifiStartChatButton
+            hasChatAlert={hasChatAlert}
             onClick={handleStartChatClick}
             disabled={disabled}
             classNames={classNames?.NotifiStartChatButton}
@@ -139,14 +177,22 @@ export const IntercomCard: React.FC<
               {companySupportDescription}
             </div>
             <NotifiIntercomFTUNotificationTargetSection
-              checked={checked}
-              setChecked={setChecked}
+              hasChatAlert={hasChatAlert}
               data={data}
               inputs={inputs}
               inputLabels={inputLabels}
               inputSeparators={inputSeparators}
             />
+            <label
+              className={clsx(
+                'NotifiEmailInput__errorMessage',
+                classNames?.errorMessage,
+              )}
+            >
+              {chatAlertErrorMessage}
+            </label>
             <NotifiStartChatButton
+              hasChatAlert={hasChatAlert}
               onClick={handleStartChatClick}
               disabled={disabled}
               classNames={classNames?.NotifiStartChatButton}

--- a/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
@@ -67,6 +67,7 @@ export const IntercomCard: React.FC<
     phoneNumber,
     smsErrorMessage,
     telegramId,
+    telegramErrorMessage,
   } = useNotifiSubscriptionContext();
 
   const alertName = 'NOTIFI_CHAT_MESSAGES';
@@ -79,7 +80,10 @@ export const IntercomCard: React.FC<
     setHasChatAlert(hasAlert);
   }, [loading, alerts]);
 
-  const hasErrors = emailErrorMessage !== '' || smsErrorMessage !== '';
+  const hasErrors =
+    emailErrorMessage !== '' ||
+    smsErrorMessage !== '' ||
+    telegramErrorMessage !== '';
   const disabled =
     (email === '' && phoneNumber === '' && telegramId === '') || hasErrors;
 

--- a/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
@@ -103,6 +103,9 @@ export const IntercomCard: React.FC<
       setIntercomCardView({ state: 'chatWindowView' });
     } catch (e) {
       setChatAlertErrorMessage('Error to subscribe, please try again');
+      setTimeout(() => {
+        setChatAlertErrorMessage('');
+      }, 5000);
     }
   };
 

--- a/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
@@ -103,6 +103,7 @@ export const IntercomCard: React.FC<
       setIntercomCardView({ state: 'chatWindowView' });
     } catch (e) {
       setChatAlertErrorMessage('Error to subscribe, please try again');
+      //TODO: use useErrorHandler hook instead of setTimeout to handle error messages
       setTimeout(() => {
         setChatAlertErrorMessage('');
       }, 5000);

--- a/packages/notifi-react-card/lib/components/intercom/NotifiIntercomCard.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/NotifiIntercomCard.tsx
@@ -26,6 +26,7 @@ export type NotifiIntercomCardProps = Readonly<{
     NotifiStartChatButton?: NotifiStartChatButtonProps['classNames'];
     NotifiIntercomChatWindowContainer?: NotifiIntercomChatWindowContainerProps['classNames'];
     NotifiIntercomSettingHeader: SettingHeaderProps['classNames'];
+    errorMessage: string;
   }>;
   companySupportTitle?: string;
   companySupportSubtitle?: string;

--- a/packages/notifi-react-card/lib/components/intercom/NotifiIntercomFTUNotificationTargetSection.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/NotifiIntercomFTUNotificationTargetSection.tsx
@@ -12,7 +12,7 @@ import {
   NotifiInputLabels,
   NotifiInputSeparators,
 } from '../subscription/NotifiSubscriptionCard';
-import { NotifiToggle, NotifiToggleProps } from '../subscription/NotifiToggle';
+import { NotifiToggleProps } from '../subscription/NotifiToggle';
 
 export type NotifiIntercomFTUNotificationTargetSectionProps = Readonly<{
   classNames?: Readonly<{
@@ -27,25 +27,18 @@ export type NotifiIntercomFTUNotificationTargetSectionProps = Readonly<{
   inputs: Record<string, string | undefined>;
   inputLabels?: NotifiInputLabels;
   inputSeparators?: NotifiInputSeparators;
-  checked: boolean;
-  setChecked: React.Dispatch<React.SetStateAction<boolean>>;
+  hasChatAlert: boolean;
 }>;
 
 export const NotifiIntercomFTUNotificationTargetSection: React.FC<
   NotifiIntercomFTUNotificationTargetSectionProps
-> = ({
-  data,
-  inputSeparators,
-  classNames,
-  inputLabels,
-  checked,
-  setChecked,
-}) => {
+> = ({ data, inputSeparators, classNames, inputLabels, hasChatAlert }) => {
   const allowedCountryCodes = [...data.contactInfo.sms.supportedCountryCodes];
 
   return (
     <div className={'NotifiSupportNotificationOption__container'}>
       <NotifiEmailInput
+        hasChatAlert={hasChatAlert}
         disabled={false}
         classNames={classNames?.NotifiEmailInput}
         copy={{ label: inputLabels?.email }}
@@ -105,6 +98,7 @@ export const NotifiIntercomFTUNotificationTargetSection: React.FC<
         </div>
       ) : null}
       <NotifiTelegramInput
+        hasChatAlert={hasChatAlert}
         disabled={false}
         classNames={classNames?.NotifiTelegramInput}
         copy={{ label: inputLabels?.telegram }}
@@ -114,39 +108,6 @@ export const NotifiIntercomFTUNotificationTargetSection: React.FC<
         intercomTelegramInputStyle={'NotifiIntercomTelegramInput__input'}
         intercomView={true}
       />
-      {inputSeparators?.telegramSeparator?.content ? (
-        <div
-          className={clsx(
-            'NotifiInputSeparator__container',
-            'NotifiIntercomInputSeparator__container',
-            inputSeparators?.smsSeparator?.classNames?.container,
-          )}
-        >
-          <div
-            className={clsx(
-              'NotifiInputSeparator__content',
-              inputSeparators.telegramSeparator.classNames?.content,
-            )}
-          >
-            {inputSeparators?.telegramSeparator?.content}
-          </div>
-        </div>
-      ) : null}
-      <div
-        className={clsx('BrowserAlertToggle__container', classNames?.container)}
-      >
-        <div className={clsx('BrowserAlertToggle__label', classNames?.label)}>
-          Opt in to browser alerts
-        </div>
-
-        <NotifiToggle
-          classNames={classNames?.toggle}
-          disabled={false}
-          checked={checked}
-          setChecked={setChecked}
-          intercomToggleStyle={'NotifiIntercomToggle__input'}
-        />
-      </div>
     </div>
   );
 };

--- a/packages/notifi-react-card/lib/components/intercom/NotifiStartChatButton.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/NotifiStartChatButton.tsx
@@ -1,8 +1,6 @@
 import clsx from 'clsx';
 import React from 'react';
 
-import { useNotifiSubscriptionContext } from '../../context';
-
 export type NotifiStartChatButtonProps = Readonly<{
   classNames?: Readonly<{
     button?: string;
@@ -10,14 +8,15 @@ export type NotifiStartChatButtonProps = Readonly<{
   }>;
   disabled: boolean;
   onClick: () => void;
+  hasChatAlert: boolean;
 }>;
 
 export const NotifiStartChatButton: React.FC<NotifiStartChatButtonProps> = ({
   classNames,
   disabled,
   onClick,
+  hasChatAlert,
 }) => {
-  const { intercomCardView } = useNotifiSubscriptionContext();
   return (
     <button
       disabled={disabled}
@@ -25,9 +24,7 @@ export const NotifiStartChatButton: React.FC<NotifiStartChatButtonProps> = ({
       onClick={onClick}
     >
       <span className={clsx('NotifiStartChatButton__label', classNames?.label)}>
-        {intercomCardView.state === 'settingView'
-          ? 'Save Changes'
-          : 'Start Chatting'}
+        {hasChatAlert ? 'Save Changes' : 'Start Chatting'}
       </span>
     </button>
   );

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
@@ -21,7 +21,9 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
   data,
 }) => {
   const eventTypes = data.eventTypes;
-  const { isInitialized, subscribe, updateTargetGroups } = useNotifiSubscribe();
+  const { isInitialized, subscribe, updateTargetGroups } = useNotifiSubscribe({
+    targetGroupName: 'Default',
+  });
 
   const { client } = useNotifiClientContext();
 

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCardContainer.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCardContainer.tsx
@@ -20,7 +20,7 @@ export const NotifiSubscriptionCardContainer: React.FC<
   inputSeparators,
   children,
 }: React.PropsWithChildren<NotifiSubscriptionCardProps>) => {
-  const { isInitialized } = useNotifiSubscribe();
+  const { isInitialized } = useNotifiSubscribe({ targetGroupName: 'Default' });
   const { loading } = useNotifiSubscriptionContext();
   const inputDisabled = loading || !isInitialized;
 

--- a/packages/notifi-react-card/lib/components/subscription/defaults.css
+++ b/packages/notifi-react-card/lib/components/subscription/defaults.css
@@ -582,6 +582,11 @@
   margin-top: 10px;
 }
 
+.NotifiIntercomTelegramInput__container
+{
+ margin-bottom: 10px;
+}
+
 .NotifiIntercomEmailInput__container:focus-within,
 .NotifiIntercomSmsInput__container:focus-within,
 .NotifiIntercomTelegramInput__container:focus-within {
@@ -785,6 +790,7 @@
 
 .NotifiEmailVerification__button,
 .NotifiTelegramVerification__button {
+  cursor: pointer;
   font-size: 13px;
   font-weight: 800;
   line-height: 16px;

--- a/packages/notifi-react-card/lib/components/subscription/defaults.css
+++ b/packages/notifi-react-card/lib/components/subscription/defaults.css
@@ -203,7 +203,8 @@
   box-shadow: inset 0px 0px 0px 3px var(--notifi-focus-color);
 }
 .NotifiEmailInput__errorMessage,
-.NotifiSmsInput__errorMessage {
+.NotifiSmsInput__errorMessage,
+.NotifiTelegramInput__errorMessage {
   color: var(--notifi-alert-color);
   font-size: 14px;
   margin-bottom: 0px !important;

--- a/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
@@ -27,9 +27,11 @@ export type NotifiSubscriptionData = Readonly<{
   setPhoneNumber: (phoneNumber: string) => void;
   setTelegramId: (telegramId: string) => void;
   setEmailErrorMessage: (message: string) => void;
+  setTelegramErrorMessage: (message: string) => void;
   setSmsErrorMessage: (message: string) => void;
   emailErrorMessage: string;
   smsErrorMessage: string;
+  telegramErrorMessage: string;
   setTelegramConfirmationUrl: (
     telegramConfirmationUrl: string | undefined,
   ) => void;
@@ -55,6 +57,7 @@ export const NotifiSubscriptionContextProvider: React.FC<
   const { cardView, setCardView } = useFetchedCardState();
   const { intercomCardView, setIntercomCardView } = useIntercomCardState();
   const [emailErrorMessage, setEmailErrorMessage] = useState<string>('');
+  const [telegramErrorMessage, setTelegramErrorMessage] = useState<string>('');
   const [smsErrorMessage, setSmsErrorMessage] = useState<string>('');
   const [emailIdThatNeedsConfirmation, setEmailIdThatNeedsConfirmation] =
     useState<string>('');
@@ -95,6 +98,8 @@ export const NotifiSubscriptionContextProvider: React.FC<
     setUseHardwareWallet,
     intercomCardView,
     setIntercomCardView,
+    telegramErrorMessage,
+    setTelegramErrorMessage,
   };
 
   return (

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -31,7 +31,13 @@ export type InstantSubscribe = Readonly<{
   alertConfiguration: AlertConfiguration | null;
 }>;
 
-export const useNotifiSubscribe: () => Readonly<{
+type useNotifiSubscribeProps = Readonly<{
+  targetGroupName: string;
+}>;
+
+export const useNotifiSubscribe: ({
+  targetGroupName = 'Default',
+}: useNotifiSubscribeProps) => Readonly<{
   isAuthenticated: boolean;
   isInitialized: boolean;
   logIn: () => Promise<SubscriptionData>;
@@ -43,7 +49,7 @@ export const useNotifiSubscribe: () => Readonly<{
   ) => Promise<SubscriptionData>;
   updateTargetGroups: () => Promise<SubscriptionData>;
   resendEmailVerificationLink: () => Promise<string>;
-}> = () => {
+}> = ({ targetGroupName = 'Default' }: useNotifiSubscribeProps) => {
   const { client } = useNotifiClientContext();
 
   const {
@@ -320,7 +326,7 @@ export const useNotifiSubscribe: () => Readonly<{
               name,
               phoneNumber: finalPhoneNumber,
               sourceId: source.id,
-              targetGroupName: 'Default',
+              targetGroupName,
               telegramId: finalTelegramId,
             });
 
@@ -336,7 +342,7 @@ export const useNotifiSubscribe: () => Readonly<{
         // We didn't create or update any alert, manually update the targets
         await client.ensureTargetGroup({
           emailAddress: finalEmail,
-          name: 'Default',
+          name: targetGroupName,
           phoneNumber: finalPhoneNumber,
           telegramId: finalTelegramId,
         });
@@ -362,7 +368,7 @@ export const useNotifiSubscribe: () => Readonly<{
     }
     await client.ensureTargetGroup({
       emailAddress: finalEmail,
-      name: 'Default',
+      name: targetGroupName,
       phoneNumber: finalPhoneNumber,
       telegramId: finalTelegramId,
     });
@@ -481,7 +487,7 @@ export const useNotifiSubscribe: () => Readonly<{
             name: alertName,
             phoneNumber: finalPhoneNumber,
             sourceId: source.id,
-            targetGroupName: 'Default',
+            targetGroupName,
             telegramId: finalTelegramId,
           });
           newResults[alertName] = alert;
@@ -494,7 +500,7 @@ export const useNotifiSubscribe: () => Readonly<{
         // We didn't create or update any alert, manually update the targets
         await client.ensureTargetGroup({
           emailAddress: finalEmail,
-          name: 'Default',
+          name: targetGroupName,
           phoneNumber: finalPhoneNumber,
           telegramId: finalTelegramId,
         });

--- a/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
+++ b/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
@@ -15,6 +15,16 @@ export type AlertConfiguration = Readonly<{
   filterOptions: FilterOptions | null;
 }>;
 
+export const chatConfiguration = (): AlertConfiguration => {
+  return {
+    filterType: 'NOTIFI_CHAT_MESSAGES',
+    filterOptions: {
+      alertFrequency: 'THREE_MINUTES',
+    },
+    sourceType: 'NOTIFI_CHAT',
+  };
+};
+
 export const broadcastMessageConfiguration = ({
   topicName,
 }: Readonly<{


### PR DESCRIPTION
Enable subscribe to chat alerts when user inputs their information

Test:
initial subscribe(when user use intercom chat for the first time):
![Untitled](https://user-images.githubusercontent.com/26240001/203154167-510f1c1f-ea67-4b4d-82fe-25545e428cff.gif)

if the user has subscribed the chat alert and come back to use intercom:
![Untitled1](https://user-images.githubusercontent.com/26240001/203154266-3d8a11b8-3ebf-43ff-bdc3-3176f69aae27.gif)

show error message when subscribe is failed:
![Screen Shot 2022-11-21 at 11 55 56 AM](https://user-images.githubusercontent.com/26240001/203154376-74868f00-7c25-49a3-ac32-065f68ad18be.png)

Story:
https://notifi.atlassian.net/browse/MVP-1583
