### PR TITLE
[MVP-1964] fix setting view layout

### DIFF
--- a/packages/notifi-react-card/lib/components/intercom/ChatMessageSection.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/ChatMessageSection.tsx
@@ -101,7 +101,7 @@ export const ChatMessageSection: React.FC<ChatMessageSectionProps> = ({
           }}
           style={{
             width: messageListWidth || '364px',
-            height: messageListHeight || '290px',
+            height: messageListHeight || '270px',
           }}
         />
       )}

--- a/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
@@ -150,7 +150,7 @@ export const IntercomCard: React.FC<
       setIntercomCardView({ state: 'chatWindowView' });
     } catch (e) {
       //TODO: use useErrorHandler hook instead of setTimeout to handle error messages
-      setChatAlertErrorMessage('Error to subscribe, please try again');
+      setChatAlertErrorMessage('An error occurred, please try again.');
       setTimeout(() => {
         setChatAlertErrorMessage('');
       }, 5000);

--- a/packages/notifi-react-card/lib/components/intercom/NotifiIntercomCard.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/NotifiIntercomCard.tsx
@@ -17,7 +17,9 @@ import { SettingHeaderProps } from './SettingHeader';
 
 export type NotifiIntercomCardProps = Readonly<{
   classNames?: Readonly<{
-    container?: string;
+    chatWindowContainer?: string;
+    startChatContainer?: string;
+    settingViewContainer?: string;
     title?: string;
     subtitle1?: string;
     subtitle2?: string;

--- a/packages/notifi-react-card/lib/components/intercom/NotifiIntercomCard.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/NotifiIntercomCard.tsx
@@ -17,9 +17,7 @@ import { SettingHeaderProps } from './SettingHeader';
 
 export type NotifiIntercomCardProps = Readonly<{
   classNames?: Readonly<{
-    chatWindowContainer?: string;
-    startChatContainer?: string;
-    settingViewContainer?: string;
+    container?: string;
     title?: string;
     subtitle1?: string;
     subtitle2?: string;

--- a/packages/notifi-react-card/lib/components/intercom/NotifiIntercomCardContainer.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/NotifiIntercomCardContainer.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import { useNotifiSubscriptionContext } from 'notifi-react-card/lib/context';
 import React from 'react';
 
 import { useIntercomCard } from '../../hooks/useIntercomCard';
@@ -18,8 +17,6 @@ export const NotifiIntercomCardContainer: React.FC<
   children,
   cardId,
 }: React.PropsWithChildren<NotifiIntercomCardProps>) => {
-  const { intercomCardView } = useNotifiSubscriptionContext();
-
   let contents: React.ReactNode = null;
   const card = useIntercomCard(cardId);
 
@@ -50,31 +47,13 @@ export const NotifiIntercomCardContainer: React.FC<
       break;
   }
 
-  let names: (string | undefined)[] = [];
-  switch (intercomCardView.state) {
-    case 'chatWindowView':
-      names = [
-        'NotifiIntercomCard__chatWindowContainer',
-        classNames?.chatWindowContainer,
-      ];
-      break;
-    case 'startChatView':
-      names = [
-        'NotifiIntercomCard__startChatContainer',
-        classNames?.startChatContainer,
-      ];
-      break;
-    case 'settingView':
-      names = [
-        'NotifiIntercomCard__settingViewContainer',
-        classNames?.settingViewContainer,
-      ];
-      break;
-  }
-
   return (
     <div
-      className={clsx(darkMode ? 'notifi__dark' : 'notifi__light', ...names)}
+      className={clsx(
+        darkMode ? 'notifi__dark' : 'notifi__light',
+        'NotifiIntercomCard__container',
+        classNames?.container,
+      )}
     >
       {children}
       {contents}

--- a/packages/notifi-react-card/lib/components/intercom/NotifiIntercomCardContainer.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/NotifiIntercomCardContainer.tsx
@@ -50,16 +50,31 @@ export const NotifiIntercomCardContainer: React.FC<
       break;
   }
 
+  let names: (string | undefined)[] = [];
+  switch (intercomCardView.state) {
+    case 'chatWindowView':
+      names = [
+        'NotifiIntercomCard__chatWindowContainer',
+        classNames?.chatWindowContainer,
+      ];
+      break;
+    case 'startChatView':
+      names = [
+        'NotifiIntercomCard__startChatContainer',
+        classNames?.startChatContainer,
+      ];
+      break;
+    case 'settingView':
+      names = [
+        'NotifiIntercomCard__settingViewContainer',
+        classNames?.settingViewContainer,
+      ];
+      break;
+  }
+
   return (
     <div
-      className={clsx(
-        darkMode ? 'notifi__dark' : 'notifi__light',
-        intercomCardView.state === 'chatWindowView' ||
-          intercomCardView.state === 'settingView'
-          ? 'NotifiIntercomCard__chatWindowContainer'
-          : 'NotifiIntercomCard__container',
-        classNames?.container,
-      )}
+      className={clsx(darkMode ? 'notifi__dark' : 'notifi__light', ...names)}
     >
       {children}
       {contents}

--- a/packages/notifi-react-card/lib/components/subscription/defaults.css
+++ b/packages/notifi-react-card/lib/components/subscription/defaults.css
@@ -37,9 +37,7 @@
 }
 
 .NotifiSubscriptionCard__container,
-.NotifiIntercomCard__startChatContainer,
-.NotifiIntercomCard__chatWindowContainer,
-.NotifiIntercomCard__settingViewContainer
+.NotifiIntercomCard__Container
 {
   color: var(--notifi-font-color);
   display: flex;
@@ -53,24 +51,12 @@
   margin-bottom: 10px;
 }
 
-.NotifiIntercomCard__startChatContainer {
+.NotifiIntercomCard__container {
   background-color: var(--notifi-intercom-card-background);
   box-shadow: 0px 4px 30px 30px #0000000A;
   width: 364px;
-}
-
-.NotifiIntercomCard__chatWindowContainer {
   padding: 0;
-  background-color: var(--notifi-intercom-card-background);
-  box-shadow: 0px 4px 30px 30px #0000000A;
-  height: 517px;
-  width: 364px;
-}
-
-.NotifiIntercomCard__settingViewContainer {
-  box-shadow: 0px 4px 30px 30px #0000000A;
-  background-color: var(--notifi-intercom-card-background);
-  padding: 0;
+  height: 500px;
 }
 
 .NotifiFooter__container {
@@ -425,6 +411,7 @@
 
 .NotifiIntercomInputSeparator__container
 {
+  margin: 10px 20px 10px 20px;
   color: #80829D;
   opacity: 45%;
 }
@@ -540,8 +527,7 @@
   background-color: #1448F3;
   border-radius: 16px;
   border: 0;
-  margin: 28px;
-  margin-top: 18px;
+  margin: 28px 48px 28px 48px;
   cursor: pointer;
 }
 
@@ -556,6 +542,7 @@
 
 .NotifiIntercomCard__title
 {
+  margin-top: 35px;
   font-size: 22px;
   font-weight: 700;
   line-height: 27px;
@@ -564,6 +551,8 @@
 
 .NotifiIntercomCard__subtitle1
 {
+  margin-left: 20px;
+  margin-right: 20px;
   color: #80829D;
   font-size: 16px;
   font-weight: 700;
@@ -574,6 +563,8 @@
 
 .NotifiIntercomCard__subtitle2
 {
+  margin-left: 20px;
+  margin-right: 20px;
   font-size: 16px;
   font-weight: 800;
   line-height: 19px;
@@ -584,8 +575,7 @@
 
 .NotifiSupportNotificationOption__container
 {
-  margin-left: 28px;
-  margin-right: 28px;
+  margin: 50px 28px 10px 28px;
 }
 
 .NotifiIntercomEmailInput__container,
@@ -594,6 +584,7 @@
 {
   background-color: var(--notifi-intercom-input-background);
   border-radius: 6px;
+  margin: 20px;
   margin-top: 10px;
 }
 
@@ -662,7 +653,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  height: 290px;
+  height: 270px;
   overflow-y:auto;
 }
 
@@ -708,7 +699,7 @@
   resize: none;
   font-family: inherit;
   font-size: 16px;
-  height: 110px;
+  height: 100px;
   border-bottom: 1px solid #E8EBF5;
   border-top: 1px solid #E8EBF5;
   border-right: none;
@@ -728,7 +719,8 @@
   text-align: center;
   border: none;
   color: #ffffff;
-  margin: 20px;
+  margin-left: 20px;
+  margin-top: 15px;
   cursor: pointer;
 }
 
@@ -769,7 +761,7 @@
 
 .NotifiIntercomChatOutgoingMessage__body {
   padding: 12px 55px 18px 16px;
-  max-width: 288px;
+  max-width: 250px;
   border-radius: 16px;
   background: #E6EBFF;
   text-align: left;
@@ -807,11 +799,13 @@
 }
 
 .NotifiIntercomCardSettingContent__container {
-  padding: 10px 15px 0 15px;
+  padding: 20px 0 0 0;
 }
 
 .NotifiEmailVerification__button,
 .NotifiTelegramVerification__button {
+  margin-left: 20px;
+  margin-right: 20px;
   cursor: pointer;
   font-size: 13px;
   font-weight: 800;

--- a/packages/notifi-react-card/lib/components/subscription/defaults.css
+++ b/packages/notifi-react-card/lib/components/subscription/defaults.css
@@ -37,8 +37,9 @@
 }
 
 .NotifiSubscriptionCard__container,
-.NotifiIntercomCard__container,
-.NotifiIntercomCard__chatWindowContainer 
+.NotifiIntercomCard__startChatContainer,
+.NotifiIntercomCard__chatWindowContainer,
+.NotifiIntercomCard__settingViewContainer
 {
   color: var(--notifi-font-color);
   display: flex;
@@ -52,7 +53,7 @@
   margin-bottom: 10px;
 }
 
-.NotifiIntercomCard__container {
+.NotifiIntercomCard__startChatContainer {
   background-color: var(--notifi-intercom-card-background);
   box-shadow: 0px 4px 30px 30px #0000000A;
   width: 364px;
@@ -64,6 +65,12 @@
   box-shadow: 0px 4px 30px 30px #0000000A;
   height: 517px;
   width: 364px;
+}
+
+.NotifiIntercomCard__settingViewContainer {
+  box-shadow: 0px 4px 30px 30px #0000000A;
+  background-color: var(--notifi-intercom-card-background);
+  padding: 0;
 }
 
 .NotifiFooter__container {

--- a/packages/notifi-react-card/lib/components/subscription/defaults.css
+++ b/packages/notifi-react-card/lib/components/subscription/defaults.css
@@ -215,6 +215,7 @@
   color: var(--notifi-alert-color);
   font-size: 14px;
   margin-bottom: 0px !important;
+  text-align: center;
 }
 
 .NotifiEmailInput__input,

--- a/packages/notifi-react-example/src/NotifiCard.tsx
+++ b/packages/notifi-react-example/src/NotifiCard.tsx
@@ -22,13 +22,7 @@ export const NotifiCard: React.FC = () => {
   };
 
   const inputSeparators: NotifiInputSeparators = {
-    smsSeparator: {
-      content: 'OR',
-    },
     emailSeparator: {
-      content: 'OR',
-    },
-    telegramSeparator: {
       content: 'OR',
     },
   };


### PR DESCRIPTION
update:
use same style of container for all three views

instead of removing the sms section in intercom card, we decided to to keep the code for flexibility and prevent tenant to turn on the sms toggle in config tool. But still need to fix the layout on settingView.

update create alert error message ‘Error to subscribe, please try again’ to ‘An error occurred, please try again.’

Test:
update:

![Untitled](https://user-images.githubusercontent.com/26240001/205217777-ba126af4-73dd-4e62-b65b-379d632480cc.gif)

<img width="398" alt="Screenshot 2022-12-01 at 8 36 58 PM" src="https://user-images.githubusercontent.com/26240001/205217690-64ebafb0-7d89-43df-a8fd-9963b59ad217.png">
<img width="406" alt="Screenshot 2022-12-01 at 7 57 42 PM" src="https://user-images.githubusercontent.com/26240001/205217693-9feef47d-1a5b-46e7-b758-d3709b992e38.png">
<img width="418" alt="Screenshot 2022-12-01 at 7 52 49 PM" src="https://user-images.githubusercontent.com/26240001/205217695-bf8716cf-cc54-4702-b681-2796ff38f9bc.png">


![Screenshot 2022-12-01 at 2 18 53 PM](https://user-images.githubusercontent.com/26240001/205171608-8c8cf79b-b3b3-4c84-ad20-81793874fd4b.png)
![Screenshot 2022-12-01 at 2 17 56 PM](https://user-images.githubusercontent.com/26240001/205171614-54ee5efb-ee09-4ffa-8175-d42c78163da3.png)

Story:
https://notifi.atlassian.net/browse/MVP-1694