### PR TITLE
Set state to 'edit' if data is missing

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
@@ -69,6 +69,8 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
       (telegramId !== '' && telegramId !== undefined)
     ) {
       setCardView({ state: 'history' });
+    } else {
+      setCardView({ state: 'edit' });
     }
   }, [email, phoneNumber, telegramId, setCardView, cardView, isInitialized]);
 


### PR DESCRIPTION
For some reason the card was always going to the alert history view.