### PR TITLE
small updates for positioninig and button colors

### DIFF
--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -155,6 +155,7 @@ input:-webkit-autofill {
   justify-content: center;
   align-items: center;
   padding-bottom: 10px;
+  position: relative;
 }
 
 .NotifiAlertHistory__notificationDate {
@@ -482,7 +483,7 @@ input:-webkit-autofill {
   font-size: 16px;
   line-height: 20px;
   cursor: pointer;
-  color: var(--notifi-font-color);
+  color: #ffffff;
 }
 
 .NotifiUserInfoPanel__emailConfirmation,
@@ -570,7 +571,7 @@ input:-webkit-autofill {
 }
 .NotifiAlertHistory__settingsIcon {
   position: absolute;
-  right: 35px;
+  right: 20px;
   height: 20px;
 }
 

--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -16,9 +16,11 @@
   --notifi-input-background: #f5f6fb;
   --notifi-input-border: #e8ebf5;
   --notifi-button-color: #1448f3;
+  --notifi-button-text-color: #fff
   --notifi-button-disabled-color: #b6b8d5;
   --notifi-incoming-message: #f5f6fb;
   --notifi-outgoing-message: #e5ebff;
+  --notifi-settings-icon-color: #262949
 }
 
 .notifi__dark {
@@ -40,8 +42,10 @@
   --notifi-input-border: #606060;
   --notifi-button-color: #678afc;
   --notifi-button-disabled-color: #80829d;
+  --notifi-button-text-color: #fff
   --notifi-incoming-message: #474858;
   --notifi-outgoing-message: #678afc;
+  --notifi-settings-icon-color: #fff
 }
 
 input:autofill,
@@ -388,7 +392,7 @@ input:-webkit-autofill {
   font-size: 16px;
   line-height: 20px;
   cursor: pointer;
-  color: #fff;
+  color: var(--notifi-button-text-color);
   width: 100%;
   display: block;
 }
@@ -483,7 +487,7 @@ input:-webkit-autofill {
   font-size: 16px;
   line-height: 20px;
   cursor: pointer;
-  color: #ffffff;
+  color: var(--notifi-button-text-color);
 }
 
 .NotifiUserInfoPanel__emailConfirmation,
@@ -571,12 +575,12 @@ input:-webkit-autofill {
 }
 .NotifiAlertHistory__settingsIcon {
   position: absolute;
-  right: 20px;
+  right: 0px;
   height: 20px;
 }
 
 .NotifiAlertHistory__settingsIcon path {
-  fill: var(--notifi-button-color);
+  fill: var(notifi-settings-icon-color);
   cursor: pointer;
 }
 .NotifiAlertHistory__emptyAlertsBellIcon path {
@@ -598,6 +602,7 @@ input:-webkit-autofill {
   z-index: 10;
   top: 0px;
   left: 0px;
+  max-height: 525px;
   background-color: var(--notifi-card-background);
   width: 360px;
   height: 100%;


### PR DESCRIPTION
we have position absolute on a child and the parent didn't have any position prop so it was using the viewport width the edit button color also didn't have enough contrast so i updated it to match the subscribe button

- updated settings icons colors through through property 
- added a max height to alert details container, it was spilling over without it.

Before:
<img width="372" alt="image" src="https://user-images.githubusercontent.com/105258726/208166740-dfeb3f05-70e5-4659-be25-d709d671bcf6.png">

After:
<img width="384" alt="image" src="https://user-images.githubusercontent.com/105258726/208166259-233442c3-90a8-4885-8fbf-3410b2bd1c63.png">


Header:
Before:
<img width="856" alt="image" src="https://user-images.githubusercontent.com/105258726/208167730-509a91f1-941e-4238-8889-8547df4a5a25.png">


<img width="413" alt="image" src="https://user-images.githubusercontent.com/105258726/208167194-2941fe97-4e12-41f0-8bc7-e026054596a7.png">

Settings Icons Colors:
<img width="440" alt="image" src="https://user-images.githubusercontent.com/105258726/208171984-d45c31e4-b33b-48b4-8035-7d3126b895ad.png">

<img width="400" alt="image" src="https://user-images.githubusercontent.com/105258726/208172023-fceafd19-973e-4d43-9d71-75d9d61ffac6.png">

max-height before:
<img width="475" alt="image" src="https://user-images.githubusercontent.com/105258726/208172452-8f212b72-26df-46c8-b6c0-c2e21e163b6e.png">

max-height after:
<img width="424" alt="image" src="https://user-images.githubusercontent.com/105258726/208172506-3968de9b-ff34-45da-97a9-894805eabedd.png">

