### PR TITLE
updates code to conditionally call logIn

### DIFF
--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -260,7 +260,10 @@ export const useNotifiSubscribe: ({
       }
 
       setLoading(true);
-      await logIn();
+
+      if (!client.isAuthenticated) {
+        await logIn();
+      }
       const data = await client.fetchData();
 
       //


### PR DESCRIPTION
when calling subscribe, login would cause re-renders in the forms due to logging in also calling on the `render` method. as a small change, we can conditionally call login based off isAuthenticated.

in the future, we may not need this due to the card not being available if the user is not isAuthenticated.