### PR TITLE
[MVP-1855] fix intercom issue with padding and empty strings

### DIFF
--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -16,11 +16,11 @@
   --notifi-input-background: #f5f6fb;
   --notifi-input-border: #e8ebf5;
   --notifi-button-color: #1448f3;
-  --notifi-button-text-color: #fff
+  --notifi-button-text-color: #fff;
   --notifi-button-disabled-color: #b6b8d5;
   --notifi-incoming-message: #f5f6fb;
   --notifi-outgoing-message: #e5ebff;
-  --notifi-settings-icon-color: #262949
+  --notifi-settings-icon-color: #262949;
 }
 
 .notifi__dark {
@@ -42,10 +42,10 @@
   --notifi-input-border: #606060;
   --notifi-button-color: #678afc;
   --notifi-button-disabled-color: #80829d;
-  --notifi-button-text-color: #fff
+  --notifi-button-text-color: #fff;
   --notifi-incoming-message: #474858;
   --notifi-outgoing-message: #678afc;
-  --notifi-settings-icon-color: #fff
+  --notifi-settings-icon-color: #fff;
 }
 
 input:autofill,
@@ -920,7 +920,7 @@ input:-webkit-autofill {
 }
 
 .NotifiIntercomChatIncomingMessage__body {
-  padding: 12px 16px 24px 16px;
+  padding: 12px 20px 24px 20px;
   max-width: 288px;
   border-radius: 16px;
   background: var(--notifi-incoming-message);
@@ -933,7 +933,7 @@ input:-webkit-autofill {
 }
 
 .NotifiIntercomChatOutgoingMessage__body {
-  padding: 12px 16px 24px 16px;
+  padding: 12px 20px 24px 20px;
   max-width: 250px;
   border-radius: 16px;
   background: var(--notifi-outgoing-message);

--- a/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
@@ -65,15 +65,14 @@ export const IntercomCard: React.FC<
     loading,
     intercomCardView,
     setIntercomCardView,
-    email,
-    phoneNumber,
-    telegramId,
     setHasChatAlert,
     setConversationId,
     setUserId,
   } = useNotifiSubscriptionContext();
 
-  const { formErrorMessages } = useNotifiForm();
+  const { formErrorMessages, formState } = useNotifiForm();
+
+  const { phoneNumber, telegram: telegramId, email } = formState;
 
   const {
     email: emailErrorMessage,
@@ -117,7 +116,7 @@ export const IntercomCard: React.FC<
     smsErrorMessage !== '' ||
     telegramErrorMessage !== '';
   const disabled =
-    (email === '' && phoneNumber === '' && telegramId === '') || hasErrors;
+    (email === '' && telegramId === '' && phoneNumber === '') || hasErrors;
 
   const labels = data.labels;
   const labelsValues = {} as LabelsMap;

--- a/packages/notifi-react-card/lib/components/intercom/SendMessageSection.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/SendMessageSection.tsx
@@ -15,7 +15,8 @@ export const SendMessageSection: React.FC<SendMessageSectionProps> = ({
   sendConversationMessages,
 }) => {
   const [sendMessage, setSendMessage] = useState<string | undefined>(undefined);
-  const disabled = sendMessage === '' || sendMessage === undefined;
+  const disabled =
+    sendMessage?.trim().length === 0 || sendMessage === undefined;
 
   const handleSend = () => {
     if (sendMessage) {
@@ -26,7 +27,7 @@ export const SendMessageSection: React.FC<SendMessageSectionProps> = ({
 
   const handleKeypressUp = useCallback(
     (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (event.key === 'Enter' && !event.shiftKey) {
+      if (event.key === 'Enter' && !event.shiftKey && !disabled) {
         handleSend();
         event.preventDefault();
       }


### PR DESCRIPTION
disabled send button when the user input string are all spaces
increase left and right padding in the message bubble
update to get email, telegram and sms for intercom from useNotifiForm
fixed the 'light mode' disabled button color

before:
![Screenshot 2023-01-01 at 4 21 03 PM](https://user-images.githubusercontent.com/26240001/210407730-3e8b3adb-725d-4529-844e-1edb8a643f86.png)
![Screenshot 2022-12-30 at 2 39 47 PM](https://user-images.githubusercontent.com/26240001/210407818-a202cc5d-4cc4-420c-96ef-9e1324752467.png)

after:
![Screenshot 2023-01-01 at 4 20 12 PM](https://user-images.githubusercontent.com/26240001/210407787-c83c6619-2246-4845-a957-d537871ea0ba.png)
![Screenshot 2023-01-03 at 9 22 51 AM](https://user-images.githubusercontent.com/26240001/210408853-aee351dd-2563-4fd3-8164-db7832e333a6.png)

test:
![Untitled1](https://user-images.githubusercontent.com/26240001/210407851-0b9354ff-a155-409e-bbda-d176ffd2f73f.gif)

