### PR TITLE
Fix: Typos in NEAR Docs

### DIFF
--- a/packages/notifi-react-card/README.md
+++ b/packages/notifi-react-card/README.md
@@ -422,9 +422,10 @@ Create a hook that gets all of the account data using NEAR API
 
 ```tsx
 import { keyStores } from 'near-api-js';
-import React, { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { useWalletSelector } from '../NEARWalletContextProvider';
+import { useWalletSelector } from '../components/NearWalletContextProvider';
+
 //assume that you have NEARWalletContextProvider setup
 //example: https://github.com/near/wallet-selector/blob/main/examples/react/contexts/WalletSelectorContext.tsx
 
@@ -442,23 +443,22 @@ export default function useNearWallet() {
 
   useEffect(() => {
     async function getPublicKey() {
-      const keyPair = await keyStore.getKey(config.networkId, accountId);
+      const keyPair = await keyStore.getKey(config.networkId, accountId!);
       const publicKey = keyPair.getPublicKey().toString();
       // remove the ed25519: appending for the wallet public key
       const publicKeyWithoutTypeAppend = publicKey.replace('ed25519:', '');
       setWalletPublicKey(publicKeyWithoutTypeAppend);
     }
     getPublicKey();
-    }
-  }, [keyStore]);
+  }, [accountId, config.networkId, keyStore]);
 
   const signMessage = useCallback(
     async (message: Uint8Array) => {
-      const keyPair = await keyStore.getKey(config.networkId, accountId);
-      const { signature } = keyPair.sign(msg);
+      const keyPair = await keyStore.getKey(config.networkId, accountId!);
+      const { signature } = keyPair.sign(message);
       return signature;
     },
-    [],
+    [accountId, config.networkId, keyStore],
   );
 
   return { account: accountId, walletPublicKey, signMessage };
@@ -505,7 +505,7 @@ export const Notifi: React.FC = () => {
       dappAddress="<YOUR OWN DAPP ADDRESS HERE>"
       env="Development"
       walletBlockchain="NEAR"
-      accountAddress={accountId}
+      accountAddress={account}
       walletPublicKey={walletPublicKey} // require wallet public key without ed25519: append
       signMessage={signMessage}
     >

--- a/packages/notifi-react-card/README.md
+++ b/packages/notifi-react-card/README.md
@@ -442,6 +442,12 @@ export default function useNearWallet() {
   }, []);
 
   useEffect(() => {
+    if (!accountId) {
+      setWalletPublicKey(null);
+    }
+  }, [accountId]);
+
+  useEffect(() => {
     async function getPublicKey() {
       const keyPair = await keyStore.getKey(config.networkId, accountId!);
       const publicKey = keyPair.getPublicKey().toString();

--- a/packages/notifi-react-card/README.md
+++ b/packages/notifi-react-card/README.md
@@ -484,7 +484,7 @@ import { useNearWallet } from 'path-to-custom-hook';
 import React, { useCallback, useState } from 'react';
 
 export const Notifi: React.FC = () => {
-  const { acoount, walletPublicKey, signMessage } = useNearWallet();
+  const { account, walletPublicKey, signMessage } = useNearWallet();
 
   if (account === null || walletPublicKey === null) {
     // account is required

--- a/packages/notifi-react-card/README.md
+++ b/packages/notifi-react-card/README.md
@@ -425,6 +425,8 @@ import { keyStores } from 'near-api-js';
 import React, { useCallback, useEffect, useMemo } from 'react';
 
 import { useWalletSelector } from '../NEARWalletContextProvider';
+//assume that you have NEARWalletContextProvider setup
+//example: https://github.com/near/wallet-selector/blob/main/examples/react/contexts/WalletSelectorContext.tsx
 
 export default function useNearWallet() {
   const { accountId } = useWalletSelector();
@@ -439,19 +441,19 @@ export default function useNearWallet() {
   }, []);
 
   useEffect(() => {
-      async function getPublicKey() {
-      const keyPair = await keyStore.getKey(config.networkId, ACCOUNT_ID);
+    async function getPublicKey() {
+      const keyPair = await keyStore.getKey(config.networkId, accountId);
       const publicKey = keyPair.getPublicKey().toString();
       // remove the ed25519: appending for the wallet public key
       const publicKeyWithoutTypeAppend = publicKey.replace('ed25519:', '');
-      setPublicKey(publicKeyWithoutTypeAppend);
+      setWalletPublicKey(publicKeyWithoutTypeAppend);
     }
     getPublicKey();
     }
   }, [keyStore]);
 
   const signMessage = useCallback(
-    async (message: Unit8Array) => {
+    async (message: Uint8Array) => {
       const keyPair = await keyStore.getKey(config.networkId, accountId);
       const { signature } = keyPair.sign(msg);
       return signature;
@@ -459,7 +461,7 @@ export default function useNearWallet() {
     [],
   );
 
-  return { account, walletPublicKey, signMessage };
+  return { account: accountId, walletPublicKey, signMessage };
 }
 ```
 
@@ -505,9 +507,7 @@ export const Notifi: React.FC = () => {
       walletBlockchain="NEAR"
       accountAddress={accountId}
       walletPublicKey={walletPublicKey} // require wallet public key without ed25519: append
-      signMessage={async (message: Uint8Array) => {
-        await signMessage(message);
-      }}
+      signMessage={signMessage}
     >
       <NotifiSubscriptionCard
         cardId="<YOUR OWN CARD ID HERE>"


### PR DESCRIPTION
- Correct setState function and variables names
- Pass in the correct signMessage function
- Add comment on assumption to have `NEARWalletContextProvider` set up

TO-DO: Set up an example repo to showcase NEAR