### PR TITLE
Fix: Aptos Sign Message in Documentation

### DIFF
--- a/packages/notifi-react-card/README.md
+++ b/packages/notifi-react-card/README.md
@@ -269,7 +269,9 @@ export const Notifi: React.FC = () => {
           nonce: `${nonce}`,
         });
 
-        return result.signature;
+        if (typeof result === 'string') {
+          return result;
+        } else return result.signature;
       }}
     >
       <NotifiSubscriptionCard


### PR DESCRIPTION
- Aptos sign-in code in current documentation returns an error because our Aptos sign message function requires a string while the Aptos sign message function itself returns either a `string` or `SignMessageResponse` type. 
- Since our Aptos sign message function is typed to string, if the `result` of `signMessage` is a string, then we return `result`. If not, then we should return the `signature` value of `result.` 

https://user-images.githubusercontent.com/108922885/208219350-225e4dda-0f98-48fc-8efa-09dcafb6667a.mov

Please reference https://github.com/notifi-network/notifi-aptos-example for confirmation. 