### PR TITLE
creates a context wrapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36585,7 +36585,7 @@
         "@notifi-network/notifi-axios-adapter": "^0.42.1",
         "@notifi-network/notifi-axios-utils": "^0.42.1",
         "@notifi-network/notifi-core": "^0.42.1",
-        "@polkadot/util": "*",
+        "@polkadot/util": "^10.1.14",
         "@types/node": "^17.0.21",
         "@types/react": "^17.0.39",
         "axios": "^0.26.0",

--- a/packages/notifi-react-card/lib/components/index.ts
+++ b/packages/notifi-react-card/lib/components/index.ts
@@ -3,3 +3,4 @@ export * from './NotifiFooter';
 export * from './NotifiLogo';
 export * from './NotifiSmsInput';
 export * from './NotifiTelegramInput';
+export * from './subscription/NotifiSubscriptionContextWrapper';

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionContextWrapper.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionContextWrapper.tsx
@@ -1,0 +1,22 @@
+import {
+  NotifiSubscriptionContextProvider,
+  useNotifiClientContext,
+} from 'notifi-react-card/lib';
+import React from 'react';
+
+export type NotifiSubscriptionContextWrapper = Readonly<{
+  cardId: string;
+}>;
+
+export const NotifiSubscriptionContextWrapper: React.FC<
+  React.PropsWithChildren<NotifiSubscriptionContextWrapper>
+> = (props: React.PropsWithChildren<NotifiSubscriptionContextWrapper>) => {
+  const { params } = useNotifiClientContext();
+  const { children } = props;
+
+  return (
+    <NotifiSubscriptionContextProvider {...params}>
+      {children}
+    </NotifiSubscriptionContextProvider>
+  );
+};

--- a/packages/notifi-react-card/lib/components/subscription/index.ts
+++ b/packages/notifi-react-card/lib/components/subscription/index.ts
@@ -9,3 +9,5 @@ export * from './NotifiSubscribeButton';
 export * from './NotifiSubscriptionCard';
 export * from './SubscriptionCardUnsupported';
 export * from './SubscriptionCardV1';
+export * from './NotifiSubscriptionContextWrapper';
+export * from './subscription-card-views';

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/index.ts
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/index.ts
@@ -1,0 +1,1 @@
+export * from './preview-panel';

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/index.ts
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/index.ts
@@ -1,0 +1,1 @@
+export * from './UserInfoPanel';

--- a/packages/notifi-react-card/lib/context/index.ts
+++ b/packages/notifi-react-card/lib/context/index.ts
@@ -1,3 +1,4 @@
 export * from './NotifiSubscriptionContext';
 export * from './NotifiClientContext';
 export * from './NotifiContext';
+export * from '../components/subscription/NotifiSubscriptionContextWrapper';


### PR DESCRIPTION
to approach creating a more globalized context where users can use hooks throughout the application, we'd need to open up the context to more than just a card. this will allow the user to create a separate context that use react card components without having to use the notifi react card