### PR TITLE
Add NEAR Login

### DIFF
--- a/packages/notifi-core/lib/NotifiClient.ts
+++ b/packages/notifi-core/lib/NotifiClient.ts
@@ -266,6 +266,10 @@ export type SignMessageParams =
   | Readonly<{
       walletBlockchain: 'ACALA';
       signMessage: AcalaSignMessageFunction;
+    }>
+  | Readonly<{
+      walletBlockchain: 'NEAR';
+      signMessage: Uint8SignMessageFunction;
     }>;
 
 export type NotifiClient = Readonly<{

--- a/packages/notifi-core/lib/operations/LogInFromDapp.ts
+++ b/packages/notifi-core/lib/operations/LogInFromDapp.ts
@@ -12,7 +12,8 @@ export type LogInFromDappInput = Readonly<{
     | 'ACALA'
     | 'POLYGON'
     | 'ARBITRUM'
-    | 'BINANCE';
+    | 'BINANCE'
+    | 'NEAR';
   accountId?: string;
 }>;
 

--- a/packages/notifi-react-card/lib/context/NotifiContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiContext.tsx
@@ -53,21 +53,30 @@ export type AcalaParams = Readonly<{
   signMessage: AcalaSignMessageFunction;
 }>;
 
+export type NearParams = Readonly<{
+  walletBlockchain: 'NEAR';
+  accountAddress: string;
+  walletPublicKey: string;
+  signMessage: Uint8SignMessageFunction;
+}>;
+
+type WalletParams =
+  | SolanaParams
+  | EthereumParams
+  | PolygonParams
+  | ArbitrumParams
+  | BinanceParams
+  | AptosParams
+  | AcalaParams
+  | NearParams;
+
 export type NotifiParams = Readonly<{
   alertConfigurations?: Record<string, AlertConfiguration | null>;
   dappAddress: string;
   env: NotifiEnvironment;
   keepSubscriptionData?: boolean;
 }> &
-  (
-    | SolanaParams
-    | EthereumParams
-    | PolygonParams
-    | ArbitrumParams
-    | BinanceParams
-    | AptosParams
-    | AcalaParams
-  );
+  WalletParams;
 
 export const NotifiContext: React.FC<React.PropsWithChildren<NotifiParams>> = ({
   children,


### PR DESCRIPTION
Please note: There seems to an existing bug with alert history showing first even before a user signs in. 

To-Do:
- We should update the signature message to be consistent with the other chains, will request BE.

Test:

https://user-images.githubusercontent.com/108922885/206565130-aa3d7464-09b3-48bc-9350-7d327b7d79db.mov

Please note:
- NEAR users do not need to manually "sign" a message in their wallet. Once the user connects their wallet, they have authorized the dapp to sign for them. 

I used `jt/near-login` to test in the `notifi-react-example`.

Next: Add documentation