### PR TITLE
[MVP-1697] chat window css polish

### DIFF
--- a/packages/notifi-react-card/lib/components/intercom/ChatMessageDate.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/ChatMessageDate.tsx
@@ -10,6 +10,7 @@ export type ChatMessageDateProps = Readonly<{
   classNames?: Readonly<{
     container: string;
     content: string;
+    body: string;
   }>;
   createdDate: string;
   isStartDate?: boolean;
@@ -29,13 +30,20 @@ export const ChatMessageDate: React.FC<ChatMessageDateProps> = ({
     >
       <div
         className={clsx(
-          'NotifiIntercomChatMessageDate__content',
-          classNames?.content,
+          'NotifiIntercomChatMessageDate__body',
+          classNames?.body,
         )}
       >
-        {isStartDate
-          ? formatConversationStartTimestamp(createdDate)
-          : formatConversationDateTimestamp(createdDate)}
+        <div
+          className={clsx(
+            'NotifiIntercomChatMessageDate__content',
+            classNames?.content,
+          )}
+        >
+          {isStartDate
+            ? formatConversationStartTimestamp(createdDate)
+            : formatConversationDateTimestamp(createdDate)}
+        </div>
       </div>
     </div>
   );

--- a/packages/notifi-react-card/lib/components/subscription/defaults.css
+++ b/packages/notifi-react-card/lib/components/subscription/defaults.css
@@ -635,7 +635,7 @@
 
 .NotifiIntercomHeader__content {
   font-size: 14px;
-  font-weight: 650;
+  font-weight: 600;
   line-height: 17px;
   text-align: left;
   margin-left: 25px;
@@ -661,7 +661,7 @@
 
 .NotifiIntercomChatMessageSectionIntro__content {
   font-size: 16px;
-  font-weight: 650;
+  font-weight: 600;
   line-height: 20px;
   margin-bottom: 12px;
 }
@@ -783,7 +783,7 @@
 
 .NotifiIntercomChatOutgoingMessage__sender {
   font-size: 16px;
-  font-weight: 650;
+  font-weight: 600;
   line-height: 20px;
   text-align: left;
   margin-bottom: 4px;

--- a/packages/notifi-react-card/lib/components/subscription/defaults.css
+++ b/packages/notifi-react-card/lib/components/subscription/defaults.css
@@ -635,7 +635,7 @@
 
 .NotifiIntercomHeader__content {
   font-size: 14px;
-  font-weight: 800;
+  font-weight: 650;
   line-height: 17px;
   text-align: left;
   margin-left: 25px;
@@ -661,12 +661,17 @@
 
 .NotifiIntercomChatMessageSectionIntro__content {
   font-size: 16px;
-  font-weight: 800;
+  font-weight: 650;
   line-height: 20px;
   margin-bottom: 12px;
 }
 
 .NotifiIntercomChatMessageDate__container {
+  display: flex;
+  justify-content: center;
+}
+
+.NotifiIntercomChatMessageDate__body {
   display: inline-block;
   width: 64px;
   padding: 5px;
@@ -736,8 +741,8 @@
 }
 
 .NotifiIntercomChatIncomingMessage__body {
-  padding: 12px 65px 18px 16px;
-  max-width: 230px;
+  padding: 12px 55px 18px 16px;
+  max-width: 288px;
   border-radius: 16px;
   background: #F5F6FB;
   text-align: left;
@@ -751,8 +756,8 @@
 }
 
 .NotifiIntercomChatOutgoingMessage__body {
-  padding: 12px 65px 18px 16px;
-  max-width: 230px;
+  padding: 12px 55px 18px 16px;
+  max-width: 288px;
   border-radius: 16px;
   background: #E6EBFF;
   text-align: left;
@@ -778,7 +783,7 @@
 
 .NotifiIntercomChatOutgoingMessage__sender {
   font-size: 16px;
-  font-weight: 800;
+  font-weight: 650;
   line-height: 20px;
   text-align: left;
   margin-bottom: 4px;


### PR DESCRIPTION
adjust bold dark fonts to match design: intro message and support staff ‘name’ 
Increase width of support staff message bubble
center the date component

Test:
before:
![Screenshot 2022-12-01 at 10 13 27 AM](https://user-images.githubusercontent.com/26240001/205129487-4cee1c48-7c18-4612-88f2-7e0e9dbe80c6.png)
![Screenshot 2022-12-01 at 9 26 39 AM](https://user-images.githubusercontent.com/26240001/205129494-13992ec7-d525-4578-b775-984811511f89.png)


after:
![Untitled](https://user-images.githubusercontent.com/26240001/205129516-547f6b73-ba6b-4c8f-8188-840dd2d8bb27.gif)


Story:
https://notifi.atlassian.net/browse/MVP-1697