### PR TITLE
Email confirmation link update

### DIFF
--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -21,6 +21,7 @@
   --notifi-incoming-message: #f5f6fb;
   --notifi-outgoing-message: #e5ebff;
   --notifi-settings-icon-color: #262949;
+  --notifi-confirmation-color: #22af3c;
 }
 
 .notifi__dark {
@@ -46,6 +47,7 @@
   --notifi-incoming-message: #474858;
   --notifi-outgoing-message: #678afc;
   --notifi-settings-icon-color: #fff;
+  --notifi-confirmation-color: #45c95e;
 }
 
 input:autofill,
@@ -1543,4 +1545,8 @@ input::-webkit-inner-spin-button {
   align-items: center;
   justify-content: start;
   gap: 20px;
+}
+
+.NotifiUserInfoPanel__emailConfirmationSent {
+  color: var(--notifi-confirmation-color);
 }

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/UserInfoPanel.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/UserInfoPanel.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { PenIcon } from 'notifi-react-card/lib/assets/PenIcon';
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import {
   useNotifiClientContext,
@@ -37,6 +37,9 @@ export const UserInfoPanel: React.FC<UserInfoPanelProps> = ({
   contactInfo,
   confirmationLabels,
 }) => {
+  const [isEmailConfirmationSent, setIsEmailConfirmationSent] =
+    useState<boolean>(false);
+
   const {
     phoneNumber,
     email,
@@ -59,7 +62,9 @@ export const UserInfoPanel: React.FC<UserInfoPanelProps> = ({
   }, [setCardView, phoneNumber, email, telegramId]);
 
   const handleResendEmailVerificationClick = useCallback(() => {
+    setIsEmailConfirmationSent(true);
     resendEmailVerificationLink();
+    setTimeout(() => setIsEmailConfirmationSent(false), 3000);
   }, []);
 
   return (
@@ -97,7 +102,9 @@ export const UserInfoPanel: React.FC<UserInfoPanelProps> = ({
                   classNames?.email?.confirmationLabel,
                 )}
               >
-                {confirmationLabels?.email ?? 'Resend Link'}
+                {confirmationLabels?.email ?? isEmailConfirmationSent
+                  ? 'Email sent!'
+                  : 'Resend Link'}
               </label>
             </a>
           ) : null}

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/UserInfoPanel.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/UserInfoPanel.tsx
@@ -100,6 +100,10 @@ export const UserInfoPanel: React.FC<UserInfoPanelProps> = ({
                 className={clsx(
                   'NotifiUserInfoPanel__emailConfirmationLabel',
                   classNames?.email?.confirmationLabel,
+                  {
+                    NotifiUserInfoPanel__emailConfirmationSent:
+                      isEmailConfirmationSent,
+                  },
                 )}
               >
                 {confirmationLabels?.email ?? isEmailConfirmationSent


### PR DESCRIPTION

https://user-images.githubusercontent.com/105258726/222253937-d3955319-795b-4d58-957c-c8b460fd4404.mov

Users wouldn't have "felt" that they sent an email confirmation.
This was previously built in another implementation.