### PR TITLE
Add fetchData function to frontendClient

### DIFF
--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -1,5 +1,6 @@
 import { Types } from '@notifi-network/notifi-graphql';
 import { NotifiService } from '@notifi-network/notifi-graphql';
+import { FetchDataQuery } from 'notifi-graphql/lib/gql/generated';
 
 import type { NotifiFrontendConfiguration } from '../configuration';
 import type { CardConfigItemV1, EventTypeItem } from '../models';
@@ -560,5 +561,45 @@ export class NotifiFrontendClient {
       throw new Error(`Unknown error requesting verification`);
     }
     return id;
+  }
+
+  async fetchData(): Promise<Required<FetchDataQuery>> {
+    const {
+      __typename,
+      alert,
+      emailTarget,
+      filter,
+      smsTarget,
+      source,
+      sourceGroup,
+      targetGroup,
+      telegramTarget,
+    } = await this._service.fetchData({});
+
+    if (
+      __typename === undefined ||
+      alert === undefined ||
+      emailTarget === undefined ||
+      filter === undefined ||
+      smsTarget === undefined ||
+      source === undefined ||
+      sourceGroup === undefined ||
+      targetGroup === undefined ||
+      telegramTarget == undefined
+    ) {
+      throw new Error(`Unknown error during fetchData`);
+    }
+
+    return {
+      __typename,
+      alert,
+      emailTarget,
+      filter,
+      smsTarget,
+      source,
+      sourceGroup,
+      targetGroup,
+      telegramTarget,
+    };
   }
 }

--- a/packages/notifi-graphql/lib/NotifiService.ts
+++ b/packages/notifi-graphql/lib/NotifiService.ts
@@ -26,6 +26,7 @@ export class NotifiService
     Operations.DeleteSourceGroupService,
     Operations.DeleteTargetGroupService,
     Operations.DeleteWebhookTargetService,
+    Operations.FetchDataService,
     Operations.FindTenantConfigService,
     Operations.GetAlertsService,
     Operations.GetConfigurationForDappService,
@@ -212,6 +213,13 @@ export class NotifiService
   ): Promise<Generated.DeleteWebhookTargetMutation> {
     const headers = this._requestHeaders();
     return this._typedClient.deleteWebhookTarget(variables, headers);
+  }
+
+  async fetchData(
+    variables: Generated.FetchDataQueryVariables,
+  ): Promise<Generated.FetchDataQuery> {
+    const headers = this._requestHeaders();
+    return this._typedClient.fetchData(variables, headers);
   }
 
   async findTenantConfig(

--- a/packages/notifi-graphql/lib/gql/queries/fetchData.gql.ts
+++ b/packages/notifi-graphql/lib/gql/queries/fetchData.gql.ts
@@ -1,0 +1,47 @@
+import { gql } from 'graphql-request';
+
+import { AlertFragment } from '../fragments/AlertFragment.gql';
+import { EmailTargetFragment } from '../fragments/EmailTargetFragment.gql';
+import { FilterFragment } from '../fragments/FilterFragment.gql';
+import { SmsTargetFragment } from '../fragments/SmsTargetFragment.gql';
+import { SourceFragment } from '../fragments/SourceFragment.gql';
+import { SourceGroupFragment } from '../fragments/SourceGroupFragment.gql';
+import { TargetGroupFragment } from '../fragments/TargetGroupFragment.gql';
+import { TelegramTargetFragment } from '../fragments/TelegramTargetFragment.gql';
+
+export const FetchData = gql`
+  query fetchData {
+    alert {
+      ...AlertFragment
+    }
+    emailTarget {
+      ...EmailTargetFragment
+    }
+    filter {
+      ...FilterFragment
+    }
+    smsTarget {
+      ...SmsTargetFragment
+    }
+    source {
+      ...SourceFragment
+    }
+    sourceGroup {
+      ...SourceGroupFragment
+    }
+    targetGroup {
+      ...TargetGroupFragment
+    }
+    telegramTarget {
+      ...TelegramTargetFragment
+    }
+  }
+  ${AlertFragment}
+  ${EmailTargetFragment}
+  ${FilterFragment}
+  ${SmsTargetFragment}
+  ${SourceFragment}
+  ${SourceGroupFragment}
+  ${TargetGroupFragment}
+  ${TelegramTargetFragment}
+`;

--- a/packages/notifi-graphql/lib/operations/FetchData.ts
+++ b/packages/notifi-graphql/lib/operations/FetchData.ts
@@ -1,0 +1,5 @@
+import type { FetchDataQuery, FetchDataQueryVariables } from '../gql/generated';
+
+export type FetchDataService = Readonly<{
+  fetchData: (variables: FetchDataQueryVariables) => Promise<FetchDataQuery>;
+}>;

--- a/packages/notifi-graphql/lib/operations/index.ts
+++ b/packages/notifi-graphql/lib/operations/index.ts
@@ -18,6 +18,7 @@ export * from './DeleteUserAlert';
 export * from './DeleteSourceGroup';
 export * from './DeleteTargetGroup';
 export * from './DeleteWebhookTarget';
+export * from './FetchData';
 export * from './FindTenantConfig';
 export * from './GetAlertsService';
 export * from './GetConfigurationForDapp';


### PR DESCRIPTION
As a proof-of-concept for future versions of the client, add a `fetchData` which fetches all of the data that are relevant to a user's state.