### PR TITLE
Add Acala, Binance, and Arbitrum to React Card Docs

### DIFF
--- a/packages/notifi-react-card/README.md
+++ b/packages/notifi-react-card/README.md
@@ -12,8 +12,6 @@ We currently support the following blockchains:
 - Aptos
 - Acala
 
-&nbsp;
-
 # Getting Started
 
 Fill out [this form](https://bit.ly/NotifiDappSetup) to receive a developer login.
@@ -44,13 +42,9 @@ Import the following CSS file into your component to get baseline styling:
 import '@notifi-network/notifi-react-card/dist/index.css';
 ```
 
-&nbsp;
-
 ## Design Guidelines
 
 We have design recommendations on how to best present the UI to your dapp users. Check them out here: [Figma](https://www.figma.com/file/ieF0Ynuc3WI608RCt7wKSf/Notifi-Template?node-id=0%3A1&t=v8zeo6UovJAOb9vR-0).
-
-&nbsp;
 
 ## Tutorial Video
 
@@ -148,8 +142,6 @@ export const Remote: React.FC = () => {
 
 </details>
 
-&nbsp;
-
 ### EVM (Ethereum, Polygon, Arbitrum, or Binance)
 
 <details>
@@ -219,8 +211,6 @@ export const Notifi: React.FC = () => {
 ```
 
 </details>
-
-&nbsp;
 
 ### Aptos
 
@@ -293,8 +283,6 @@ export const Notifi: React.FC = () => {
 ```
 
 </details>
-
-&nbsp;
 
 ### Acala
 

--- a/packages/notifi-react-card/README.md
+++ b/packages/notifi-react-card/README.md
@@ -301,10 +301,13 @@ export default function useAcalaWallet() {
     null,
   );
 
-  const getAccounts = useCallback(async () => {
-    const allAccounts = await web3Accounts();
-    const account = allAccounts[0].address;
-    if (account) setAccount(account);
+  useEffect(() => {
+    async function getAccounts() {
+      const allAccounts = await web3Accounts();
+      const account = allAccounts[0].address;
+      if (account) setAccount(account);
+    }
+    getAccounts();
   }, []);
 
   const signMessage = useCallback(async (address: string, message: string) => {

--- a/packages/notifi-react-card/README.md
+++ b/packages/notifi-react-card/README.md
@@ -1,44 +1,93 @@
 # `@notifi-network/notifi-react-card`
 
-> Configurable component for Notifi alerts
+A drop-in component that can get your dapp up and running with alert notifications in minutes.
 
-## Usage
+We currently support the following blockchains:
+
+- Solana
+- Ethereum
+- Polygon
+- Arbitrum
+- Binance
+- Aptos
+- Acala
+
+&nbsp;
+
+# Getting Started
+
+Fill out [this form](https://bit.ly/NotifiDappSetup) to receive a developer login.
+
+With a developer login, you can generate an API key and customize component configurations.
+
+&nbsp;
+
+# Installation
+
+**npm**
 
 ```
 npm install @notifi-network/notifi-react-card
 npm install --save-dev @notifi-network/notifi-core
 ```
 
-You can import the default stylesheet to get baseline styling.
-Be sure to get your DAPP ID here: https://bit.ly/NotifiDappSetup
+**yarn**
 
-## Video
+```
+yarn add @notifi-network/notifi-react-card
+yarn add --dev @notifi-network/notifi-core
+```
 
-Here is a [link](https://www.youtube.com/watch?v=LIKu-clf9bg) covering how to setup the React Card Config.
+Import the following CSS file into your component to get baseline styling:
+
+```
+import '@notifi-network/notifi-react-card/dist/index.css';
+```
+
+&nbsp;
+
+## Design Guidelines
+
+We have design recommendations on how to best present the UI to your dapp users. Check them out here: [Figma](https://www.figma.com/file/ieF0Ynuc3WI608RCt7wKSf/Notifi-Template?node-id=0%3A1&t=v8zeo6UovJAOb9vR-0).
+
+&nbsp;
+
+## Tutorial Video
+
+Here is a [link](https://www.youtube.com/watch?v=LIKu-clf9bg) covering how to setup the React Card config.
 
 The video covers the following:
 
-- Configuring the card
+- Configuring the card in our developer tool
 - Adding Event Types
 - Installing the react package into your project
-- Updating the default values to match your dapp.
+- Updating the default values to match your dapp
 
-
-### Design Guidelines
-
-We have general guidelines that we like to follow. You can see them here: [Figma](https://www.figma.com/file/ieF0Ynuc3WI608RCt7wKSf/Notifi-Template?node-id=0%3A1&t=v8zeo6UovJAOb9vR-0).
-
-###### Example tips
+#### Example tips
 
 - Embed the bell icon by the wallet login section.
   ie. ![here](https://i.imgur.com/f2rnrpk.png)
+
+  &nbsp;
+
 - There should be a state for the bell icon when connected/not connected.
   ie. ![example of not connected state](https://i.imgur.com/V9yEeCj.png)
   ie. If not connected, the bell icon should be hidden.
+
 - Make sure that there is enough contrast between color selections.
+
 - Styling should be consistent with your current UI.
 
+&nbsp;
+
+# Code Examples
+
+Please see below for code examples on the component configuration. Click on the dropdown button to check out the code snippet.
+
 ### Solana
+
+<details>
+<summary>Integrate Card Component</summary>
 
 ```tsx
 import {
@@ -97,9 +146,16 @@ export const Remote: React.FC = () => {
 };
 ```
 
-### Ethereum OR Polygon
+</details>
 
-Note: Polygon also uses ethers, so if using polygon be sure to update the `NotifiContext` params accordingly.
+&nbsp;
+
+### EVM (Ethereum, Polygon, Arbitrum, or Binance)
+
+<details>
+<summary>Integrate Card Component</summary>
+
+Note: All EVM chains use Ethers. If using a supported EVM-chain, be sure to update the `NotifiContext` params accordingly.
 
 ```tsx
 import { arrayify } from '@ethersproject/bytes';
@@ -146,7 +202,10 @@ export const Notifi: React.FC = () => {
       }}
       walletPublicKey={account}
       ßß
-      walletBlockchain="ETHEREUM" // NOTE, if using polygon be sure to use POLYGON
+      walletBlockchain="ETHEREUM" // NOTE - Please update to the correct chain name.
+      //If Polygon, use "POLYGON"
+      //If Arbitrum, use "ARBITRUM"
+      //If Binance, use "BINANCE"
     >
       <NotifiSubscriptionCard
         cardId="<YOUR OWN CARD ID HERE>"
@@ -159,7 +218,14 @@ export const Notifi: React.FC = () => {
 };
 ```
 
+</details>
+
+&nbsp;
+
 ### Aptos
+
+<details>
+<summary>Integrate Card Component</summary>
 
 ```tsx
 import { useWallet } from '@manahippo/aptos-wallet-adapter';
@@ -225,3 +291,132 @@ export const Notifi: React.FC = () => {
   );
 };
 ```
+
+</details>
+
+&nbsp;
+
+### Acala
+
+<details>
+<summary>Integrate Card Component</summary>
+
+Create a hook that gets all of the account data using Polkadot util libraries
+
+```tsx
+import { web3Accounts, web3FromAddress } from '@polkadot/extension-dapp';
+
+export default function useAcalaWallet() {
+  const [account, setAccount] = useState<string | null>(null);
+  const [acalaAddress, setAcalaAddress] = useState<string | null>(null);
+  const [polkadotPublicKey, setPolkadotPublicKey] = useState<string | null>(
+    null,
+  );
+
+  const getAccounts = useCallback(async () => {
+    const allAccounts = await web3Accounts();
+    const account = allAccounts[0].address;
+    if (account) setAccount(account);
+  }, []);
+
+  const signMessage = useCallback(async (address: string, message: string) => {
+    const extension = await web3FromAddress(address);
+    const signRaw = extension?.signer?.signRaw;
+    const signMessage = await signRaw({
+      address,
+      data: message,
+      type: 'bytes',
+    });
+    return signMessage.signature;
+  }, []);
+
+  const getAcalaAddress = (address: string): string => {
+    const publicKey = decodeAddress(address);
+    return encodeAddress(publicKey, 10);
+  };
+
+  const getPolkadotPublicKey = (address: string): string => {
+    const publicKey = decodeAddress(address);
+    const decodedPublicKey = u8aToHex(publicKey);
+    return decodedPublicKey;
+  };
+
+  useEffect(() => {
+    if (account) {
+      const acalaAddress = getAcalaAddress(account);
+      if (acalaAddress) setAcalaAddress(acalaAddress);
+      const polkadotPublicKey = getPolkadotPublicKey(account);
+      if (polkadotPublicKey) setPolkadotPublicKey(polkadotPublicKey);
+    }
+  }, [account]);
+
+  return { account, acalaAddress, polkadotPublicKey, signMessage };
+}
+```
+
+Create a component for the Notifi React Card
+
+```tsx
+import {
+  NotifiContext,
+  NotifiInputSeparators,
+  NotifiSubscriptionCard,
+} from '@notifi-network/notifi-react-card';
+import '@notifi-network/notifi-react-card/dist/index.css';
+import React, { useCallback, useState } from 'react';
+import { useAcalaWallet } from 'path-to-custom-hook';
+
+export const Notifi: React.FC = () => {
+
+  const { acoount, acalaAddress, polkadotPublicKey, signMessage } = useAcalaWallet();
+
+  if (
+    account === null ||
+    acalaAddress === null ||
+    polkadotPublicKey === null
+  ) {
+    // account is required
+    return null;
+  }
+
+  const inputLabels = {
+    email: 'Email',
+    sms: 'Text Message',
+    telegram: 'Telegram',
+  };
+
+  const inputSeparators: NotifiInputSeparators = {
+    smsSeparator: {
+      content: 'OR',
+    },
+    emailSeparator: {
+      content: 'OR',
+    },
+  };
+
+  return (
+    <NotifiContext
+      dappAddress="<YOUR OWN DAPP ADDRESS HERE>"
+      env="Development"
+      walletBlockchain="ACALA"
+      accountAddress={acalaAddress}
+      walletPublicKey={polkadotPublicKey}
+      signMessage={async (accountAddress: string, message: string) => {
+        await signMessage(
+          address: accountAddress;
+          message: message;
+      );
+      }}
+    >
+      <NotifiSubscriptionCard
+        cardId="<YOUR OWN CARD ID HERE>"
+        inputLabels={inputLabels}
+        inputSeparators={inputSeparators}
+        darkMode //optional
+      />
+    </NotifiContext>
+  );
+};
+```
+
+</details>


### PR DESCRIPTION
Preview: https://github.com/notifi-network/notifi-sdk-ts/blob/526da541e5d3c3b57f21f9d7a69b278ee67ce068/packages/notifi-react-card/README.md

- Add Acala code snippet
- Add Binance and Arbitrum as EVM chains
- Add toggle dropdown of code snippets for readability (instead of scrolling to see the chain code snippet that most pertains to you)