### PR TITLE
[MVP-1635] update the font family in textarea to match other component

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/defaults.css
+++ b/packages/notifi-react-card/lib/components/subscription/defaults.css
@@ -685,7 +685,7 @@
 }
 
 .NotifiIntercomSendMessageSection__textarea {
-  font-family: Rota;
+  font-family: inherit;
   font-size: 16px;
   height: 110px;
   border-bottom: 1px solid #E8EBF5;


### PR DESCRIPTION
update the font family in textarea to match other component

Test:
before:
<img width="387" alt="Screen Shot 2022-11-25 at 11 03 32 AM" src="https://user-images.githubusercontent.com/26240001/204042815-a39d55ba-f096-44bd-8688-98128c66655b.png">


after:
<img width="454" alt="Screen Shot 2022-11-25 at 10 53 39 AM" src="https://user-images.githubusercontent.com/26240001/204042640-c2698655-7e63-470b-bcc9-d635f0ca871c.png">
<img width="416" alt="Screen Shot 2022-11-25 at 10 54 02 AM" src="https://user-images.githubusercontent.com/26240001/204042646-d0eb0a96-b5b3-4cd8-bacf-78504206d293.png">

Story:
https://notifi.atlassian.net/browse/MVP-1635
