### PR TITLE
[MVP-1691] fix chat window header layout

### DIFF
--- a/packages/notifi-react-card/lib/components/intercom/ChatWindowHeader.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/ChatWindowHeader.tsx
@@ -23,18 +23,12 @@ export const ChatWindowHeader: React.FC<ChatWindowHeaderProps> = ({
   };
   return (
     <div
-      className={clsx(
-        'NotifiIntercomHeader__container',
-        classNames?.container,
-      )}
+      className={clsx('NotifiIntercomHeader__container', classNames?.container)}
     >
       <div className={'NotifiIntercomHeader__leftContainer'}>
         <ChatIcon />
         <div
-          className={clsx(
-            'NotifiIntercomHeader__content',
-            classNames?.content,
-          )}
+          className={clsx('NotifiIntercomHeader__content', classNames?.content)}
         >
           {chatWindowHeaderContent}
         </div>

--- a/packages/notifi-react-card/lib/components/intercom/ChatWindowHeader.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/ChatWindowHeader.tsx
@@ -24,15 +24,15 @@ export const ChatWindowHeader: React.FC<ChatWindowHeaderProps> = ({
   return (
     <div
       className={clsx(
-        'NotifiIntercomChatWindowHeader__container',
+        'NotifiIntercomHeader__container',
         classNames?.container,
       )}
     >
-      <div className={'NotifiIntercomChatWindowHeader__leftContainer'}>
+      <div className={'NotifiIntercomHeader__leftContainer'}>
         <ChatIcon />
         <div
           className={clsx(
-            'NotifiIntercomChatWindowHeader__content',
+            'NotifiIntercomHeader__content',
             classNames?.content,
           )}
         >

--- a/packages/notifi-react-card/lib/components/intercom/SendMessageSection.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/SendMessageSection.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 export type SendMessageSectionProps = Readonly<{
   classNames?: Readonly<{
@@ -23,6 +23,17 @@ export const SendMessageSection: React.FC<SendMessageSectionProps> = ({
       setSendMessage('');
     }
   };
+
+  const handleKeypressDown = useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        handleSend();
+        event.preventDefault();
+      }
+    },
+    [handleSend],
+  );
+
   return (
     <div
       className={clsx(
@@ -31,6 +42,7 @@ export const SendMessageSection: React.FC<SendMessageSectionProps> = ({
       )}
     >
       <textarea
+        onKeyDown={handleKeypressDown}
         className={clsx(
           'NotifiIntercomSendMessageSection__textarea',
           classNames?.textarea,

--- a/packages/notifi-react-card/lib/components/intercom/SendMessageSection.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/SendMessageSection.tsx
@@ -24,7 +24,7 @@ export const SendMessageSection: React.FC<SendMessageSectionProps> = ({
     }
   };
 
-  const handleKeypressDown = useCallback(
+  const handleKeypressUp = useCallback(
     (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (event.key === 'Enter' && !event.shiftKey) {
         handleSend();
@@ -42,7 +42,7 @@ export const SendMessageSection: React.FC<SendMessageSectionProps> = ({
       )}
     >
       <textarea
-        onKeyDown={(e) => handleKeypressDown(e)}
+        onKeyUp={(e) => handleKeypressUp(e)}
         className={clsx(
           'NotifiIntercomSendMessageSection__textarea',
           classNames?.textarea,

--- a/packages/notifi-react-card/lib/components/intercom/SendMessageSection.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/SendMessageSection.tsx
@@ -42,7 +42,7 @@ export const SendMessageSection: React.FC<SendMessageSectionProps> = ({
       )}
     >
       <textarea
-        onKeyDown={handleKeypressDown}
+        onKeyDown={(e) => handleKeypressDown(e)}
         className={clsx(
           'NotifiIntercomSendMessageSection__textarea',
           classNames?.textarea,


### PR DESCRIPTION
fix chat window header layout
changed className in chat window header component to match in css

add onKeyDown in textarea, user can send message by hitting enter key.

<img width="441" alt="Screenshot 2022-11-29 at 7 45 32 PM" src="https://user-images.githubusercontent.com/26240001/204705516-834f39bf-e953-403f-a23e-b49186134529.png">
before:


after:
<img width="472" alt="Screenshot 2022-11-29 at 8 01 48 PM" src="https://user-images.githubusercontent.com/26240001/204705465-fc4c2c75-0712-40c2-9684-2a6f8d063ec4.png">