### PR TITLE
[MVP-1649] implement polling for intercom chat

### DIFF
--- a/packages/notifi-react-card/lib/components/NotifiEmailInput.tsx
+++ b/packages/notifi-react-card/lib/components/NotifiEmailInput.tsx
@@ -32,7 +32,6 @@ export const NotifiEmailInput: React.FC<NotifiEmailInputProps> = ({
   intercomEmailInputStyle,
   intercomEmailInputContainerStyle,
   intercomView,
-  hasChatAlert = false,
 }: NotifiEmailInputProps) => {
   const {
     email,
@@ -40,6 +39,7 @@ export const NotifiEmailInput: React.FC<NotifiEmailInputProps> = ({
     setEmailErrorMessage,
     emailErrorMessage,
     emailIdThatNeedsConfirmation,
+    intercomCardView,
   } = useNotifiSubscriptionContext();
 
   const { resendEmailVerificationLink } = useNotifiSubscribe({
@@ -68,7 +68,9 @@ export const NotifiEmailInput: React.FC<NotifiEmailInputProps> = ({
   return (
     <>
       {intercomView ? (
-        email && hasChatAlert && emailIdThatNeedsConfirmation != '' ? (
+        email &&
+        intercomCardView.state === 'settingView' &&
+        emailIdThatNeedsConfirmation != '' ? (
           <div
             onClick={handleClick}
             className={clsx(

--- a/packages/notifi-react-card/lib/components/NotifiEmailInput.tsx
+++ b/packages/notifi-react-card/lib/components/NotifiEmailInput.tsx
@@ -68,7 +68,6 @@ export const NotifiEmailInput: React.FC<NotifiEmailInputProps> = ({
   return (
     <>
       {intercomView ? (
-        email &&
         intercomCardView.state === 'settingView' &&
         emailIdThatNeedsConfirmation != '' ? (
           <div

--- a/packages/notifi-react-card/lib/components/NotifiTelegramInput.tsx
+++ b/packages/notifi-react-card/lib/components/NotifiTelegramInput.tsx
@@ -63,7 +63,6 @@ export const NotifiTelegramInput: React.FC<NotifiTelegramInputProps> = ({
   return (
     <>
       {intercomView ? (
-        telegramId &&
         intercomCardView.state === 'settingView' &&
         telegramConfirmationUrl != null ? (
           <div

--- a/packages/notifi-react-card/lib/components/NotifiTelegramInput.tsx
+++ b/packages/notifi-react-card/lib/components/NotifiTelegramInput.tsx
@@ -31,7 +31,6 @@ export const NotifiTelegramInput: React.FC<NotifiTelegramInputProps> = ({
   intercomTelegramInputStyle,
   intercomTelegramInputContainerStyle,
   intercomView,
-  hasChatAlert = false,
 }: NotifiTelegramInputProps) => {
   const {
     telegramId,
@@ -39,6 +38,7 @@ export const NotifiTelegramInput: React.FC<NotifiTelegramInputProps> = ({
     telegramConfirmationUrl,
     setTelegramErrorMessage,
     telegramErrorMessage,
+    intercomCardView,
   } = useNotifiSubscriptionContext();
 
   const validateTelegram = () => {
@@ -63,7 +63,9 @@ export const NotifiTelegramInput: React.FC<NotifiTelegramInputProps> = ({
   return (
     <>
       {intercomView ? (
-        hasChatAlert && telegramId && telegramConfirmationUrl != null ? (
+        telegramId &&
+        intercomCardView.state === 'settingView' &&
+        telegramConfirmationUrl != null ? (
           <div
             onClick={handleClick}
             className={clsx(

--- a/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import { useNotifiClientContext } from 'notifi-react-card/lib/context';
 import React, { useEffect, useState } from 'react';
 
 import { useNotifiSubscriptionContext } from '../../context/NotifiSubscriptionContext';
@@ -51,7 +52,6 @@ export const IntercomCard: React.FC<
   inputSeparators,
   data,
 }: React.PropsWithChildren<IntercomCardProps>) => {
-  const [hasChatAlert, setHasChatAlert] = useState<boolean>(false);
   const [chatAlertErrorMessage, setChatAlertErrorMessage] =
     useState<string>('');
   const { instantSubscribe } = useNotifiSubscribe({
@@ -68,17 +68,22 @@ export const IntercomCard: React.FC<
     smsErrorMessage,
     telegramId,
     telegramErrorMessage,
+    setHasChatAlert,
   } = useNotifiSubscriptionContext();
 
-  const alertName = 'NOTIFI_CHAT_MESSAGES';
+  const { client } = useNotifiClientContext();
 
+  const alertName = 'NOTIFI_CHAT_MESSAGES';
   useEffect(() => {
-    if (loading) {
+    if (loading || !client.isInitialized) {
       return;
     }
     const hasAlert = alerts[alertName] !== undefined;
     setHasChatAlert(hasAlert);
-  }, [loading, alerts]);
+    setIntercomCardView({
+      state: hasAlert ? 'chatWindowView' : 'startChatView',
+    });
+  }, [alerts, loading]);
 
   const hasErrors =
     emailErrorMessage !== '' ||
@@ -152,7 +157,6 @@ export const IntercomCard: React.FC<
             {companySupportDescription}
           </div>
           <NotifiIntercomFTUNotificationTargetSection
-            hasChatAlert={hasChatAlert}
             data={data}
             inputs={inputs}
             inputLabels={inputLabels}
@@ -167,7 +171,6 @@ export const IntercomCard: React.FC<
             {chatAlertErrorMessage}
           </label>
           <NotifiStartChatButton
-            hasChatAlert={hasChatAlert}
             onClick={handleStartChatClick}
             disabled={disabled}
             classNames={classNames?.NotifiStartChatButton}
@@ -199,7 +202,6 @@ export const IntercomCard: React.FC<
               {companySupportDescription}
             </div>
             <NotifiIntercomFTUNotificationTargetSection
-              hasChatAlert={hasChatAlert}
               data={data}
               inputs={inputs}
               inputLabels={inputLabels}
@@ -214,7 +216,6 @@ export const IntercomCard: React.FC<
               {chatAlertErrorMessage}
             </label>
             <NotifiStartChatButton
-              hasChatAlert={hasChatAlert}
               onClick={handleStartChatClick}
               disabled={disabled}
               classNames={classNames?.NotifiStartChatButton}
@@ -222,6 +223,9 @@ export const IntercomCard: React.FC<
           </div>
         </>
       );
+      break;
+    case 'loadingView':
+      view = null;
       break;
   }
   return <>{view}</>;

--- a/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
@@ -75,7 +75,11 @@ export const IntercomCard: React.FC<
 
   const alertName = 'NOTIFI_CHAT_MESSAGES';
   useEffect(() => {
-    if (loading || !client.isInitialized) {
+    if (
+      loading ||
+      !client.isInitialized ||
+      intercomCardView.state === 'settingView'
+    ) {
       return;
     }
     const hasAlert = alerts[alertName] !== undefined;

--- a/packages/notifi-react-card/lib/components/intercom/NotifiIntercomFTUNotificationTargetSection.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/NotifiIntercomFTUNotificationTargetSection.tsx
@@ -27,19 +27,17 @@ export type NotifiIntercomFTUNotificationTargetSectionProps = Readonly<{
   inputs: Record<string, string | undefined>;
   inputLabels?: NotifiInputLabels;
   inputSeparators?: NotifiInputSeparators;
-  hasChatAlert: boolean;
 }>;
 
 export const NotifiIntercomFTUNotificationTargetSection: React.FC<
   NotifiIntercomFTUNotificationTargetSectionProps
-> = ({ data, inputSeparators, classNames, inputLabels, hasChatAlert }) => {
+> = ({ data, inputSeparators, classNames, inputLabels }) => {
   const allowedCountryCodes = [...data.contactInfo.sms.supportedCountryCodes];
 
   return (
     <div className={'NotifiSupportNotificationOption__container'}>
       {data.contactInfo.email.active ? (
         <NotifiEmailInput
-          hasChatAlert={hasChatAlert}
           disabled={false}
           classNames={classNames?.NotifiEmailInput}
           copy={{ label: inputLabels?.email }}
@@ -105,7 +103,6 @@ export const NotifiIntercomFTUNotificationTargetSection: React.FC<
       ) : null}
       {data.contactInfo.telegram.active ? (
         <NotifiTelegramInput
-          hasChatAlert={hasChatAlert}
           disabled={false}
           classNames={classNames?.NotifiTelegramInput}
           copy={{ label: inputLabels?.telegram }}

--- a/packages/notifi-react-card/lib/components/intercom/NotifiStartChatButton.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/NotifiStartChatButton.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import { useNotifiSubscriptionContext } from 'notifi-react-card/lib/context';
 import React from 'react';
 
 export type NotifiStartChatButtonProps = Readonly<{
@@ -8,15 +9,14 @@ export type NotifiStartChatButtonProps = Readonly<{
   }>;
   disabled: boolean;
   onClick: () => void;
-  hasChatAlert: boolean;
 }>;
 
 export const NotifiStartChatButton: React.FC<NotifiStartChatButtonProps> = ({
   classNames,
   disabled,
   onClick,
-  hasChatAlert,
 }) => {
+  const { intercomCardView } = useNotifiSubscriptionContext();
   return (
     <button
       disabled={disabled}
@@ -24,7 +24,9 @@ export const NotifiStartChatButton: React.FC<NotifiStartChatButtonProps> = ({
       onClick={onClick}
     >
       <span className={clsx('NotifiStartChatButton__label', classNames?.label)}>
-        {hasChatAlert ? 'Save Changes' : 'Start Chatting'}
+        {intercomCardView.state === 'settingView'
+          ? 'Save Changes'
+          : 'Start Chatting'}
       </span>
     </button>
   );

--- a/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
@@ -42,6 +42,8 @@ export type NotifiSubscriptionData = Readonly<{
   setIsSmsConfirmed: (isConfirmed: boolean | null) => void;
   emailIdThatNeedsConfirmation: string;
   setEmailIdThatNeedsConfirmation: (emailId: string) => void;
+  hasChatAlert: boolean;
+  setHasChatAlert: (hasChatAlert: boolean) => void;
 }>;
 
 const NotifiSubscriptionContext = createContext<NotifiSubscriptionData>(
@@ -53,6 +55,7 @@ export const NotifiSubscriptionContextProvider: React.FC<
 > = ({ children, ...params }) => {
   const [email, setEmail] = useState<string>('');
   const [phoneNumber, setPhoneNumber] = useState<string>('');
+  const [hasChatAlert, setHasChatAlert] = useState<boolean>(false);
   const [telegramId, setTelegramId] = useState<string>('');
   const { cardView, setCardView } = useFetchedCardState();
   const { intercomCardView, setIntercomCardView } = useIntercomCardState();
@@ -100,6 +103,8 @@ export const NotifiSubscriptionContextProvider: React.FC<
     setIntercomCardView,
     telegramErrorMessage,
     setTelegramErrorMessage,
+    hasChatAlert,
+    setHasChatAlert,
   };
 
   return (

--- a/packages/notifi-react-card/lib/hooks/useIntercomCardState.ts
+++ b/packages/notifi-react-card/lib/hooks/useIntercomCardState.ts
@@ -12,11 +12,19 @@ export type settingView = Readonly<{
   state: 'settingView';
 }>;
 
-export type IntercomCardView = startChatView | chatWindowView | settingView;
+export type loadingView = Readonly<{
+  state: 'loadingView';
+}>;
+
+export type IntercomCardView =
+  | startChatView
+  | chatWindowView
+  | settingView
+  | loadingView;
 
 export const useIntercomCardState = () => {
   const [intercomCardView, setIntercomCardView] = useState<IntercomCardView>({
-    state: 'startChatView',
+    state: 'loadingView',
   });
 
   return {

--- a/packages/notifi-react-card/lib/hooks/useIntercomChat.ts
+++ b/packages/notifi-react-card/lib/hooks/useIntercomChat.ts
@@ -65,19 +65,17 @@ export const useIntercomChat = ({
         .then((response) => {
           if (Array.isArray(response.nodes)) {
             const nodes = response.nodes;
-            if (nodes[0].id === chatMessages[0].id) {
-              return;
-            } else {
-              const chatMessageIds = chatMessages.map((message) => message.id);
-              const dedupeNewMessages = nodes.filter(
-                (node) => !chatMessageIds.includes(node.id),
-              );
-              const dedupeMessages = [...dedupeNewMessages, ...chatMessages];
-              const sortedMessages = dedupeMessages.sort(
-                sortByDate((message) => new Date(message.createdDate), 'DESC'),
-              );
-              setChatMessages([...sortedMessages]);
-            }
+            const chatMessageIds = new Set(
+              chatMessages.map((message) => message.id),
+            );
+            const dedupeNewMessages = nodes.filter(
+              (node) => chatMessageIds.has(node.id) === false,
+            );
+            const dedupeMessages = [...dedupeNewMessages, ...chatMessages];
+            const sortedMessages = dedupeMessages.sort(
+              sortByDate((message) => new Date(message.createdDate), 'DESC'),
+            );
+            setChatMessages([...sortedMessages]);
           }
         });
     }, 5000);

--- a/packages/notifi-react-card/lib/hooks/useIntercomChat.ts
+++ b/packages/notifi-react-card/lib/hooks/useIntercomChat.ts
@@ -52,6 +52,32 @@ export const useIntercomChat = ({
   const [isScrolling, setIsScrolling] = useState<boolean | null>();
   const { client } = useNotifiClientContext();
 
+  useEffect(() => {
+    const intervalId = setInterval(function () {
+      client
+        .getConversationMessages({
+          first: MESSAGES_NUMBER,
+          getConversationMessagesInput: { conversationId },
+        })
+        .then((response) => {
+          if (Array.isArray(response.nodes)) {
+            const nodes = response.nodes;
+            if (nodes[0].id === chatMessages[0].id) {
+              return;
+            } else {
+              nodes.forEach((node, index) => {
+                if (node.id === chatMessages[0].id) {
+                  const newMessages = nodes.slice(0, index);
+                  setChatMessages([...newMessages, ...chatMessages]);
+                }
+              });
+            }
+          }
+        });
+    }, 5000);
+    return () => clearInterval(intervalId);
+  }, [chatMessages]);
+
   const getConversationMessages = useCallback(
     (first = MESSAGES_NUMBER) => {
       setIsLoading(true);

--- a/packages/notifi-react-card/lib/utils/datetimeUtils.ts
+++ b/packages/notifi-react-card/lib/utils/datetimeUtils.ts
@@ -1,5 +1,22 @@
 import { format, parseISO } from 'date-fns';
 
+export const sortByDate = <T>(
+  getDate: (item: T) => Date,
+  direction: 'ASC' | 'DESC',
+): ((a: T, b: T) => number) => {
+  return (a, b) => {
+    const aDate = getDate(a);
+    const bDate = getDate(b);
+
+    switch (direction) {
+      case 'ASC':
+        return aDate.getTime() - bDate.getTime();
+      case 'DESC':
+        return bDate.getTime() - aDate.getTime();
+    }
+  };
+};
+
 export const formatConversationDateTimestamp = (date: string): string => {
   try {
     const parsedDate = parseISO(date);


### PR DESCRIPTION
implement polling for intercom chat
update intercom chat flow, when users come back to use intercom, bring them directly to the chat view instead of to the start chat view.

Test:
![Untitled1](https://user-images.githubusercontent.com/26240001/203394916-6ca20d2f-a539-4217-bb77-9b36bbacef2c.gif)

Story:
https://notifi.atlassian.net/browse/MVP-1649
