### PR TITLE
[MVP-1810] add liquidation alert selection to SDK react card - UI

### DIFF
--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -349,6 +349,7 @@ input:-webkit-autofill {
 .EventTypeLabelRow__container,
 .EventTypeBroadcastRow__container,
 .EventTypeDirectPushRow__container,
+.EventTypeHealthCheckRow__container,
 .BrowserAlertToggle__container {
   display: flex;
   flex-direction: row;
@@ -356,6 +357,7 @@ input:-webkit-autofill {
 
 .EventTypeBroadcastRow__label,
 .EventTypeDirectPushRow__label,
+.EventTypeHealthCheckRow__label,
 .BrowserAlertToggle__label {
   display: flex;
   flex-direction: row;
@@ -364,6 +366,17 @@ input:-webkit-autofill {
   font-size: 16px;
   line-height: 20px;
   text-align: left;
+}
+
+.EventTypeHealthCheckRow__container,
+.EventTypeHealthCheckRow__label {
+  margin-bottom: 0 !important;
+}
+
+
+.EventTypeHealthCheckRow__content {
+  font-size: 14px;
+  color: var(--notifi-secondary-font-color);
 }
 
 .EventTypeLabelRow__label {
@@ -1006,4 +1019,39 @@ input:-webkit-autofill {
   border-radius: 20px;
   background-color: #f5f6fb;
   height: 34px;
+}
+
+.EventTypeHealthCheckRow__button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #F6F6FA;
+  color: #808080;
+  height: 47px;
+  width: 65px;
+  border-radius: 8px;
+  opacity: 90%;
+  margin-right: 16px;
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 20px;
+  border: 1px solid #DAE0E1;
+  cursor: pointer;
+}
+
+.EventTypeHealthCheckRow__buttonSelected {
+  border: 2px solid var( --notifi-button-color);
+  color: #000000;
+}
+
+.EventTypeHealthCheckRow__customButton {
+  text-align: center;
+  width: 110px;
+  color: #000000;
+}
+
+.EventTypeHealthCheckRow__buttonContainer {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
 }

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeHealthCheckRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeHealthCheckRow.tsx
@@ -71,9 +71,10 @@ export const EventTypeHealthCheckRow: React.FC<
       setEnabled(true);
     } else {
       if (
-        customValue.indexOf('%') === customValue.length - 1 &&
-        parseFloat(customValue.slice(0, -1)) >= 1 &&
-        parseFloat(customValue.slice(0, -1)) <= 99
+        selectedRatio !== '' ||
+        (customValue.indexOf('%') === customValue.length - 1 &&
+          parseFloat(customValue.slice(0, -1)) >= 1 &&
+          parseFloat(customValue.slice(0, -1)) <= 99)
       ) {
         console.log(selectedRatio);
         return;

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeHealthCheckRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeHealthCheckRow.tsx
@@ -1,0 +1,199 @@
+import clsx from 'clsx';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useNotifiSubscriptionContext } from '../../context';
+import {
+  CheckRatio,
+  HealthCheckEventTypeItem,
+  useNotifiSubscribe,
+} from '../../hooks';
+import { DeepPartialReadonly } from '../../utils';
+import type { NotifiToggleProps } from './NotifiToggle';
+import { NotifiToggle } from './NotifiToggle';
+import { NotifiTooltip, NotifiTooltipProps } from './NotifiTooltip';
+
+export type EventTypeHealthCheckRowProps = Readonly<{
+  classNames?: DeepPartialReadonly<{
+    container: string;
+    label: string;
+    content: string;
+    button: string;
+    buttonContainer: string;
+    errorMessage: string;
+    toggle: NotifiToggleProps['classNames'];
+    tooltip: NotifiTooltipProps['classNames'];
+  }>;
+  disabled: boolean;
+  config: HealthCheckEventTypeItem;
+  inputs?: Record<string, string | undefined>;
+}>;
+
+export const EventTypeHealthCheckRow: React.FC<
+  EventTypeHealthCheckRowProps
+> = ({
+  classNames,
+  config,
+  disabled,
+  inputs,
+}: EventTypeHealthCheckRowProps) => {
+  const { alerts, loading } = useNotifiSubscriptionContext();
+  const { instantSubscribe } = useNotifiSubscribe({
+    targetGroupName: 'Default',
+  });
+  const [enabled, setEnabled] = useState(false);
+  const [ratios, setRatios] = useState<CheckRatio[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [selectedRatio, setSelectedRatio] = useState<string>('');
+  const [customValue, setCustomValue] = useState<string>('');
+  const [cutomButtonPlaceholder, setCustomButtonPlaceholder] =
+    useState<string>('Custom');
+  const [errorMessage, setErrorMessage] = useState<string>('');
+
+  const alertName = useMemo<string>(() => config.name, [config]);
+  const tooltipContent = config.tooltipContent;
+  useEffect(() => {
+    if (loading) {
+      return;
+    }
+    const hasAlert = alerts[alertName] !== undefined;
+    setEnabled(hasAlert);
+  }, [alertName, alerts, loading]);
+
+  useEffect(() => {
+    if (config && config.checkRatios.type === 'value') {
+      setRatios(config.checkRatios.value);
+    }
+  }, [config, setRatios]);
+
+  const handleNewSubscription = () => {
+    if (loading) {
+      return;
+    }
+    if (
+      customValue.indexOf('%') === customValue.length - 1 &&
+      parseFloat(customValue.slice(0, -1)) > 0 &&
+      parseFloat(customValue.slice(0, -1)) <= 100
+    ) {
+      console.log(selectedRatio);
+      return;
+      //TODO: hook up API call here
+      // if (!enabled) {
+      //   instantSubscribe({
+      //     alertConfiguration: alertConfiguration,
+      //     alertName: alertName,
+      //   });
+      // } else {
+      //   instantSubscribe({
+      //     alertConfiguration: null,
+      //     alertName: alertName,
+      //   });
+      // }
+    } else {
+      setErrorMessage('Please enter a valid number');
+    }
+  };
+
+  return (
+    <div>
+      <div
+        className={clsx(
+          'EventTypeHealthCheckRow__container',
+          classNames?.container,
+        )}
+      >
+        <div
+          className={clsx('EventTypeHealthCheckRow__label', classNames?.label)}
+        >
+          {config.name}
+          {tooltipContent !== undefined && tooltipContent.length > 0 ? (
+            <NotifiTooltip
+              classNames={classNames?.tooltip}
+              content={tooltipContent}
+            />
+          ) : null}
+        </div>
+        <NotifiToggle
+          checked={enabled}
+          classNames={classNames?.toggle}
+          disabled={disabled}
+          setChecked={handleNewSubscription}
+        />
+      </div>
+      <div
+        className={clsx(
+          'EventTypeHealthCheckRow__content',
+          classNames?.content,
+        )}
+      >
+        Alert me when my margin ratio is {ratios[0]?.type}
+      </div>
+      <div
+        className={clsx(
+          'EventTypeHealthCheckRow__buttonContainer',
+          classNames?.buttonContainer,
+        )}
+      >
+        {ratios.map((value, index) => {
+          const percentage = value.ratio * 100 + '%';
+          return (
+            <div
+              key={index}
+              className={clsx(
+                'EventTypeHealthCheckRow__button',
+                `${
+                  index === selectedIndex
+                    ? ' EventTypeHealthCheckRow__buttonSelected'
+                    : undefined
+                }`,
+                classNames?.button,
+              )}
+              onClick={() => {
+                setSelectedIndex(index);
+                setCustomButtonPlaceholder('Custom');
+                setCustomValue('');
+                setSelectedRatio(percentage);
+                setErrorMessage('');
+              }}
+            >
+              {percentage}
+            </div>
+          );
+        })}
+        <input
+          onClick={() => {
+            //assume we should only allow no more than two specific values and one custom value here
+            //need to double check with product
+            //will update in following PR when connect api
+            setSelectedIndex(3);
+            setCustomButtonPlaceholder('0.00%');
+            setErrorMessage('');
+          }}
+          value={customValue}
+          placeholder={cutomButtonPlaceholder}
+          className={clsx(
+            'EventTypeHealthCheckRow__button',
+            'EventTypeHealthCheckRow__customButton',
+            `${
+              selectedIndex === 3
+                ? ' EventTypeHealthCheckRow__buttonSelected'
+                : undefined
+            }`,
+            classNames?.button,
+          )}
+          onChange={(e) => {
+            setCustomValue(e.target.value ?? '');
+            setSelectedRatio(e.target.value);
+          }}
+        />
+      </div>
+      <label
+        className={clsx(
+          'NotifiEmailInput__errorMessage',
+          classNames?.errorMessage,
+        )}
+      >
+        {errorMessage}
+      </label>
+    </div>
+  );
+};

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeHealthCheckRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeHealthCheckRow.tsx
@@ -72,8 +72,8 @@ export const EventTypeHealthCheckRow: React.FC<
     } else {
       if (
         customValue.indexOf('%') === customValue.length - 1 &&
-        parseFloat(customValue.slice(0, -1)) > 0 &&
-        parseFloat(customValue.slice(0, -1)) < 100
+        parseFloat(customValue.slice(0, -1)) >= 1 &&
+        parseFloat(customValue.slice(0, -1)) <= 99
       ) {
         console.log(selectedRatio);
         return;

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeHealthCheckRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeHealthCheckRow.tsx
@@ -70,18 +70,21 @@ export const EventTypeHealthCheckRow: React.FC<
       setIsShowSelectButton(true);
       setEnabled(true);
     } else {
+      const selectedRatioNumber = parseFloat(customValue.slice(0, -1));
       if (
         selectedRatio !== '' ||
         (customValue.indexOf('%') === customValue.length - 1 &&
-          parseFloat(customValue.slice(0, -1)) >= 1 &&
-          parseFloat(customValue.slice(0, -1)) <= 99)
+          selectedRatioNumber >= 1 &&
+          selectedRatioNumber <= 99)
       ) {
-        console.log(selectedRatio);
         return;
-        //TODO: hook up API call here
+        // TODO: hook up API call here
         // if (!enabled) {
         //   instantSubscribe({
-        //     alertConfiguration: alertConfiguration,
+        //     alertConfiguration: healthThresholdConfiguration({
+        //       alertFrequency: 'ALWAYS',
+        //       percentage: selectedRatioNumber,
+        //     }),
         //     alertName: alertName,
         //   });
         // } else {

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/AlertListPreview.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/AlertListPreview.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { CardConfigItemV1 } from 'notifi-frontend-client/dist';
+import { CardConfigItemV1 } from 'notifi-react-card/lib/hooks';
 import { DeepPartialReadonly } from 'notifi-react-card/lib/utils';
 import React from 'react';
 

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/AlertsPanel.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/AlertsPanel.tsx
@@ -10,6 +10,10 @@ import {
   EventTypeDirectPushRowProps,
 } from '../../EventTypeDirectPushRow';
 import {
+  EventTypeHealthCheckRow,
+  EventTypeHealthCheckRowProps,
+} from '../../EventTypeHealthCheckRow';
+import {
   EventTypeLabelRow,
   EventTypeLabelRowProps,
 } from '../../EventTypeLabelRow';
@@ -24,6 +28,7 @@ export type AlertsPanelProps = Readonly<{
   classNames?: Readonly<{
     EventTypeBroadcastRow?: EventTypeBroadcastRowProps['classNames'];
     EventTypeDirectPushRow?: EventTypeDirectPushRowProps['classNames'];
+    EventTypeHealthCheckRow?: EventTypeHealthCheckRowProps['classNames'];
     EventTypeLabelRow?: EventTypeLabelRowProps['classNames'];
     EventTypeUnsupportedRow?: EventTypeUnsupportedRowProps['classNames'];
   }>;
@@ -54,6 +59,16 @@ export const AlertsPanel: React.FC<AlertsPanelProps> = ({
               <EventTypeDirectPushRow
                 key={eventType.name}
                 classNames={classNames?.EventTypeDirectPushRow}
+                disabled={inputDisabled}
+                config={eventType}
+                inputs={inputs}
+              />
+            );
+          case 'healthCheck':
+            return (
+              <EventTypeHealthCheckRow
+                key={eventType.name}
+                classNames={classNames?.EventTypeHealthCheckRow}
                 disabled={inputDisabled}
                 config={eventType}
                 inputs={inputs}

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/AlertsPanel.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/AlertsPanel.tsx
@@ -71,7 +71,6 @@ export const AlertsPanel: React.FC<AlertsPanelProps> = ({
                 classNames={classNames?.EventTypeHealthCheckRow}
                 disabled={inputDisabled}
                 config={eventType}
-                inputs={inputs}
               />
             );
           case 'label':

--- a/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
+++ b/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
@@ -24,6 +24,25 @@ export type BroadcastEventTypeItem = Readonly<{
   tooltipContent?: string;
 }>;
 
+export type HealthCheckEventTypeItem = Readonly<{
+  type: 'healthCheck';
+  name: string;
+  checkRatios: ValueOrRef<CheckRatio[]>;
+  tooltipContent?: string;
+}>;
+
+type RatiosBelow = Readonly<{
+  type: 'below';
+  ratio: number;
+}>;
+
+type RatiosAbove = Readonly<{
+  type: 'above';
+  ratio: number;
+}>;
+
+export type CheckRatio = RatiosBelow | RatiosAbove;
+
 export type LabelEventTypeItem = Readonly<{
   type: 'label';
   name: string;
@@ -33,6 +52,7 @@ export type LabelEventTypeItem = Readonly<{
 export type EventTypeItem =
   | DirectPushEventTypeItem
   | BroadcastEventTypeItem
+  | HealthCheckEventTypeItem
   | LabelEventTypeItem;
 
 export type EventTypeConfig = ReadonlyArray<EventTypeItem>;

--- a/packages/notifi-react-example/src/NotifiCard/NotifiCard.tsx
+++ b/packages/notifi-react-example/src/NotifiCard/NotifiCard.tsx
@@ -56,10 +56,10 @@ export const NotifiCard: React.FC = () => {
         signMessage={signMessage}
       >
         <NotifiSubscriptionCard
-          darkMode
+          // darkMode
           inputLabels={inputLabels}
           inputSeparators={inputSeparators}
-          cardId="f64359eac9b14d358671aede15574731"
+          cardId="7f35dd52d252453f9c89dc087fc05f13"
         />
         {/* <NotifiIntercomCard
           darkMode

--- a/packages/notifi-react-example/src/NotifiCard/NotifiCard.tsx
+++ b/packages/notifi-react-example/src/NotifiCard/NotifiCard.tsx
@@ -1,6 +1,7 @@
 import {
   NotifiContext,
   NotifiInputSeparators,
+  NotifiIntercomCard,
   NotifiSubscriptionCard,
 } from '@notifi-network/notifi-react-card';
 import '@notifi-network/notifi-react-card/dist/index.css';
@@ -38,11 +39,11 @@ export const NotifiCard: React.FC = () => {
     },
   };
 
-  // const intercomInputSeparators: NotifiInputSeparators = {
-  //   emailSeparator: {
-  //     content: 'OR',
-  //   },
-  // };
+  const intercomInputSeparators: NotifiInputSeparators = {
+    emailSeparator: {
+      content: 'OR',
+    },
+  };
 
   return (
     <div className="container">
@@ -56,17 +57,17 @@ export const NotifiCard: React.FC = () => {
         signMessage={signMessage}
       >
         <NotifiSubscriptionCard
-          // darkMode
+          darkMode
           inputLabels={inputLabels}
           inputSeparators={inputSeparators}
-          cardId="7f35dd52d252453f9c89dc087fc05f13"
+          cardId="71562316475a4171ae9c980adaefab7d"
         />
-        {/* <NotifiIntercomCard
+        <NotifiIntercomCard
           darkMode
           inputLabels={inputLabels}
           inputSeparators={intercomInputSeparators}
           cardId="1045f61752b148eabab0403c08cd60b2"
-        /> */}
+        />
       </NotifiContext>
     </div>
   );


### PR DESCRIPTION
Add Liquidation LTV Alert Selection to SDK React Card
Toggle: If toggle is turned ON, then the notification buttons drop down. The user can select or enter per 
Button 1: XX%
Button 2: YY%
Button 3: Custom entry of a percent ranging from 1%-99%

## Test:
![Untitled1](https://user-images.githubusercontent.com/26240001/209054169-e408ecd3-ff92-4749-aeec-7fa7498a58ab.gif)

## Story: 
https://notifi.atlassian.net/jira/software/c/projects/MVP/boards/1?modal=detail&selectedIssue=MVP-1810&sprint=63