### PR TITLE
updates unit tests for webhooks

### DIFF
--- a/packages/notifi-core/lib/models/TargetGroup.ts
+++ b/packages/notifi-core/lib/models/TargetGroup.ts
@@ -1,3 +1,5 @@
+import { WebhookTarget } from 'notifi-core/dist';
+
 import { EmailTarget } from './EmailTarget';
 import { SmsTarget } from './SmsTarget';
 import { TelegramTarget } from './TelegramTarget';
@@ -21,4 +23,5 @@ export type TargetGroup = Readonly<{
   name: string | null;
   smsTargets: ReadonlyArray<SmsTarget>;
   telegramTargets: ReadonlyArray<TelegramTarget>;
+  webHookTargets: ReadonlyArray<WebhookTarget>;
 }>;

--- a/packages/notifi-react-hooks/lib/utils/ensureSourceGroup.spec.ts
+++ b/packages/notifi-react-hooks/lib/utils/ensureSourceGroup.spec.ts
@@ -13,6 +13,7 @@ const createSource = (id: string): Source => {
   return {
     id,
     name: id,
+    blockchainAddress: 'BBqe9bApNYvr27fKXZxA8QuYdihYDBNX4E2EZJz8zNRY',
     type: 'SOLANA_WALLET',
     applicableFilters: [],
   };

--- a/packages/notifi-react-hooks/lib/utils/ensureTargetGroup.spec.ts
+++ b/packages/notifi-react-hooks/lib/utils/ensureTargetGroup.spec.ts
@@ -34,6 +34,7 @@ const createTelegramTarget = (id: string): TelegramTarget => {
     id,
     name: 'some-telegram-id',
     telegramId: 'some-telegram-id',
+    confirmationUrl: null,
     isConfirmed: true,
   };
 };

--- a/packages/notifi-react-hooks/lib/utils/ensureTargetIds.spec.ts
+++ b/packages/notifi-react-hooks/lib/utils/ensureTargetIds.spec.ts
@@ -35,6 +35,7 @@ describe('ensureTargetIds', () => {
       return {
         id: 'created-telegram-target',
         name: input.name,
+        confirmationUrl: null,
         telegramId: input.value,
         isConfirmed: true,
       };

--- a/packages/notifi-react-hooks/lib/utils/fetchDataImpl.spec.ts
+++ b/packages/notifi-react-hooks/lib/utils/fetchDataImpl.spec.ts
@@ -8,6 +8,8 @@ describe('fetchDataImpl', () => {
     getTargetGroups: jest.fn().mockResolvedValue([]),
     getEmailTargets: jest.fn().mockResolvedValue([]),
     getSmsTargets: jest.fn().mockResolvedValue([]),
+    getTopics: jest.fn().mockResolvedValue([]),
+    getWebhookTargets: jest.fn().mockResolvedValue([]),
     getTelegramTargets: jest.fn().mockResolvedValue([]),
   };
 
@@ -22,6 +24,8 @@ describe('fetchDataImpl', () => {
     service.getTargetGroups.mockClear();
     service.getEmailTargets.mockClear();
     service.getSmsTargets.mockClear();
+    service.getWebhookTargets.mockClear();
+    service.getTopics.mockClear();
     service.getTelegramTargets.mockClear();
     timeProvider.now.mockClear();
   });
@@ -32,6 +36,9 @@ describe('fetchDataImpl', () => {
     expect(service.getSourceGroups).toHaveBeenCalledTimes(count);
     expect(service.getTargetGroups).toHaveBeenCalledTimes(count);
     expect(service.getEmailTargets).toHaveBeenCalledTimes(count);
+    // get topics currently does not work
+    expect(service.getTopics).toHaveBeenCalledTimes(0);
+    expect(service.getWebhookTargets).toHaveBeenCalledTimes(count);
     expect(service.getSmsTargets).toHaveBeenCalledTimes(count);
     expect(service.getTelegramTargets).toHaveBeenCalledTimes(count);
   };


### PR DESCRIPTION
ensureTargetGroup spec was failing due to webhook targets. updated as i wanted to update inputs in the future discord and twitter

can run test by using:
`npm run test ensureTargetGroup.spec.ts`