### PR TITLE
[MVP-2002] only show avatar and sender name for the first message

### DIFF
--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -941,6 +941,11 @@ input:-webkit-autofill {
   overflow-y: auto;
 }
 
+.NotifiIntercomChatMessageList__groupContainer {
+  display: flex;
+  flex-direction: row;
+}
+
 .ChatWindowIntro__virtualContainer {
   height: 80px;
   color: red;
@@ -1033,7 +1038,6 @@ input:-webkit-autofill {
 .NotifiIntercomChatIncomingMessage__container {
   display: flex;
   flex-direction: row;
-  margin-left: 16px;
 }
 
 .NotifiIntercomChatIncomingMessage__body {
@@ -1111,6 +1115,7 @@ input:-webkit-autofill {
   border-radius: 20px;
   background-color: #f5f6fb;
   height: 34px;
+  margin-left: 16px;
 }
 
 .NotifiExpiredTokenCard__container {

--- a/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
@@ -311,7 +311,16 @@ export const IntercomCard: React.FC<
       );
       break;
     case 'loadingView':
-      view = <div>Loading&#8230;</div>;
+      view = (
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+          }}
+        >
+          Loading&#8230;
+        </div>
+      );
       break;
   }
   return <>{view}</>;

--- a/packages/notifi-react-card/lib/components/intercom/MessageGroup.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/MessageGroup.tsx
@@ -11,7 +11,6 @@ export type MessageGroupProps = Readonly<{
     messageBody: string;
     timeStamp: string;
     sender: string;
-    avatar: string;
   }>;
   messages: ChatMessage[];
   direction: string;
@@ -32,7 +31,6 @@ export const MessageGroup: React.FC<MessageGroupProps> = ({
       )}
     >
       {messages.map((message, index) => {
-        const participantProfile = message.conversationParticipant.profile;
         return (
           <div
             className={clsx(
@@ -43,23 +41,6 @@ export const MessageGroup: React.FC<MessageGroupProps> = ({
             )}
             key={index}
           >
-            {isIncoming ? (
-              <img
-                src={
-                  participantProfile.avatarDataType === 'URL'
-                    ? participantProfile.avatarData
-                    : ''
-                }
-                onError={(e) => {
-                  const img = e.target as HTMLImageElement;
-                  img.style.display = 'none';
-                }}
-                className={clsx(
-                  'NotifiIntercomChatMessage__avatar',
-                  classNames?.avatar,
-                )}
-              />
-            ) : null}
             <div
               key={index}
               className={clsx(
@@ -69,7 +50,7 @@ export const MessageGroup: React.FC<MessageGroupProps> = ({
                 classNames?.messageBody,
               )}
             >
-              {isIncoming ? (
+              {isIncoming && index === 0 ? (
                 <div
                   className={clsx(
                     'NotifiIntercomChatOutgoingMessage__sender',

--- a/packages/notifi-react-card/lib/components/intercom/MessageList.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/MessageList.tsx
@@ -8,6 +8,7 @@ export type MessageListProps = Readonly<{
   classNames?: Readonly<{
     container: string;
     messageGroup: MessageGroupProps['classNames'];
+    avatar: string;
   }>;
   feed: FeedEntry;
 }>;
@@ -16,6 +17,8 @@ export const MessageList: React.FC<MessageListProps> = ({
   classNames,
   feed,
 }) => {
+  const isIncoming = feed.direction === 'INCOMING';
+  const participantProfile = feed.messages[0].conversationParticipant.profile;
   return (
     <div
       className={clsx(
@@ -23,11 +26,43 @@ export const MessageList: React.FC<MessageListProps> = ({
         classNames?.container,
       )}
     >
-      <MessageGroup
-        classNames={classNames?.messageGroup}
-        messages={feed.messages}
-        direction={feed.direction}
-      />
+      {isIncoming ? (
+        <div
+          className={clsx(
+            'NotifiIntercomChatMessageList__groupContainer',
+            classNames?.container,
+          )}
+        >
+          <img
+            src={
+              participantProfile.avatarDataType === 'URL'
+                ? participantProfile.avatarData
+                : ''
+            }
+            onError={(e) => {
+              const img = e.target as HTMLImageElement;
+              img.style.display = 'none';
+            }}
+            className={clsx(
+              'NotifiIntercomChatMessage__avatar',
+              classNames?.avatar,
+            )}
+          />
+          <MessageGroup
+            classNames={classNames?.messageGroup}
+            messages={feed.messages}
+            direction={feed.direction}
+          />
+        </div>
+      ) : (
+        <>
+          <MessageGroup
+            classNames={classNames?.messageGroup}
+            messages={feed.messages}
+            direction={feed.direction}
+          />
+        </>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
We are currently have the avatar and sender name for each incoming message
should only show the sender name and avatar for the first incoming message in messages group
also fix the loading... content on loading view to be centered
test:
![Screenshot 2023-01-20 at 1 09 06 PM](https://user-images.githubusercontent.com/26240001/213807272-faddd1c5-d379-427e-afad-7d17af35013b.png)
![Screenshot 2023-01-20 at 1 15 36 PM](https://user-images.githubusercontent.com/26240001/213807334-b00f61e9-2c6d-412d-90d0-6c832b9d51b2.png)
