### PR TITLE
Expose add/remove Source to/from SourceGroup

### DIFF
--- a/packages/notifi-graphql/lib/NotifiService.ts
+++ b/packages/notifi-graphql/lib/NotifiService.ts
@@ -7,6 +7,7 @@ import type * as Operations from './operations';
 
 export class NotifiService
   implements
+    Operations.AddSourceToSourceGroupService,
     Operations.BeginLogInByTransactionService,
     Operations.BroadcastMessageService,
     Operations.CompleteLogInByTransactionService,
@@ -43,6 +44,7 @@ export class NotifiService
     Operations.LogInFromDappService,
     Operations.LogInFromServiceService,
     Operations.RefreshAuthorizationService,
+    Operations.RemoveSourceFromSourceGroupService,
     Operations.SendEmailTargetVerificationRequestService,
     Operations.SendMessageService,
     Operations.UpdateSourceGroupService,
@@ -61,6 +63,13 @@ export class NotifiService
 
   async logOut(): Promise<void> {
     this._jwt = undefined;
+  }
+
+  async addSourceToSourceGroup(
+    variables: Generated.AddSourceToSourceGroupMutationVariables,
+  ): Promise<Generated.AddSourceToSourceGroupMutation> {
+    const headers = this._requestHeaders();
+    return this._typedClient.addSourceToSourceGroup(variables, headers);
   }
 
   async beginLogInByTransaction(
@@ -346,6 +355,13 @@ export class NotifiService
       this._jwt = token;
     }
     return result;
+  }
+
+  async removeSourceFromSourceGroup(
+    variables: Generated.RemoveSourceFromSourceGroupMutationVariables,
+  ): Promise<Generated.RemoveSourceFromSourceGroupMutation> {
+    const headers = this._requestHeaders();
+    return this._typedClient.removeSourceFromSourceGroup(variables, headers);
   }
 
   async sendEmailTargetVerificationRequest(

--- a/packages/notifi-graphql/lib/gql/mutations/addSourceToSourceGroup.gql.ts
+++ b/packages/notifi-graphql/lib/gql/mutations/addSourceToSourceGroup.gql.ts
@@ -1,0 +1,12 @@
+import { gql } from 'graphql-request';
+
+import { SourceGroupFragment } from '../fragments/SourceGroupFragment.gql';
+
+export const AddSourceToSourceGroup = gql`
+  ${SourceGroupFragment}
+  mutation addSourceToSourceGroup($input: AddSourceToSourceGroupInput!) {
+    addSourceToSourceGroup(addSourceToSourceGroupInput: $input) {
+      ...SourceGroupFragment
+    }
+  }
+`;

--- a/packages/notifi-graphql/lib/gql/mutations/removeSourceFromSourceGroup.gql.ts
+++ b/packages/notifi-graphql/lib/gql/mutations/removeSourceFromSourceGroup.gql.ts
@@ -1,0 +1,14 @@
+import { gql } from 'graphql-request';
+
+import { SourceGroupFragment } from '../fragments/SourceGroupFragment.gql';
+
+export const removeSourceFromSourceGroup = gql`
+  ${SourceGroupFragment}
+  mutation removeSourceFromSourceGroup(
+    $input: RemoveSourceFromSourceGroupInput!
+  ) {
+    removeSourceFromSourceGroup(removeSourceFromSourceGroupInput: $input) {
+      ...SourceGroupFragment
+    }
+  }
+`;

--- a/packages/notifi-graphql/lib/operations/AddSourceToSourceGroup.ts
+++ b/packages/notifi-graphql/lib/operations/AddSourceToSourceGroup.ts
@@ -1,0 +1,10 @@
+import {
+  AddSourceToSourceGroupMutation,
+  AddSourceToSourceGroupMutationVariables,
+} from '../gql/generated';
+
+export type AddSourceToSourceGroupService = Readonly<{
+  addSourceToSourceGroup: (
+    variables: AddSourceToSourceGroupMutationVariables,
+  ) => Promise<AddSourceToSourceGroupMutation>;
+}>;

--- a/packages/notifi-graphql/lib/operations/RemoveSourceFromSourceGroup.ts
+++ b/packages/notifi-graphql/lib/operations/RemoveSourceFromSourceGroup.ts
@@ -1,0 +1,10 @@
+import {
+  RemoveSourceFromSourceGroupMutation,
+  RemoveSourceFromSourceGroupMutationVariables,
+} from '../gql/generated';
+
+export type RemoveSourceFromSourceGroupService = Readonly<{
+  removeSourceFromSourceGroup: (
+    variables: RemoveSourceFromSourceGroupMutationVariables,
+  ) => Promise<RemoveSourceFromSourceGroupMutation>;
+}>;

--- a/packages/notifi-graphql/lib/operations/index.ts
+++ b/packages/notifi-graphql/lib/operations/index.ts
@@ -1,3 +1,4 @@
+export * from './AddSourceToSourceGroup';
 export * from './BeginLogInByTransaction';
 export * from './BroadcastMessage';
 export * from './CompleteLogInByTransaction';
@@ -35,6 +36,7 @@ export * from './GetWebhookTargets';
 export * from './LogInFromDappService';
 export * from './LogInFromServiceService';
 export * from './RefreshAuthorization';
+export * from './RemoveSourceFromSourceGroup';
 export * from './SendMessageService';
 export * from './SendEmailTargetVerificationRequest';
 export * from './UpdateSourceGroup';

--- a/packages/notifi-node-sample/lib/index.ts
+++ b/packages/notifi-node-sample/lib/index.ts
@@ -443,6 +443,124 @@ app.post('/sendDirectPush', authorizeMiddleware, (req, res) => {
     });
 });
 
+app.post('/addSourceToSourceGroup', authorizeMiddleware, (req, res) => {
+  const jwt: string = res.locals.jwt;
+
+  const {
+    sourceGroupId,
+    sourceId,
+    walletAddress,
+    sourceType,
+  }: Readonly<{
+    sourceGroupId?: string;
+    sourceId?: string;
+    walletAddress?: string;
+    sourceType?: string;
+  }> = req.body ?? {};
+
+  if (sourceGroupId === undefined) {
+    return res.status(400).json({
+      message: 'walletPublicKey is required',
+    });
+  }
+
+  if (sourceId === undefined) {
+    if (walletAddress === undefined || sourceType === undefined) {
+      return res.status(400).json({
+        message:
+          'Both walletAddress and sourceType are required if sourceId is not provided',
+      });
+    }
+  } else if (walletAddress !== undefined || sourceType === undefined) {
+    return res.status(400).json({
+      message: 'Cannot provide both sourceId and walletAddress/sourceType',
+    });
+  }
+
+  const client = new NotifiClient(res.locals.notifiService);
+
+  return client
+    .addSourceToSourceGroup(jwt, {
+      sourceGroupId,
+      sourceId,
+      walletAddress,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sourceType: sourceType as any,
+    })
+    .then((sourceGroup) => {
+      return res.status(200).json({ sourceGroup });
+    })
+    .catch((e: unknown) => {
+      let message = 'Unknown server error';
+      if (e instanceof GqlError) {
+        message = `${e.message}: ${e.getErrorMessages().join(', ')}`;
+      } else if (e instanceof Error) {
+        message = e.message;
+      }
+
+      return res.status(500).json({ message });
+    });
+});
+
+app.post('/removeSourceFromSourceGroup', authorizeMiddleware, (req, res) => {
+  const jwt: string = res.locals.jwt;
+
+  const {
+    sourceGroupId,
+    sourceId,
+    walletAddress,
+    sourceType,
+  }: Readonly<{
+    sourceGroupId?: string;
+    sourceId?: string;
+    walletAddress?: string;
+    sourceType?: string;
+  }> = req.body ?? {};
+
+  if (sourceGroupId === undefined) {
+    return res.status(400).json({
+      message: 'walletPublicKey is required',
+    });
+  }
+
+  if (sourceId === undefined) {
+    if (walletAddress === undefined || sourceType === undefined) {
+      return res.status(400).json({
+        message:
+          'Both walletAddress and sourceType are required if sourceId is not provided',
+      });
+    }
+  } else if (walletAddress !== undefined || sourceType === undefined) {
+    return res.status(400).json({
+      message: 'Cannot provide both sourceId and walletAddress/sourceType',
+    });
+  }
+
+  const client = new NotifiClient(res.locals.notifiService);
+
+  return client
+    .removeSourceFromSourceGroup(jwt, {
+      sourceGroupId,
+      sourceId,
+      walletAddress,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sourceType: sourceType as any,
+    })
+    .then((sourceGroup) => {
+      return res.status(200).json({ sourceGroup });
+    })
+    .catch((e: unknown) => {
+      let message = 'Unknown server error';
+      if (e instanceof GqlError) {
+        message = `${e.message}: ${e.getErrorMessages().join(', ')}`;
+      } else if (e instanceof Error) {
+        message = e.message;
+      }
+
+      return res.status(500).json({ message });
+    });
+});
+
 app.listen(port, () => {
   console.log(`Listening on ${port}`);
 });

--- a/packages/notifi-node/lib/client/NotifiClient.ts
+++ b/packages/notifi-node/lib/client/NotifiClient.ts
@@ -284,6 +284,32 @@ class NotifiClient {
     return alert;
   };
 
+  addSourceToSourceGroup: (
+    jwt: string,
+    input: Gql.AddSourceToSourceGroupMutationVariables['input'],
+  ) => Promise<Gql.SourceGroupFragmentFragment> = async (jwt, input) => {
+    this.service.setJwt(jwt);
+    const result = await this.service.addSourceToSourceGroup({ input });
+    if (result.addSourceToSourceGroup === undefined) {
+      throw new Error('Failed to add Source to SourceGroup');
+    }
+
+    return result.addSourceToSourceGroup;
+  };
+
+  removeSourceFromSourceGroup: (
+    jwt: string,
+    input: Gql.RemoveSourceFromSourceGroupMutationVariables['input'],
+  ) => Promise<Gql.SourceGroupFragmentFragment> = async (jwt, input) => {
+    this.service.setJwt(jwt);
+    const result = await this.service.removeSourceFromSourceGroup({ input });
+    if (result.removeSourceFromSourceGroup === undefined) {
+      throw new Error('Failed to remove Source from SourceGroup');
+    }
+
+    return result.removeSourceFromSourceGroup;
+  };
+
   getOrCreateSourceGroup: (
     name: string,
   ) => Promise<Gql.SourceGroupFragmentFragment> = async (name) => {


### PR DESCRIPTION
This operation will be useful for clients who are managing SourceGroups with a lot of Sources.

Remaining work:
- expose `sources` Connection
- make sure SourceGroups with a lot of sources don't go through the array field on SourceGroup
