### PR TITLE
Prepopulate form

### DIFF
--- a/packages/notifi-react-card/lib/components/NotifiEmailInput.tsx
+++ b/packages/notifi-react-card/lib/components/NotifiEmailInput.tsx
@@ -36,8 +36,13 @@ export const NotifiEmailInput: React.FC<NotifiEmailInputProps> = ({
   const { emailIdThatNeedsConfirmation, intercomCardView } =
     useNotifiSubscriptionContext();
 
-  const { formState, formErrorMessages, setEmail, setEmailErrorMessage } =
-    useNotifiForm();
+  const {
+    formState,
+    formErrorMessages,
+    setEmail,
+    setEmailErrorMessage,
+    setHasChanges,
+  } = useNotifiForm();
 
   const { email } = formState;
 
@@ -107,6 +112,7 @@ export const NotifiEmailInput: React.FC<NotifiEmailInputProps> = ({
           value={email}
           onFocus={() => setEmailErrorMessage('')}
           onChange={(e) => {
+            setHasChanges(true);
             setEmail(e.target.value ?? '');
           }}
           placeholder={copy?.placeholder ?? 'Email Address'}

--- a/packages/notifi-react-card/lib/components/NotifiSmsInput.tsx
+++ b/packages/notifi-react-card/lib/components/NotifiSmsInput.tsx
@@ -48,6 +48,7 @@ export const NotifiSmsInput: React.FC<NotifiSmsInputProps> = ({
     formState,
     setPhoneNumber,
     setPhoneNumberErrorMessage,
+    setHasChanges,
   } = useNotifiForm();
 
   const { phoneNumber: phoneNumberErrorMessage } = formErrorMessages;
@@ -181,6 +182,10 @@ export const NotifiSmsInput: React.FC<NotifiSmsInputProps> = ({
                 className="NotifiSmsInput__dropdownInput"
                 type="hidden"
                 value={phoneValues.dialCode}
+                onChange={(e) => {
+                  setHasChanges(true);
+                  handleBaseNumberChange(e);
+                }}
               />
               <svg
                 className="NotifiSmsInput__dropdownSelectIcon"
@@ -209,7 +214,10 @@ export const NotifiSmsInput: React.FC<NotifiSmsInputProps> = ({
           disabled={disabled}
           name="notifi-sms"
           onBlur={validateSmsInput}
-          onChange={(e) => handleBaseNumberChange(e)}
+          onChange={(e) => {
+            setHasChanges(true);
+            handleBaseNumberChange(e);
+          }}
           onFocus={() => setPhoneNumberErrorMessage('')}
           placeholder={copy?.placeholder ?? 'Phone Number'}
           type="tel"

--- a/packages/notifi-react-card/lib/components/NotifiTelegramInput.tsx
+++ b/packages/notifi-react-card/lib/components/NotifiTelegramInput.tsx
@@ -35,8 +35,13 @@ export const NotifiTelegramInput: React.FC<NotifiTelegramInputProps> = ({
   const { telegramConfirmationUrl, intercomCardView } =
     useNotifiSubscriptionContext();
 
-  const { formState, formErrorMessages, setTelegram, setTelegramErrorMessage } =
-    useNotifiForm();
+  const {
+    formState,
+    formErrorMessages,
+    setTelegram,
+    setTelegramErrorMessage,
+    setHasChanges,
+  } = useNotifiForm();
 
   const { telegram } = formState;
 
@@ -102,6 +107,7 @@ export const NotifiTelegramInput: React.FC<NotifiTelegramInputProps> = ({
           value={telegram}
           onFocus={() => setTelegramErrorMessage('')}
           onChange={(e) => {
+            setHasChanges(true);
             setTelegram(e.target.value ?? '');
           }}
           placeholder={copy?.placeholder ?? 'Telegram ID'}

--- a/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { useNotifiClientContext } from 'notifi-react-card/lib/context';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { useNotifiForm, useNotifiSubscriptionContext } from '../../context/';
 import { useNotifiSubscribe } from '../../hooks';
@@ -55,13 +55,15 @@ export const IntercomCard: React.FC<
   const [chatAlertErrorMessage, setChatAlertErrorMessage] =
     useState<string>('');
 
-  const { instantSubscribe, isAuthenticated, isInitialized, didFetch } =
+  const { instantSubscribe, isAuthenticated, isInitialized } =
     useNotifiSubscribe({
       targetGroupName: 'Intercom',
     });
 
   useEffect(() => {
-    checkForExistingTargetGroups();
+    if (isAuthenticated && isInitialized) {
+      checkForExistingTargetGroups();
+    }
   }, [instantSubscribe]);
 
   const {
@@ -101,7 +103,6 @@ export const IntercomCard: React.FC<
       );
 
       if (confirmedEmailTarget?.emailAddress) {
-        console.log('confirmed email', confirmedEmailTarget);
         setFormEmail(confirmedEmailTarget.emailAddress);
       }
 
@@ -110,7 +111,6 @@ export const IntercomCard: React.FC<
       );
 
       if (confirmedTelegramTarget?.telegramId) {
-        console.log('confirmed telegram target', confirmedTelegramTarget);
         setFormTelegram(confirmedTelegramTarget?.telegramId);
       }
 
@@ -162,21 +162,6 @@ export const IntercomCard: React.FC<
       });
     }
   }, [alerts, loading, isInitialized]);
-
-  // const hasLoaded = useRef(false);
-
-  // useEffect(() => {
-  //   if (
-  //     !hasLoaded.current &&
-  //     didFetch.current === true &&
-  //     isInitialized &&
-  //     isAuthenticated
-  //   ) {
-  //     checkForExistingTargetGroups();
-  //     hasLoaded.current = true;
-  //     return;
-  //   }
-  // }, [didFetch, isInitialized, isAuthenticated]);
 
   const hasErrors =
     emailErrorMessage !== '' ||

--- a/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { useNotifiClientContext } from 'notifi-react-card/lib/context';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useNotifiForm, useNotifiSubscriptionContext } from '../../context/';
 import { useNotifiSubscribe } from '../../hooks';
@@ -55,10 +55,14 @@ export const IntercomCard: React.FC<
   const [chatAlertErrorMessage, setChatAlertErrorMessage] =
     useState<string>('');
 
-  const { instantSubscribe, isAuthenticated, isInitialized } =
+  const { instantSubscribe, isAuthenticated, isInitialized, didFetch } =
     useNotifiSubscribe({
       targetGroupName: 'Intercom',
     });
+
+  useEffect(() => {
+    checkForExistingTargetGroups();
+  }, [instantSubscribe]);
 
   const {
     alerts,
@@ -96,9 +100,8 @@ export const IntercomCard: React.FC<
         (email) => email.isConfirmed === true,
       );
 
-      console.log('target group', targetGroup);
       if (confirmedEmailTarget?.emailAddress) {
-        console.log(confirmedEmailTarget);
+        console.log('confirmed email', confirmedEmailTarget);
         setFormEmail(confirmedEmailTarget.emailAddress);
       }
 
@@ -107,7 +110,7 @@ export const IntercomCard: React.FC<
       );
 
       if (confirmedTelegramTarget?.telegramId) {
-        console.log(confirmedTelegramTarget);
+        console.log('confirmed telegram target', confirmedTelegramTarget);
         setFormTelegram(confirmedTelegramTarget?.telegramId);
       }
 
@@ -154,13 +157,26 @@ export const IntercomCard: React.FC<
         });
       });
     } else {
-      console.log('hit');
-      checkForExistingTargetGroups();
       setIntercomCardView({
         state: 'startChatView',
       });
     }
-  }, [alerts, loading, isInitialized, isAuthenticated]);
+  }, [alerts, loading, isInitialized]);
+
+  // const hasLoaded = useRef(false);
+
+  // useEffect(() => {
+  //   if (
+  //     !hasLoaded.current &&
+  //     didFetch.current === true &&
+  //     isInitialized &&
+  //     isAuthenticated
+  //   ) {
+  //     checkForExistingTargetGroups();
+  //     hasLoaded.current = true;
+  //     return;
+  //   }
+  // }, [didFetch, isInitialized, isAuthenticated]);
 
   const hasErrors =
     emailErrorMessage !== '' ||

--- a/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
@@ -61,10 +61,10 @@ export const IntercomCard: React.FC<
     });
 
   useEffect(() => {
-    if (isAuthenticated && isInitialized) {
+    if (isAuthenticated && isInitialized && hasChanges === false) {
       checkForExistingTargetGroups();
     }
-  }, [instantSubscribe]);
+  }, [instantSubscribe, isAuthenticated, isInitialized]);
 
   const {
     alerts,
@@ -81,6 +81,7 @@ export const IntercomCard: React.FC<
     formState,
     setEmail: setFormEmail,
     setTelegram: setFormTelegram,
+    hasChanges,
   } = useNotifiForm();
 
   const { email, phoneNumber, telegram: telegramId } = formState;

--- a/packages/notifi-react-card/lib/context/NotifiFormContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiFormContext.tsx
@@ -11,6 +11,8 @@ export type FormErrorMessages = FormInputs;
 export type NotifiFormData = Readonly<{
   formState: FormInputs;
   formErrorMessages: FormErrorMessages;
+  hasChanges: boolean;
+  setHasChanges: (value: boolean) => void;
 
   setEmail: (value: string) => void;
   setEmailErrorMessage: (value: string) => void;
@@ -32,6 +34,7 @@ export type EditFormType = {
 const NotifiFormContext = createContext<NotifiFormData>({} as NotifiFormData);
 
 export const NotifiFormProvider: React.FC = ({ children }) => {
+  const [hasChanges, setHasChanges] = useState<boolean>(false);
   const [formState, setFormInput] = useState<FormInputs>({
     email: '',
     phoneNumber: '',
@@ -87,6 +90,8 @@ export const NotifiFormProvider: React.FC = ({ children }) => {
   const value = {
     formState,
     formErrorMessages,
+    hasChanges,
+    setHasChanges,
     setEmail,
     setEmailErrorMessage,
     setTelegram,

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -42,7 +42,6 @@ export const useNotifiSubscribe: ({
   isAuthenticated: boolean;
   isInitialized: boolean;
   isTokenExpired: boolean;
-  didFetch: MutableRefObject<boolean>;
   logIn: () => Promise<SubscriptionData>;
   subscribe: (
     alertConfigs: Record<string, AlertConfiguration>,
@@ -552,7 +551,6 @@ export const useNotifiSubscribe: ({
     isInitialized: client.isInitialized,
     isTokenExpired: client.isTokenExpired,
     logIn,
-    didFetch,
     subscribe,
     updateTargetGroups,
   };

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -10,7 +10,7 @@ import {
   TransactionInstruction,
 } from '@solana/web3.js';
 import { isValidPhoneNumber } from 'libphonenumber-js';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { MutableRefObject, useCallback, useEffect, useRef } from 'react';
 
 import { useNotifiSubscriptionContext } from '../context';
 import { useNotifiClientContext } from '../context/NotifiClientContext';
@@ -42,6 +42,7 @@ export const useNotifiSubscribe: ({
   isAuthenticated: boolean;
   isInitialized: boolean;
   isTokenExpired: boolean;
+  didFetch: MutableRefObject<boolean>;
   logIn: () => Promise<SubscriptionData>;
   subscribe: (
     alertConfigs: Record<string, AlertConfiguration>,
@@ -53,9 +54,6 @@ export const useNotifiSubscribe: ({
   resendEmailVerificationLink: () => Promise<string>;
 }> = ({ targetGroupName = 'Default' }: useNotifiSubscribeProps) => {
   const { client } = useNotifiClientContext();
-
-  const [hasCheckedForTargetGroups, setHasCheckedForTargetGroups] =
-    useState<boolean>();
 
   const {
     formState,
@@ -117,6 +115,8 @@ export const useNotifiSubscribe: ({
         setEmailIdThatNeedsConfirmation('');
       }
 
+      console.log('email to set', emailToSet);
+      console.log('target group name', targetGroupName);
       setFormEmail(emailToSet);
       setEmail(emailToSet);
 
@@ -156,7 +156,6 @@ export const useNotifiSubscribe: ({
   // Initial fetch
   const didFetch = useRef(false);
   useEffect(() => {
-    console.log('usEffect');
     if (client.isAuthenticated && !didFetch.current) {
       didFetch.current = true;
       client
@@ -232,7 +231,6 @@ export const useNotifiSubscribe: ({
     }
 
     const newData = await client.fetchData();
-    console.log('within the login');
     const results = render(newData);
     setLoading(false);
     return results;
@@ -556,6 +554,7 @@ export const useNotifiSubscribe: ({
     isInitialized: client.isInitialized,
     isTokenExpired: client.isTokenExpired,
     logIn,
+    didFetch,
     subscribe,
     updateTargetGroups,
   };

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -115,8 +115,6 @@ export const useNotifiSubscribe: ({
         setEmailIdThatNeedsConfirmation('');
       }
 
-      console.log('email to set', emailToSet);
-      console.log('target group name', targetGroupName);
       setFormEmail(emailToSet);
       setEmail(emailToSet);
 

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -10,7 +10,7 @@ import {
   TransactionInstruction,
 } from '@solana/web3.js';
 import { isValidPhoneNumber } from 'libphonenumber-js';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useNotifiSubscriptionContext } from '../context';
 import { useNotifiClientContext } from '../context/NotifiClientContext';
@@ -53,6 +53,9 @@ export const useNotifiSubscribe: ({
   resendEmailVerificationLink: () => Promise<string>;
 }> = ({ targetGroupName = 'Default' }: useNotifiSubscribeProps) => {
   const { client } = useNotifiClientContext();
+
+  const [hasCheckedForTargetGroups, setHasCheckedForTargetGroups] =
+    useState<boolean>();
 
   const {
     formState,
@@ -153,6 +156,7 @@ export const useNotifiSubscribe: ({
   // Initial fetch
   const didFetch = useRef(false);
   useEffect(() => {
+    console.log('usEffect');
     if (client.isAuthenticated && !didFetch.current) {
       didFetch.current = true;
       client
@@ -228,7 +232,7 @@ export const useNotifiSubscribe: ({
     }
 
     const newData = await client.fetchData();
-
+    console.log('within the login');
     const results = render(newData);
     setLoading(false);
     return results;

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -10,7 +10,7 @@ import {
   TransactionInstruction,
 } from '@solana/web3.js';
 import { isValidPhoneNumber } from 'libphonenumber-js';
-import { MutableRefObject, useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { useNotifiSubscriptionContext } from '../context';
 import { useNotifiClientContext } from '../context/NotifiClientContext';

--- a/packages/notifi-react-example/src/NotifiCard/NotifiCard.tsx
+++ b/packages/notifi-react-example/src/NotifiCard/NotifiCard.tsx
@@ -68,12 +68,12 @@ export const NotifiCard: React.FC = () => {
           inputSeparators={inputSeparators}
           cardId="7f35dd52d252453f9c89dc087fc05f13"
         />
-        {/* <NotifiIntercomCard
+        <NotifiIntercomCard
           darkMode
           inputLabels={inputLabels}
           inputSeparators={intercomInputSeparators}
           cardId="1045f61752b148eabab0403c08cd60b2"
-        /> */}
+        />
       </NotifiContext>
     </div>
   );


### PR DESCRIPTION
When a user does not have chat alerts set up,
the form should be prepopulated with the user information if they currently have the SDK setup on their application.

how to test:

create a new wallet
sign up for sdk alerts on react card
refresh on intercom card to see if user info is pre-populated