### PR TITLE
Implement tradingPair renderer

### DIFF
--- a/packages/notifi-core/lib/NotifiClient.ts
+++ b/packages/notifi-core/lib/NotifiClient.ts
@@ -59,6 +59,7 @@ export type FilterOptions = Partial<{
     | { and: ReadonlyArray<ValueItemConfig> }
     | { or: ReadonlyArray<ValueItemConfig> }
   >;
+  tradingPair: string;
 }>;
 
 /**

--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -427,7 +427,7 @@ export class NotifiFrontendClient {
     inputs,
   }: Readonly<{
     eventType: EventTypeItem;
-    inputs: Record<string, string | undefined>;
+    inputs: Record<string, unknown>;
   }>): Promise<Types.AlertFragmentFragment> {
     const [alertsQuery, targetGroupsQuery, sourceAndFilters] =
       await Promise.all([

--- a/packages/notifi-frontend-client/lib/client/ensureSource.ts
+++ b/packages/notifi-frontend-client/lib/client/ensureSource.ts
@@ -14,7 +14,7 @@ import { resolveStringRef } from '../utils/resolveRef';
 const ensureDirectPushSource = async (
   service: Operations.GetSourcesService & Operations.CreateSourceService,
   _eventType: DirectPushEventTypeItem,
-  _inputs: Record<string, string | undefined>,
+  _inputs: Record<string, unknown>,
 ): Promise<Types.SourceFragmentFragment> => {
   const sourcesQuery = await service.getSources({});
   const sources = sourcesQuery.source;
@@ -32,7 +32,7 @@ const ensureDirectPushSource = async (
 const ensureBroadcastSource = async (
   service: Operations.GetSourcesService & Operations.CreateSourceService,
   eventType: BroadcastEventTypeItem,
-  inputs: Record<string, string | undefined>,
+  inputs: Record<string, unknown>,
 ): Promise<Types.SourceFragmentFragment> => {
   const sourcesQuery = await service.getSources({});
   const sources = sourcesQuery.source;
@@ -69,7 +69,7 @@ const ensureBroadcastSource = async (
 const ensurePriceChangeSources = async (
   service: Operations.GetSourcesService & Operations.CreateSourceService,
   eventType: PriceChangeEventTypeItem,
-  _inputs: Record<string, string | undefined>,
+  _inputs: Record<string, unknown>,
 ): Promise<ReadonlyArray<Types.SourceFragmentFragment>> => {
   const sourcesQuery = await service.getSources({});
   const sources = sourcesQuery.source;
@@ -111,7 +111,7 @@ const ensurePriceChangeSources = async (
 const ensureSources = async (
   service: Operations.GetSourcesService & Operations.CreateSourceService,
   eventType: EventTypeItem,
-  inputs: Record<string, string | undefined>,
+  inputs: Record<string, unknown>,
 ): Promise<ReadonlyArray<Types.SourceFragmentFragment>> => {
   switch (eventType.type) {
     case 'directPush': {
@@ -188,7 +188,7 @@ type GetFilterResults = Readonly<{
 const getDirectPushFilter = (
   source: SourceFragmentFragment,
   eventType: DirectPushEventTypeItem,
-  inputs: Record<string, string | undefined>,
+  inputs: Record<string, unknown>,
 ): GetFilterResults => {
   const filter = source.applicableFilters?.find(
     (it) => it?.filterType === 'DIRECT_TENANT_MESSAGES',
@@ -211,7 +211,7 @@ const getDirectPushFilter = (
 const getBroadcastFilter = (
   source: SourceFragmentFragment,
   _eventType: BroadcastEventTypeItem,
-  _inputs: Record<string, string | undefined>,
+  _inputs: Record<string, unknown>,
 ): GetFilterResults => {
   const filter = source.applicableFilters?.find(
     (it) => it?.filterType === 'BROADCAST_MESSAGES',
@@ -229,7 +229,7 @@ const getBroadcastFilter = (
 const getPriceChangeFilter = (
   sources: ReadonlyArray<SourceFragmentFragment>,
   _eventType: PriceChangeEventTypeItem,
-  _inputs: Record<string, string | undefined>,
+  _inputs: Record<string, unknown>,
 ): GetFilterResults => {
   const filter = sources
     .flatMap((it) => it.applicableFilters ?? [])
@@ -251,7 +251,7 @@ export const ensureSourceAndFilters = async (
     Operations.CreateSourceGroupService &
     Operations.UpdateSourceGroupService,
   eventType: EventTypeItem,
-  inputs: Record<string, string | undefined>,
+  inputs: Record<string, unknown>,
 ): Promise<
   Readonly<{
     sourceGroup: Types.SourceGroupFragmentFragment;

--- a/packages/notifi-react-card/lib/assets/DeleteIcon.tsx
+++ b/packages/notifi-react-card/lib/assets/DeleteIcon.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export type Props = React.SVGProps<SVGSVGElement>;
+
+export const DeleteIcon: React.FC<Props> = (props: Props) => {
+  return (
+    <svg
+      {...props}
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="inherit"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M7.5 17.4444C7.5 18.3 8.175 19 9 19H15C15.825 19 16.5 18.3 16.5 17.4444V8.11111H7.5V17.4444ZM17.25 5.77778H14.625L13.875 5H10.125L9.375 5.77778H6.75V7.33333H17.25V5.77778Z"
+        fill="#inherit"
+      />
+    </svg>
+  );
+};

--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -1183,15 +1183,35 @@ input:-webkit-autofill {
   padding: 10px 0;
 }
 
-.TradingPairAlertRow__name {
+.TradingPairAlertRow__textContainer {
+  display: flex;
   flex-grow: 1;
+  flex-direction: column;
+  align-items: stretch;
+  margin-right: 10px;
   margin-bottom: 0 !important;
+}
+
+.TradingPairAlertRow__name {
+  display: block;
+  font-size: 16px;
+  line-height: 20px;
+  color: var(--notifi-font-color);
+}
+
+.TradingPairAlertRow__description {
+  display: block;
+  font-size: 14px;
+  line-height: 18px;
+  color: var(--notifi-secondary-font-color);
 }
 
 .TradingPairAlertRow__deleteIcon {
   width: 24px;
   height: 24px;
   flex-shrink: 0;
+  fill: var(--notifi-font-color);
+  cursor: pointer;
 }
 
 .TradingPairSettingsRow__priceInputContainer {

--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -364,7 +364,6 @@ input:-webkit-autofill {
   margin-bottom: 0 !important;
 }
 
-
 .EventTypeHealthCheckRow__content {
   font-size: 14px;
   color: var(--notifi-secondary-font-color);
@@ -1049,7 +1048,7 @@ input:-webkit-autofill {
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: #F6F6FA;
+  background-color: #f6f6fa;
   color: #808080;
   height: 47px;
   width: 65px;
@@ -1059,12 +1058,12 @@ input:-webkit-autofill {
   font-size: 16px;
   font-weight: 500;
   line-height: 20px;
-  border: 1px solid #DAE0E1;
+  border: 1px solid #dae0e1;
   cursor: pointer;
 }
 
 .EventTypeHealthCheckRow__buttonSelected {
-  border: 2px solid var( --notifi-button-color);
+  border: 2px solid var(--notifi-button-color);
   color: #000000;
 }
 

--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -1078,3 +1078,160 @@ input:-webkit-autofill {
   flex-direction: row;
   justify-content: center;
 }
+
+.EventTypeTradingPairsRow__container {
+  display: flex;
+  align-items: stretch;
+  flex-direction: column;
+}
+
+.EventTypeTradingPairsRow__container > * {
+  margin-bottom: 0 !important;
+}
+
+.EventTypeTradingPairsRow__container > *:not(:first-child) {
+  padding-top: 10px;
+}
+
+.EventTypeTradingPairsRow__container > *:not(:last-child) {
+  padding-bottom: 10px;
+  border-bottom: 1px var(--notifi-font-color) solid;
+}
+
+.EventTypeTradingPairsRow__addPair {
+  display: inline-block;
+  align-self: flex-start;
+  cursor: pointer;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--notifi-link-color);
+  font-size: 16px;
+  line-height: 20px;
+}
+
+.EventTypeTradingPairsRow__addPair:disabled {
+  cursor: default;
+  color: var(--notifi-secondary-font-color);
+}
+
+.EventTypeTradingPairsRow__addPair::before {
+  content: '+ ';
+}
+
+.TradingPairSettingsRow__container {
+  display: flex;
+  align-items: stretch;
+  flex-direction: column;
+  padding: 10px 0;
+}
+
+.TradingPairSettingsRow__dropdownContainer {
+  background-color: var(--notifi-input-background);
+  display: flex;
+  align-items: center;
+  border: 1px var(--notifi-input-border) solid;
+  border-radius: 5px;
+}
+
+.TradingPairSettingsRow__dropdownContainer::after {
+  content: '';
+  width: 1em;
+  height: 1em;
+  margin-right: 10px;
+  background-color: var(--notifi-font-color);
+  clip-path: polygon(90% 30%, 10% 30%, 50% 70%);
+}
+
+.TradingPairSettingsRow__dropdown {
+  box-sizing: border-box;
+  appearance: none;
+  background-color: transparent;
+  border: none;
+  padding: 10px 20px;
+  margin: 0;
+  width: 100%;
+  color: inherit;
+  cursor: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  outline: none;
+}
+
+.TradingPairSettingsRow__radioButton {
+  font-size: 16px;
+  line-height: 20px;
+  padding: 10px 30px;
+  margin-right: 10px;
+  margin-bottom: 0 !important;
+  border-radius: 5px;
+  border: none;
+  color: #000;
+  background-color: var(--notifi-tooltip-background);
+  cursor: pointer;
+}
+.TradingPairSettingsRow__radioSelected {
+  color: var(--notifi-button-text);
+  background-color: var(--notifi-button-color);
+}
+
+.TradingPairAlertRow__container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 10px 0;
+}
+
+.TradingPairAlertRow__name {
+  flex-grow: 1;
+  margin-bottom: 0 !important;
+}
+
+.TradingPairAlertRow__deleteIcon {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+}
+
+.TradingPairSettingsRow__priceInputContainer {
+  background-color: var(--notifi-input-background);
+  display: flex;
+  align-items: center;
+  border: 1px var(--notifi-input-border) solid;
+  border-radius: 5px;
+}
+
+.TradingPairSettingsRow__priceInput {
+  box-sizing: border-box;
+  appearance: none;
+  background-color: transparent;
+  border: none;
+  padding: 10px 20px;
+  margin: 0;
+  width: 100%;
+  color: inherit;
+  cursor: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  outline: none;
+}
+
+.TradingPairSettingsRow__saveButton {
+  font-size: 16px;
+  line-height: 20px;
+  padding: 5px 20px;
+  align-self: flex-start;
+  border-radius: 5px;
+  border: none;
+  color: var(--notifi-button-text);
+  background-color: var(--notifi-button-color);
+  cursor: pointer;
+}
+
+.TradingPairSettingsRow__saveButton:disabled {
+  cursor: default;
+  color: var(--notifi-secondary-font-color);
+  background-color: var(--notifi-button-disabled-color);
+}

--- a/packages/notifi-react-card/lib/components/intercom/NotifiIntercomFTUNotificationTargetSection.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/NotifiIntercomFTUNotificationTargetSection.tsx
@@ -24,7 +24,7 @@ export type NotifiIntercomFTUNotificationTargetSectionProps = Readonly<{
     toggle: NotifiToggleProps['classNames'];
   }>;
   data: IntercomCardConfigItemV1;
-  inputs: Record<string, string | undefined>;
+  inputs: Record<string, unknown>;
   inputTextFields?: NotifiInputFieldsText;
   inputSeparators?: NotifiInputSeparators;
 }>;

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeBroadcastRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeBroadcastRow.tsx
@@ -22,7 +22,7 @@ export type EventTypeBroadcastRowProps = Readonly<{
   }>;
   disabled: boolean;
   config: BroadcastEventTypeItem;
-  inputs: Record<string, string | undefined>;
+  inputs: Record<string, unknown>;
 }>;
 
 export const EventTypeBroadcastRow: React.FC<EventTypeBroadcastRowProps> = ({

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeDirectPushRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeDirectPushRow.tsx
@@ -22,7 +22,7 @@ export type EventTypeDirectPushRowProps = Readonly<{
   }>;
   disabled: boolean;
   config: DirectPushEventTypeItem;
-  inputs: Record<string, string | undefined>;
+  inputs: Record<string, unknown>;
 }>;
 
 export const EventTypeDirectPushRow: React.FC<EventTypeDirectPushRowProps> = ({

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeTradingPairsRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeTradingPairsRow.tsx
@@ -148,9 +148,11 @@ export type TradingPairSettingsRowProps = Readonly<{
     radioButton: string;
     container: string;
     dropdown: string;
+    dropdownContainer: string;
     label: string;
     option: string;
     priceInput: string;
+    priceInputContainer: string;
     saveButton: string;
   }>;
   config: TradingPairEventTypeItem;
@@ -186,34 +188,44 @@ export const TradingPairSettingsRow: React.FC<TradingPairSettingsRowProps> = ({
         classNames?.container,
       )}
     >
-      <select
+      <div
         className={clsx(
-          'TradingPairSettingsRow__dropdown',
-          classNames?.dropdown,
+          'TradingPairSettingsRow__dropdownContainer',
+          classNames?.dropdownContainer,
         )}
-        onChange={(e) => setSelectedPair(e.target.value)}
-        value={selectedPair}
       >
-        <option
-          className={clsx('TradingPairSettingsRow__option', classNames?.option)}
-          key="unselected"
-          value={undefined}
+        <select
+          className={clsx(
+            'TradingPairSettingsRow__dropdown',
+            classNames?.dropdown,
+          )}
+          onChange={(e) => setSelectedPair(e.target.value)}
+          value={selectedPair}
         >
-          Select a trading pair
-        </option>
-        {tradingPairs.map((pair) => (
           <option
             className={clsx(
               'TradingPairSettingsRow__option',
               classNames?.option,
             )}
-            key={pair}
-            value={pair}
+            key="unselected"
+            value={undefined}
           >
-            {pair}
+            Select a trading pair
           </option>
-        ))}
-      </select>
+          {tradingPairs.map((pair) => (
+            <option
+              className={clsx(
+                'TradingPairSettingsRow__option',
+                classNames?.option,
+              )}
+              key={pair}
+              value={pair}
+            >
+              {pair}
+            </option>
+          ))}
+        </select>
+      </div>
       <div
         className={clsx(
           'TradingPairSettingsRow__buttonContainer',
@@ -241,23 +253,32 @@ export const TradingPairSettingsRow: React.FC<TradingPairSettingsRowProps> = ({
           Below
         </button>
       </div>
-      <input
+      <div
         className={clsx(
-          'TradingPairSettingsRow__priceInput',
-          classNames?.priceInput,
+          'TradingPairSettingsRow__priceInputContainer',
+          classNames?.priceInputContainer,
         )}
-        name="notifi-tradingpair-price"
-        type="number"
-        value={price}
-        onChange={(e) => {
-          setPrice(e.target.valueAsNumber);
-        }}
-      />
+      >
+        <input
+          className={clsx(
+            'TradingPairSettingsRow__priceInput',
+            classNames?.priceInput,
+          )}
+          name="notifi-tradingpair-price"
+          type="text"
+          inputMode="numeric"
+          value={price}
+          onChange={(e) => {
+            setPrice(e.target.valueAsNumber);
+          }}
+        />
+      </div>
       <button
         className={clsx(
           'TradingPairSettingsRow__saveButton',
           classNames?.saveButton,
         )}
+        disabled={selectedPair === undefined}
         onClick={async () => {
           if (selectedPair !== undefined) {
             const alertConfiguration = tradingPairContiguration({

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeTradingPairsRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeTradingPairsRow.tsx
@@ -1,0 +1,291 @@
+import clsx from 'clsx';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+
+import { BackArrow } from '../../assets/backArrow';
+import { useNotifiSubscriptionContext } from '../../context';
+import { TradingPairEventTypeItem, useNotifiSubscribe } from '../../hooks';
+import { DeepPartialReadonly, tradingPairContiguration } from '../../utils';
+import { NotifiTooltip, NotifiTooltipProps } from './NotifiTooltip';
+import { resolveStringArrayRef } from './resolveRef';
+
+export type EventTypeTradingPairsRowProps = Readonly<{
+  classNames?: DeepPartialReadonly<{
+    container: string;
+    label: string;
+    addPair: string;
+    tooltip: NotifiTooltipProps['classNames'];
+    tradingPairAlertRow: TradingPairAlertRowProps['classNames'];
+    tradingPairSettingsRow: TradingPairSettingsRowProps['classNames'];
+  }>;
+  config: TradingPairEventTypeItem;
+  inputs: Record<string, unknown>;
+}>;
+
+export const EventTypeTradingPairsRow: React.FC<
+  EventTypeTradingPairsRowProps
+> = ({ classNames, config, inputs }: EventTypeTradingPairsRowProps) => {
+  const { name, tooltipContent } = config;
+  const { alerts } = useNotifiSubscriptionContext();
+
+  const tradingPairAlertNames = useMemo(() => {
+    if (alerts === undefined) {
+      return [];
+    }
+
+    return Object.keys(alerts).filter((alertName) => {
+      return alertName.indexOf(config.name) >= 0;
+    });
+  }, [alerts, config.name]);
+
+  const [showInput, setShowInput] = useState(false);
+  const hasSetInput = useRef(false);
+  useEffect(() => {
+    if (!hasSetInput.current && alerts !== undefined) {
+      hasSetInput.current = true;
+      setShowInput(tradingPairAlertNames.length === 0);
+    }
+  }, [alerts, tradingPairAlertNames]);
+
+  return (
+    <div
+      className={clsx(
+        'EventTypeTradingPairsRow__container',
+        classNames?.container,
+      )}
+    >
+      <div
+        className={clsx('EventTypeTradingPairsRow__label', classNames?.label)}
+      >
+        {name}
+        {tooltipContent !== undefined && tooltipContent.length > 0 ? (
+          <NotifiTooltip
+            classNames={classNames?.tooltip}
+            content={tooltipContent}
+          />
+        ) : null}
+      </div>
+      {tradingPairAlertNames.map((alertName) => {
+        return (
+          <TradingPairAlertRow
+            key={alertName}
+            classNames={classNames?.tradingPairAlertRow}
+            label={alertName}
+            alertName={alertName}
+          />
+        );
+      })}
+      {showInput ? (
+        <TradingPairSettingsRow
+          classNames={classNames?.tradingPairSettingsRow}
+          config={config}
+          inputs={inputs}
+          onSave={() => {
+            setShowInput(false);
+          }}
+        />
+      ) : null}
+      <button
+        className={clsx(
+          'EventTypeTradingPairsRow__addPair',
+          classNames?.addPair,
+        )}
+        disabled={showInput}
+        onClick={() => {
+          setShowInput(true);
+        }}
+      >
+        Add pair
+      </button>
+    </div>
+  );
+};
+
+export type TradingPairAlertRowProps = Readonly<{
+  classNames?: DeepPartialReadonly<{
+    container: string;
+    name: string;
+    deleteIcon: string;
+  }>;
+  label: string;
+  alertName: string;
+}>;
+
+export const TradingPairAlertRow: React.FC<TradingPairAlertRowProps> = ({
+  classNames,
+  label,
+  alertName,
+}: TradingPairAlertRowProps) => {
+  const { instantSubscribe } = useNotifiSubscribe({
+    targetGroupName: 'Default',
+  });
+  return (
+    <div
+      className={clsx('TradingPairAlertRow__container', classNames?.container)}
+    >
+      <span className={clsx('TradingPairAlertRow__name', classNames?.name)}>
+        {label}
+      </span>
+      <div
+        className={clsx(
+          'TradingPairAlertRow__deleteIcon',
+          classNames?.deleteIcon,
+        )}
+        onClick={() => {
+          instantSubscribe({
+            alertConfiguration: null,
+            alertName,
+          });
+        }}
+      >
+        <BackArrow />
+      </div>
+    </div>
+  );
+};
+export type TradingPairSettingsRowProps = Readonly<{
+  classNames?: DeepPartialReadonly<{
+    buttonContainer: string;
+    radioButton: string;
+    container: string;
+    dropdown: string;
+    label: string;
+    option: string;
+    priceInput: string;
+    saveButton: string;
+  }>;
+  config: TradingPairEventTypeItem;
+  inputs: Record<string, unknown>;
+  onSave: () => void;
+}>;
+
+export const TradingPairSettingsRow: React.FC<TradingPairSettingsRowProps> = ({
+  classNames,
+  config,
+  inputs,
+  onSave,
+}: TradingPairSettingsRowProps) => {
+  const tradingPairs = resolveStringArrayRef(
+    config.name,
+    config.tradingPairs,
+    inputs,
+  );
+
+  const [selectedPair, setSelectedPair] = useState<string | undefined>(
+    undefined,
+  );
+  const [above, setAbove] = useState<boolean>(true);
+  const [price, setPrice] = useState<number>(0.0);
+  const { instantSubscribe } = useNotifiSubscribe({
+    targetGroupName: 'Default',
+  });
+
+  return (
+    <div
+      className={clsx(
+        'TradingPairSettingsRow__container',
+        classNames?.container,
+      )}
+    >
+      <select
+        className={clsx(
+          'TradingPairSettingsRow__dropdown',
+          classNames?.dropdown,
+        )}
+        onChange={(e) => setSelectedPair(e.target.value)}
+        value={selectedPair}
+      >
+        <option
+          className={clsx('TradingPairSettingsRow__option', classNames?.option)}
+          key="unselected"
+          value={undefined}
+        >
+          Select a trading pair
+        </option>
+        {tradingPairs.map((pair) => (
+          <option
+            className={clsx(
+              'TradingPairSettingsRow__option',
+              classNames?.option,
+            )}
+            key={pair}
+            value={pair}
+          >
+            {pair}
+          </option>
+        ))}
+      </select>
+      <div
+        className={clsx(
+          'TradingPairSettingsRow__buttonContainer',
+          classNames?.buttonContainer,
+        )}
+      >
+        <button
+          className={clsx(
+            'TradingPairSettingsRow__radioButton',
+            classNames?.radioButton,
+            { TradingPairSettingsRow__radioSelected: above },
+          )}
+          onClick={() => setAbove(true)}
+        >
+          Above
+        </button>
+        <button
+          className={clsx(
+            'TradingPairSettingsRow__radioButton',
+            classNames?.radioButton,
+            { TradingPairSettingsRow__radioSelected: !above },
+          )}
+          onClick={() => setAbove(false)}
+        >
+          Below
+        </button>
+      </div>
+      <input
+        className={clsx(
+          'TradingPairSettingsRow__priceInput',
+          classNames?.priceInput,
+        )}
+        name="notifi-tradingpair-price"
+        type="number"
+        value={price}
+        onChange={(e) => {
+          setPrice(e.target.valueAsNumber);
+        }}
+      />
+      <button
+        className={clsx(
+          'TradingPairSettingsRow__saveButton',
+          classNames?.saveButton,
+        )}
+        onClick={async () => {
+          if (selectedPair !== undefined) {
+            const alertConfiguration = tradingPairContiguration({
+              tradingPair: selectedPair,
+              above,
+              price,
+            });
+
+            const now = new Date().toISOString();
+
+            const alertName = `${config.name}:;:${now}:;:${selectedPair}:;:${
+              above ? 'above' : 'below'
+            }:;:${price}`;
+
+            await instantSubscribe({
+              alertName,
+              alertConfiguration,
+            });
+
+            setSelectedPair(undefined);
+            setAbove(true);
+            setPrice(0.0);
+            onSave();
+          }
+        }}
+      >
+        Save
+      </button>
+    </div>
+  );
+};

--- a/packages/notifi-react-card/lib/components/subscription/FetchedStateCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/FetchedStateCard.tsx
@@ -16,7 +16,7 @@ export type FetchedStateCardProps = Readonly<{
   }>;
   card: FetchedState;
   inputDisabled: boolean;
-  inputs: Record<string, string | undefined>;
+  inputs: Record<string, unknown>;
   inputLabels?: NotifiInputFieldsText;
   inputSeparators?: NotifiInputSeparators;
 }>;

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCard.tsx
@@ -58,7 +58,7 @@ export type NotifiSubscriptionCardProps = Readonly<{
   inputLabels?: NotifiInputFieldsText;
   darkMode?: boolean;
   cardId: string;
-  inputs?: Record<string, string | undefined>;
+  inputs?: Record<string, unknown>;
   inputSeparators?: NotifiInputSeparators;
 }>;
 

--- a/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
@@ -38,7 +38,7 @@ export type SubscriptionCardV1Props = Readonly<{
   };
   inputDisabled: boolean;
   data: CardConfigItemV1;
-  inputs: Record<string, string | undefined>;
+  inputs: Record<string, unknown>;
   inputLabels?: NotifiInputFieldsText;
   inputSeparators?: NotifiInputSeparators;
 }>;

--- a/packages/notifi-react-card/lib/components/subscription/resolveRef.ts
+++ b/packages/notifi-react-card/lib/components/subscription/resolveRef.ts
@@ -35,3 +35,12 @@ export const resolveStringRef = createRefResolver(
     return typeof item === 'string';
   },
 );
+
+export const resolveStringArrayRef = createRefResolver(
+  (item: unknown): item is ReadonlyArray<string> => {
+    return (
+      Array.isArray(item) &&
+      item.every((element) => typeof element === 'string')
+    );
+  },
+);

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/PreviewCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/PreviewCard.tsx
@@ -21,7 +21,7 @@ export type PreviewCardProps = Readonly<{
   };
   data: CardConfigItemV1;
   inputDisabled: boolean;
-  inputs: Record<string, string | undefined>;
+  inputs: Record<string, unknown>;
 }>;
 
 export const PreviewCard: React.FC<PreviewCardProps> = ({

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/AlertsPanel.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/AlertsPanel.tsx
@@ -18,6 +18,10 @@ import {
   EventTypeLabelRowProps,
 } from '../../EventTypeLabelRow';
 import {
+  EventTypeTradingPairsRow,
+  EventTypeTradingPairsRowProps,
+} from '../../EventTypeTradingPairsRow';
+import {
   EventTypeUnsupportedRow,
   EventTypeUnsupportedRowProps,
 } from '../../EventTypeUnsupportedRow';
@@ -30,9 +34,10 @@ export type AlertsPanelProps = Readonly<{
     EventTypeDirectPushRow?: EventTypeDirectPushRowProps['classNames'];
     EventTypeHealthCheckRow?: EventTypeHealthCheckRowProps['classNames'];
     EventTypeLabelRow?: EventTypeLabelRowProps['classNames'];
+    EventTypeTradingPairsRow?: EventTypeTradingPairsRowProps['classNames'];
     EventTypeUnsupportedRow?: EventTypeUnsupportedRowProps['classNames'];
   }>;
-  inputs: Record<string, string | undefined>;
+  inputs: Record<string, unknown>;
 }>;
 export const AlertsPanel: React.FC<AlertsPanelProps> = ({
   data,
@@ -79,6 +84,15 @@ export const AlertsPanel: React.FC<AlertsPanelProps> = ({
                 key={eventType.name}
                 classNames={classNames?.EventTypeLabelRow}
                 config={eventType}
+              />
+            );
+          case 'tradingPair':
+            return (
+              <EventTypeTradingPairsRow
+                key={eventType.name}
+                classNames={classNames?.EventTypeTradingPairsRow}
+                config={eventType}
+                inputs={inputs}
               />
             );
           default:

--- a/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
+++ b/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
@@ -49,11 +49,19 @@ export type LabelEventTypeItem = Readonly<{
   tooltipContent?: string;
 }>;
 
+export type TradingPairEventTypeItem = Readonly<{
+  type: 'tradingPair';
+  name: string;
+  tooltipContent?: string;
+  tradingPairs: ValueOrRef<ReadonlyArray<string>>;
+}>;
+
 export type EventTypeItem =
   | DirectPushEventTypeItem
   | BroadcastEventTypeItem
   | HealthCheckEventTypeItem
-  | LabelEventTypeItem;
+  | LabelEventTypeItem
+  | TradingPairEventTypeItem;
 
 export type EventTypeConfig = ReadonlyArray<EventTypeItem>;
 export type InputType =

--- a/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
+++ b/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
@@ -88,6 +88,33 @@ export const hedgeProtocolConfiguration = ({
   };
 };
 
+export const tradingPairContiguration = ({
+  tradingPair,
+  above,
+  price,
+}: Readonly<{
+  tradingPair: string;
+  above: boolean;
+  price: number;
+}>): AlertConfiguration => {
+  return {
+    sourceType: 'DIRECT_PUSH',
+    filterType: 'DIRECT_TENANT_MESSAGES',
+    filterOptions: {
+      tradingPair,
+      values: {
+        and: [
+          {
+            key: 'spotPrice',
+            op: above ? 'gt' : 'lt',
+            value: price.toFixed(8),
+          },
+        ],
+      },
+    },
+  };
+};
+
 export const createConfigurations = (
   eventTypes: EventTypeConfig,
 ): Record<string, AlertConfiguration> => {


### PR DESCRIPTION
For now, add a tradingPair renderer which subscribes to Direct Tenant Messages.

This is the first instance where we have one "EventItem" that resutls in many Alerts. We need to be able to associate it to the one EventItem, so for now encode the information within alert.name.

![Screen Shot 2023-01-11 at 9 41 55 PM](https://user-images.githubusercontent.com/100658137/211987043-1307f62a-bce6-4e94-9c71-92105e395ec4.png)
![Screen Shot 2023-01-11 at 9 42 13 PM](https://user-images.githubusercontent.com/100658137/211987059-f544733d-1f16-4107-bcf4-7df18be6fca7.png)
![Screen Shot 2023-01-11 at 9 41 42 PM](https://user-images.githubusercontent.com/100658137/211987076-f4694b40-eae5-46ab-9c00-b41465430c98.png)
