### PR TITLE
use alertFrequency from config data to create health check alert

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/EventTypeHealthCheckRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeHealthCheckRow.tsx
@@ -113,7 +113,7 @@ export const EventTypeHealthCheckRow: React.FC<
     if (!enabled && initialRatio !== null) {
       instantSubscribe({
         alertConfiguration: healthThresholdConfiguration({
-          alertFrequency: 'DAILY',
+          alertFrequency: config.alertFrequency,
           percentage: initialRatio,
         }),
         alertName: alertName,
@@ -136,7 +136,7 @@ export const EventTypeHealthCheckRow: React.FC<
     if (value) {
       instantSubscribe({
         alertConfiguration: healthThresholdConfiguration({
-          alertFrequency: 'DAILY',
+          alertFrequency: config.alertFrequency,
           percentage: value,
         }),
         alertName: alertName,
@@ -167,7 +167,7 @@ export const EventTypeHealthCheckRow: React.FC<
       ) {
         instantSubscribe({
           alertConfiguration: healthThresholdConfiguration({
-            alertFrequency: 'DAILY',
+            alertFrequency: config.alertFrequency,
             percentage: ratioNumber / 100,
           }),
           alertName: alertName,

--- a/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
+++ b/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
@@ -1,5 +1,5 @@
 // TODO: Import from library rather than copy / paste
-import { AlertFrequency } from 'notifi-frontend-client/dist';
+import { AlertFrequency } from '@notifi-network/notifi-core';
 
 export type ValueOrRef<ValueType> =
   | Readonly<{

--- a/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
+++ b/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
@@ -1,4 +1,5 @@
 // TODO: Import from library rather than copy / paste
+import { AlertFrequency } from 'notifi-frontend-client/dist';
 
 export type ValueOrRef<ValueType> =
   | Readonly<{
@@ -28,6 +29,7 @@ export type HealthCheckEventTypeItem = Readonly<{
   type: 'healthCheck';
   name: string;
   checkRatios: ValueOrRef<CheckRatio[]>;
+  alertFrequency: AlertFrequency;
   tooltipContent?: string;
 }>;
 


### PR DESCRIPTION
Currently, we allow tenant to select alert frequency for health check in admin tool
update in SDK subscription card to get alertFrequency for health check from config data