### PR TITLE
brings react card into react example repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31500,7 +31500,6 @@
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@manahippo/aptos-wallet-adapter": "^1.0.2",
-        "@notifi-network/notifi-react-hooks": "^0.42.1",
         "@solana/wallet-adapter-base": "^0.9.18",
         "@solana/wallet-adapter-react": "^0.15.24",
         "@solana/wallet-adapter-react-ui": "^0.9.22",
@@ -36477,7 +36476,6 @@
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "@manahippo/aptos-wallet-adapter": "^1.0.2",
-        "@notifi-network/notifi-react-hooks": "^0.42.1",
         "@solana/wallet-adapter-base": "^0.9.18",
         "@solana/wallet-adapter-react": "^0.15.24",
         "@solana/wallet-adapter-react-ui": "^0.9.22",

--- a/packages/notifi-react-example/package.json
+++ b/packages/notifi-react-example/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@ethersproject/bytes": "^5.7.0",
     "@manahippo/aptos-wallet-adapter": "^1.0.2",
-    "@notifi-network/notifi-react-hooks": "^0.42.1",
     "@solana/wallet-adapter-base": "^0.9.18",
     "@solana/wallet-adapter-react": "^0.15.24",
     "@solana/wallet-adapter-react-ui": "^0.9.22",

--- a/packages/notifi-react-example/src/App.css
+++ b/packages/notifi-react-example/src/App.css
@@ -13,7 +13,6 @@ nav {
 }
 
 .container {
-  height: calc(100vh - 110px);
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/packages/notifi-react-example/src/App.tsx
+++ b/packages/notifi-react-example/src/App.tsx
@@ -1,84 +1,12 @@
-import { arrayify } from '@ethersproject/bytes';
-import {
-  SignMessageParams,
-  useNotifiClient,
-} from '@notifi-network/notifi-react-hooks';
-import { useWallet } from '@solana/wallet-adapter-react';
-import {
-  WalletDisconnectButton,
-  WalletMultiButton,
-} from '@solana/wallet-adapter-react-ui';
-import { useEffect } from 'react';
+import React from 'react';
 
 import './App.css';
+import { NotifiCard } from './NotifiCard/NotifiCard';
 
 function App() {
-  const { publicKey, signMessage, connected } = useWallet();
-  const DAPP_ADDRESS = 'junitest.xyz';
-
-  const notifiClient = useNotifiClient({
-    dappAddress: DAPP_ADDRESS,
-    walletBlockchain: 'SOLANA',
-    env: 'Development',
-    walletPublicKey: publicKey?.toBase58() ?? '',
-  });
-
-  const { logIn, logOut, isAuthenticated } = notifiClient;
-
-  const handleLogin = async () => {
-    if (!publicKey) {
-      throw new Error('no public key');
-    }
-    if (!signMessage) {
-      throw new Error('no sign message');
-    }
-    const signer: SignMessageParams = {
-      walletBlockchain: 'SOLANA',
-      signMessage: async (buffer: Uint8Array) => {
-        const result = await signMessage(buffer);
-        return arrayify(result);
-      },
-    };
-
-    await logIn(signer);
-  };
-
-  useEffect(() => {
-    if (!connected) {
-      logOut();
-    }
-  }, [connected, logOut]);
-
   return (
-    <div className="app">
-      <nav className="nav">
-        {connected ? <WalletDisconnectButton /> : <WalletMultiButton />}
-      </nav>
-
-      <div className="container">
-        {connected ? (
-          <>
-            {!isAuthenticated ? (
-              <button
-                className="button"
-                disabled={isAuthenticated}
-                onClick={handleLogin}
-              >
-                Log In
-              </button>
-            ) : (
-              <>
-                <button className="button" onClick={logOut}>
-                  Log out
-                </button>
-                <h2>Message signed!</h2>
-              </>
-            )}
-          </>
-        ) : (
-          <h1>Connect a wallet to get started</h1>
-        )}
-      </div>
+    <div className="App">
+      <NotifiCard />
     </div>
   );
 }

--- a/packages/notifi-react-example/src/NotifiCard/NotifiCard.css
+++ b/packages/notifi-react-example/src/NotifiCard/NotifiCard.css
@@ -1,0 +1,4 @@
+.container {
+  width: 400px;
+  position: relative;
+}

--- a/packages/notifi-react-example/src/NotifiCard/NotifiCard.tsx
+++ b/packages/notifi-react-example/src/NotifiCard/NotifiCard.tsx
@@ -1,0 +1,61 @@
+import {
+  NotifiContext,
+  NotifiInputSeparators,
+  NotifiSubscriptionCard,
+} from '@notifi-network/notifi-react-card';
+import '@notifi-network/notifi-react-card/dist/index.css';
+import { useConnection, useWallet } from '@solana/wallet-adapter-react';
+import React from 'react';
+
+import './NotifiCard.css';
+
+export const NotifiCard: React.FC = () => {
+  const { connection } = useConnection();
+  const { wallet, sendTransaction, signMessage } = useWallet();
+  const adapter = wallet?.adapter;
+  const publicKey = adapter?.publicKey?.toBase58() ?? null;
+
+  if (publicKey === null || signMessage === undefined) {
+    // publicKey is required
+    return null;
+  }
+
+  const inputLabels = {
+    email: 'Email',
+    sms: 'Text Message',
+    telegram: 'Telegram',
+  };
+
+  const inputSeparators: NotifiInputSeparators = {
+    smsSeparator: {
+      content: 'OR',
+    },
+    emailSeparator: {
+      content: 'OR',
+    },
+    telegramSeparator: {
+      content: 'OR',
+    },
+  };
+
+  return (
+    <div className="container">
+      <NotifiContext
+        dappAddress="junitest.xyz"
+        walletBlockchain="SOLANA"
+        env="Development"
+        walletPublicKey={publicKey}
+        connection={connection}
+        sendTransaction={sendTransaction}
+        signMessage={signMessage}
+      >
+        <NotifiSubscriptionCard
+          darkMode
+          inputLabels={inputLabels}
+          inputSeparators={inputSeparators}
+          cardId="71562316475a4171ae9c980adaefab7d"
+        ></NotifiSubscriptionCard>
+      </NotifiContext>
+    </div>
+  );
+};

--- a/packages/notifi-react-example/src/SolanaWalletProvider.tsx
+++ b/packages/notifi-react-example/src/SolanaWalletProvider.tsx
@@ -3,7 +3,11 @@ import {
   ConnectionProvider,
   WalletProvider,
 } from '@solana/wallet-adapter-react';
-import { WalletModalProvider } from '@solana/wallet-adapter-react-ui';
+import {
+  WalletDisconnectButton,
+  WalletModalProvider,
+  WalletMultiButton,
+} from '@solana/wallet-adapter-react-ui';
 import {
   PhantomWalletAdapter,
   SolflareWalletAdapter,
@@ -11,23 +15,42 @@ import {
 import { clusterApiUrl } from '@solana/web3.js';
 import React, { FC, useMemo } from 'react';
 
+import App from './App';
+
+// Default styles that can be overridden by your app
 require('@solana/wallet-adapter-react-ui/styles.css');
 
-export const SolanaWalletProvider: FC = ({ children }) => {
+export const SolanaWalletProvider: FC = () => {
+  // The network can be set to 'devnet', 'testnet', or 'mainnet-beta'.
   const network = WalletAdapterNetwork.Devnet;
 
+  // You can also provide a custom RPC endpoint.
   const endpoint = useMemo(() => clusterApiUrl(network), [network]);
 
   const wallets = useMemo(
-    () => [new SolflareWalletAdapter(), new PhantomWalletAdapter()],
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    () => [
+      /**
+       * Select the wallets you wish to support, by instantiating wallet adapters here.
+       *
+       * Common adapters can be found in the npm package `@solana/wallet-adapter-wallets`.
+       * That package supports tree shaking and lazy loading -- only the wallets you import
+       * will be compiled into your application, and only the dependencies of wallets that
+       * your users connect to will be loaded.
+       */
+      new PhantomWalletAdapter({ network }),
+      new SolflareWalletAdapter({ network }),
+    ],
     [network],
   );
 
   return (
     <ConnectionProvider endpoint={endpoint}>
       <WalletProvider wallets={wallets} autoConnect>
-        <WalletModalProvider>{children}</WalletModalProvider>
+        <WalletModalProvider>
+          <WalletMultiButton />
+          <WalletDisconnectButton />
+          <App />
+        </WalletModalProvider>
       </WalletProvider>
     </ConnectionProvider>
   );


### PR DESCRIPTION
<img width="623" alt="image" src="https://user-images.githubusercontent.com/105258726/204602236-f6272a80-f959-4855-8c39-95cc732e5365.png">

Updates the `react-example` to use the react card for development. We had a lengthier method to build and test; hopefully this should ease some pain in developing on the sdk card.