### PR TITLE
updates react card css to add progress spinner

### DIFF
--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -440,6 +440,10 @@ input::-webkit-inner-spin-button {
   transform: translateX(var(--notifi-toggle-size));
 }
 
+.NotifiToggleSlider--disabled {
+  cursor: progress;
+}
+
 .NotifiIntercomToggle__input:checked + .NotifiToggle__slider {
   background-color: #1448f3;
 }

--- a/packages/notifi-react-card/lib/components/subscription/NotifiToggle.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiToggle.tsx
@@ -36,11 +36,9 @@ export const NotifiToggle: React.FC<NotifiToggleProps> = ({
         }}
       />
       <span
-        className={clsx(
-          'NotifiToggle__slider',
-          classNames?.slider,
-          disabled ? 'NotifiToggleSlider--disabled' : undefined,
-        )}
+        className={clsx('NotifiToggle__slider', classNames?.slider, {
+          'NotifiToggleSlider--disabled': disabled,
+        })}
       ></span>
     </label>
   );

--- a/packages/notifi-react-card/lib/components/subscription/NotifiToggle.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiToggle.tsx
@@ -35,7 +35,13 @@ export const NotifiToggle: React.FC<NotifiToggleProps> = ({
           setChecked(e.target.checked);
         }}
       />
-      <span className={clsx('NotifiToggle__slider', classNames?.slider)}></span>
+      <span
+        className={clsx(
+          'NotifiToggle__slider',
+          classNames?.slider,
+          disabled ? 'NotifiToggleSlider--disabled' : undefined,
+        )}
+      ></span>
     </label>
   );
 };


### PR DESCRIPTION
Previously we tried using css to update the Input but it's actually not visible,
instead we should add another class to the span when it's disabled that can be targeted.