### PR TITLE
updates alert labels from showing up in the preview view

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/AlertListPreview.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/AlertListPreview.tsx
@@ -29,6 +29,10 @@ export const AlertListPreview: React.FC<AlertListProps> = ({
   description,
 }) => {
   const alertNames = eventTypes.map((eventType) => {
+    // skip showing alert previews for labels
+    if (eventType.type === 'label') {
+      return;
+    }
     return (
       <div className="NotifiAlertList__listItem">
         <Checkmark


### PR DESCRIPTION
<img width="391" alt="image" src="https://user-images.githubusercontent.com/105258726/220006445-51636cba-29b8-44bf-8c72-74bd19a17b9e.png">

Labels would show up in the preview panel because they're technically an 'event type' from the config tool.