### PR TITLE
Make copy configurable from top level

### DIFF
--- a/packages/notifi-react-card/lib/components/common/ErrorStateCard.tsx
+++ b/packages/notifi-react-card/lib/components/common/ErrorStateCard.tsx
@@ -2,10 +2,14 @@ import clsx from 'clsx';
 import React from 'react';
 
 import { ErrorState } from '../../hooks';
+import { DeepPartialReadonly } from '../../utils';
 import NotifiAlertBox, { NotifiAlertBoxProps } from '../NotifiAlertBox';
 
 export type ErrorStateCardProps = Readonly<{
   card: ErrorState;
+  copy?: DeepPartialReadonly<{
+    header: string;
+  }>;
   classNames?: Readonly<{
     NotifiAlertBox?: NotifiAlertBoxProps['classNames'];
     label?: string;
@@ -16,6 +20,7 @@ export type ErrorStateCardProps = Readonly<{
 
 export const ErrorStateCard: React.FC<ErrorStateCardProps> = ({
   card,
+  copy,
   classNames,
   onClose,
 }) => {
@@ -32,7 +37,7 @@ export const ErrorStateCard: React.FC<ErrorStateCardProps> = ({
               }
         }
       >
-        <h2>Something went wrong</h2>
+        <h2>{copy?.header ?? 'Something went wrong'}</h2>
       </NotifiAlertBox>
       <div
         className={clsx(

--- a/packages/notifi-react-card/lib/components/common/LoadingStateCard.tsx
+++ b/packages/notifi-react-card/lib/components/common/LoadingStateCard.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import React from 'react';
 
 import { LoadingState } from '../../hooks';
+import { DeepPartialReadonly } from '../../utils';
 import NotifiAlertBox, { NotifiAlertBoxProps } from '../NotifiAlertBox';
 import Spinner from './Spinner';
 
@@ -9,6 +10,10 @@ export type LoadingStateCardProps = Readonly<{
   card: LoadingState;
   spinnerSize?: string;
   ringColor?: string;
+  copy?: DeepPartialReadonly<{
+    header: string;
+    content: string;
+  }>;
   classNames?: Readonly<{
     container?: string;
     label?: string;
@@ -18,6 +23,7 @@ export type LoadingStateCardProps = Readonly<{
 }>;
 
 export const LoadingStateCard: React.FC<LoadingStateCardProps> = ({
+  copy,
   classNames,
   spinnerSize,
   ringColor,
@@ -36,7 +42,7 @@ export const LoadingStateCard: React.FC<LoadingStateCardProps> = ({
               }
         }
       >
-        <h2>Something went wrong</h2>
+        <h2>{copy?.header ?? 'Loading'}</h2>
       </NotifiAlertBox>
       <div
         className={clsx(
@@ -47,7 +53,7 @@ export const LoadingStateCard: React.FC<LoadingStateCardProps> = ({
         <label
           className={clsx('NotifiLoadingStateCard__label', classNames?.label)}
         >
-          Loading...
+          {copy?.content ?? 'Loading…'}
         </label>
         <Spinner size={spinnerSize} ringColor={ringColor} />
       </div>

--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -198,7 +198,6 @@ input::-webkit-inner-spin-button {
 .NotifiAlertBox__btn--spacer {
   width: 24px;
   height: 24px;
-  padding: 10px;
   visibility: hidden;
   margin-bottom: 0 !important;
 }

--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -941,12 +941,14 @@ input::-webkit-inner-spin-button {
   font-size: 13px;
   font-weight: 500;
   padding-bottom: 8px;
+  text-align: center;
 }
 
 .NotifiAlertListPreview__headerText {
   margin-bottom: 12px;
   font-weight: 500;
   font-size: 16px;
+  text-align: center;
 }
 
 .NotifiAlertListContainer__checkmarkIcon {

--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -943,13 +943,6 @@ input::-webkit-inner-spin-button {
   text-align: center;
 }
 
-.NotifiAlertListPreview__headerText {
-  margin-bottom: 12px;
-  font-weight: 500;
-  font-size: 16px;
-  text-align: center;
-}
-
 .NotifiAlertListContainer__checkmarkIcon {
   margin-bottom: 0px !important;
   height: 15px;

--- a/packages/notifi-react-card/lib/components/subscription/FetchedStateCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/FetchedStateCard.tsx
@@ -13,6 +13,9 @@ export type FetchedStateCardProps = Readonly<{
   classNames?: Readonly<{
     SubscriptionCardV1?: SubscriptionCardV1Props['classNames'];
   }>;
+  copy?: Readonly<{
+    SubscriptionCardV1?: SubscriptionCardV1Props['copy'];
+  }>;
   card: FetchedState;
   inputDisabled: boolean;
   inputs: Record<string, unknown>;
@@ -24,6 +27,7 @@ export type FetchedStateCardProps = Readonly<{
 export const FetchedStateCard: React.FC<FetchedStateCardProps> = ({
   inputDisabled,
   classNames,
+  copy,
   card,
   inputs,
   inputLabels,
@@ -36,6 +40,7 @@ export const FetchedStateCard: React.FC<FetchedStateCardProps> = ({
       contents = (
         <SubscriptionCardV1
           classNames={classNames?.SubscriptionCardV1}
+          copy={copy?.SubscriptionCardV1}
           data={card.data}
           inputs={inputs}
           inputDisabled={inputDisabled}

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCard.tsx
@@ -46,6 +46,9 @@ export type NotifiInputFieldsText = {
 };
 
 export type NotifiSubscriptionCardProps = Readonly<{
+  copy?: Readonly<{
+    FetchedStateCard?: FetchedStateCardProps['copy'];
+  }>;
   classNames?: Readonly<{
     container?: string;
     ErrorStateCard?: ErrorStateCardProps['classNames'];

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCard.tsx
@@ -5,6 +5,7 @@ import {
   NotifiSubscriptionContextProvider,
   useNotifiClientContext,
 } from '../../context';
+import { DeepPartialReadonly } from '../../utils';
 import type { NotifiFooterProps } from '../NotifiFooter';
 import type { LoadingStateCardProps } from '../common';
 import type { ErrorStateCardProps } from '../common/ErrorStateCard';
@@ -46,8 +47,10 @@ export type NotifiInputFieldsText = {
 };
 
 export type NotifiSubscriptionCardProps = Readonly<{
-  copy?: Readonly<{
-    FetchedStateCard?: FetchedStateCardProps['copy'];
+  copy?: DeepPartialReadonly<{
+    ErrorStateCard: ErrorStateCardProps['copy'];
+    FetchedStateCard: FetchedStateCardProps['copy'];
+    LoadingStateCard: LoadingStateCardProps['copy'];
   }>;
   classNames?: Readonly<{
     container?: string;
@@ -60,7 +63,6 @@ export type NotifiSubscriptionCardProps = Readonly<{
   loadingSpinnerSize?: string;
   loadingRingColor?: string;
   disclosureCopy?: string;
-  buttonText?: string;
   inputLabels?: NotifiInputFieldsText;
   darkMode?: boolean;
   cardId: string;

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCardContainer.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCardContainer.tsx
@@ -38,6 +38,7 @@ export const NotifiSubscriptionCardContainer: React.FC<
     case 'loading':
       contents = (
         <LoadingStateCard
+          copy={copy?.LoadingStateCard}
           spinnerSize={loadingSpinnerSize}
           ringColor={loadingRingColor}
           classNames={classNames?.LoadingStateCard}
@@ -49,6 +50,7 @@ export const NotifiSubscriptionCardContainer: React.FC<
     case 'error':
       contents = (
         <ErrorStateCard
+          copy={copy?.ErrorStateCard}
           classNames={classNames?.ErrorStateCard}
           card={card}
           onClose={onClose}

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCardContainer.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCardContainer.tsx
@@ -12,6 +12,7 @@ export const NotifiSubscriptionCardContainer: React.FC<
   React.PropsWithChildren<NotifiSubscriptionCardProps>
 > = ({
   classNames,
+  copy,
   cardId,
   darkMode,
   inputLabels,
@@ -58,6 +59,7 @@ export const NotifiSubscriptionCardContainer: React.FC<
       contents = (
         <FetchedStateCard
           classNames={classNames?.FetchedStateCard}
+          copy={copy?.FetchedStateCard}
           card={card}
           inputs={inputs}
           inputDisabled={inputDisabled}

--- a/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
@@ -34,6 +34,12 @@ import VerifyWalletView, {
 export type SubscriptionCardV1Props = Readonly<{
   copy?: DeepPartialReadonly<{
     EditCard: EditCardViewProps['copy'];
+    expiredHeader: string;
+    manageAlertsHeader: string;
+    signUpHeader: string;
+    editHeader: string;
+    verifyWalletsHeader: string;
+    historyHeader: string;
   }>;
   classNames?: DeepPartialReadonly<{
     AlertHistoryView: AlertHistoryViewProps['classNames'];
@@ -112,7 +118,7 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
             classNames={classNames?.NotifiAlertBox}
             rightIcon={rightIcon}
           >
-            <h2>Manage Alerts</h2>
+            <h2>{copy?.expiredHeader ?? 'Welcome back'}</h2>
           </NotifiAlertBox>
           <ExpiredTokenView classNames={classNames?.ExpiredTokenView} />
         </>
@@ -129,7 +135,7 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
             }}
             rightIcon={rightIcon}
           >
-            <h2>Manage Alerts</h2>
+            <h2>{copy?.manageAlertsHeader ?? 'Manage Alerts'}</h2>
           </NotifiAlertBox>
           <PreviewCard
             data={data}
@@ -157,9 +163,9 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
             rightIcon={rightIcon}
           >
             {cardView.state === 'signup' ? (
-              <h2>Get Notified</h2>
+              <h2>{copy?.signUpHeader ?? 'Get Notified'}</h2>
             ) : (
-              <h2>Update Settings</h2>
+              <h2>{copy?.editHeader ?? 'Update Settings'}</h2>
             )}
           </NotifiAlertBox>
           <EditCardView
@@ -194,7 +200,7 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
             }}
             rightIcon={rightIcon}
           >
-            <h2>Verify Wallets</h2>
+            <h2>{copy?.verifyWalletsHeader ?? 'Verify Wallets'}</h2>
           </NotifiAlertBox>
           <VerifyWalletView
             classNames={classNames?.VerifyWalletView}
@@ -216,7 +222,7 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
             }}
             rightIcon={rightIcon}
           >
-            <h2>Alert History</h2>
+            <h2>{copy?.historyHeader ?? 'Alert History'}</h2>
           </NotifiAlertBox>
           <AlertHistoryView classNames={classNames?.AlertHistoryView} />
         </>

--- a/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
@@ -11,7 +11,6 @@ import {
   NotifiInputFieldsText,
   NotifiInputSeparators,
 } from './NotifiSubscriptionCard';
-import { AlertListProps } from './subscription-card-views/AlertListPreview';
 import {
   EditCardView,
   EditCardViewProps,
@@ -33,12 +32,14 @@ import VerifyWalletView, {
 } from './subscription-card-views/VerifyWalletView';
 
 export type SubscriptionCardV1Props = Readonly<{
+  copy?: DeepPartialReadonly<{
+    EditCard: EditCardViewProps['copy'];
+  }>;
   classNames?: DeepPartialReadonly<{
     AlertHistoryView: AlertHistoryViewProps['classNames'];
     PreviewCard: PreviewCardProps['classNames'];
     HistoryCard?: AlertHistoryViewProps['classNames'];
     EditCard: EditCardViewProps['classNames'];
-    AlertList: AlertListProps['classNames'];
     ExpiredTokenView: ExpiredTokenViewCardProps['classNames'];
     VerifyWalletView: VerifyWalletViewProps['classNames'];
     NotifiAlertBox: NotifiAlertBoxProps['classNames'];
@@ -53,6 +54,7 @@ export type SubscriptionCardV1Props = Readonly<{
 
 export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
   classNames,
+  copy,
   data,
   inputDisabled,
   inputs,
@@ -163,6 +165,7 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
           <EditCardView
             buttonText={cardView.state === 'signup' ? 'Next' : 'Update'}
             data={data}
+            copy={copy?.EditCard}
             classNames={classNames?.EditCard}
             inputDisabled={inputDisabled}
             inputTextFields={inputLabels}

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/AlertListPreview.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/AlertListPreview.tsx
@@ -12,14 +12,12 @@ export type AlertListPreviewProps = Readonly<{
   }>;
   eventTypes: CardConfigItemV1['eventTypes'];
   copy?: DeepPartialReadonly<{
-    headerText: string;
     description: string;
   }>;
   classNames?: DeepPartialReadonly<{
     checkmarkIcon: string;
     container: string;
     description: string;
-    headerText: string;
     eventListItem: string;
   }>;
 }>;
@@ -62,14 +60,6 @@ export const AlertListPreview: React.FC<AlertListPreviewProps> = ({
         classNames?.container,
       )}
     >
-      <label
-        className={clsx(
-          'NotifiAlertListPreview__headerText',
-          classNames?.headerText,
-        )}
-      >
-        {copy?.headerText ?? 'Get Notifications'}
-      </label>
       <label
         className={clsx(
           'NotifiAlertListPreview__descriptionText',

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/AlertListPreview.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/AlertListPreview.tsx
@@ -5,14 +5,16 @@ import React from 'react';
 
 import { CheckIcon } from '../../../assets/CheckIcon';
 
-export type AlertListProps = Readonly<{
+export type AlertListPreviewProps = Readonly<{
   alertList?: DeepPartialReadonly<{
     container: string;
     listItem: string;
   }>;
   eventTypes: CardConfigItemV1['eventTypes'];
-  headerText?: string;
-  description?: string;
+  copy?: DeepPartialReadonly<{
+    headerText: string;
+    description: string;
+  }>;
   classNames?: DeepPartialReadonly<{
     checkmarkIcon: string;
     container: string;
@@ -22,12 +24,11 @@ export type AlertListProps = Readonly<{
   }>;
 }>;
 
-export const AlertListPreview: React.FC<AlertListProps> = ({
+export const AlertListPreview: React.FC<AlertListPreviewProps> = ({
   eventTypes,
-  headerText,
+  copy,
   classNames,
-  description,
-}) => {
+}: AlertListPreviewProps) => {
   const alertNames = eventTypes.map((eventType) => {
     // skip showing alert previews for labels
     if (eventType.type === 'label') {
@@ -67,7 +68,7 @@ export const AlertListPreview: React.FC<AlertListProps> = ({
           classNames?.headerText,
         )}
       >
-        {headerText ? headerText : 'Get Notifications'}
+        {copy?.headerText ?? 'Get Notifications'}
       </label>
       <label
         className={clsx(
@@ -75,7 +76,7 @@ export const AlertListPreview: React.FC<AlertListProps> = ({
           classNames?.description,
         )}
       >
-        {description ? description : 'Subscribe to any of these alerts'}
+        {copy?.description ?? 'Subscribe to any of these alerts'}
       </label>
       <div className={clsx('NotifiAlertLisPreview__checkmarkContainer')}>
         {alertNames}

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/EditCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/EditCardView.tsx
@@ -11,7 +11,7 @@ import {
   NotifiInputFieldsText,
   NotifiInputSeparators,
 } from '../NotifiSubscriptionCard';
-import { AlertListPreview } from './AlertListPreview';
+import { AlertListPreview, AlertListPreviewProps } from './AlertListPreview';
 import { InputFields, InputFieldsProps } from './InputFields';
 
 export type EditCardViewProps = Readonly<{
@@ -19,7 +19,11 @@ export type EditCardViewProps = Readonly<{
   data: CardConfigItemV1;
   inputDisabled: boolean;
   showPreview?: boolean;
+  copy?: Readonly<{
+    AlertListPreview?: AlertListPreviewProps['copy'];
+  }>;
   classNames?: Readonly<{
+    AlertListPreview?: AlertListPreviewProps['classNames'];
     NotifiInputContainer?: string;
     InputFields?: DeepPartialReadonly<InputFieldsProps['classNames']>;
     NotifiSubscribeButton?: NotifiSubscribeButtonProps['classNames'];
@@ -33,6 +37,7 @@ export type EditCardViewProps = Readonly<{
 export const EditCardView: React.FC<EditCardViewProps> = ({
   allowedCountryCodes,
   buttonText,
+  copy,
   classNames,
   showPreview,
   data,
@@ -44,7 +49,13 @@ export const EditCardView: React.FC<EditCardViewProps> = ({
     <div
       className={clsx('NotifiInputContainer', classNames?.NotifiInputContainer)}
     >
-      {showPreview ? <AlertListPreview eventTypes={data.eventTypes} /> : null}
+      {showPreview ? (
+        <AlertListPreview
+          copy={copy?.AlertListPreview}
+          classNames={classNames?.AlertListPreview}
+          eventTypes={data.eventTypes}
+        />
+      ) : null}
 
       <InputFields
         data={data}

--- a/packages/notifi-react-example/src/NotifiCard/NotifiCard.tsx
+++ b/packages/notifi-react-example/src/NotifiCard/NotifiCard.tsx
@@ -82,7 +82,6 @@ export const NotifiCard: React.FC = () => {
                 signUpHeader: 'Please sign up',
                 EditCard: {
                   AlertListPreview: {
-                    headerText: 'This is a custom header text',
                     description:
                       'Get your alerts here!!! you can subscribe to any of the following:',
                   },

--- a/packages/notifi-react-example/src/NotifiCard/NotifiCard.tsx
+++ b/packages/notifi-react-example/src/NotifiCard/NotifiCard.tsx
@@ -79,6 +79,7 @@ export const NotifiCard: React.FC = () => {
           copy={{
             FetchedStateCard: {
               SubscriptionCardV1: {
+                signUpHeader: 'Please sign up',
                 EditCard: {
                   AlertListPreview: {
                     headerText: 'This is a custom header text',

--- a/packages/notifi-react-example/src/NotifiCard/NotifiCard.tsx
+++ b/packages/notifi-react-example/src/NotifiCard/NotifiCard.tsx
@@ -76,6 +76,19 @@ export const NotifiCard: React.FC = () => {
           inputSeparators={inputSeparators}
           cardId="b469c6029e3f40aaab49ddd78fe7f228"
           onClose={() => alert('nope you must stay')}
+          copy={{
+            FetchedStateCard: {
+              SubscriptionCardV1: {
+                EditCard: {
+                  AlertListPreview: {
+                    headerText: 'This is a custom header text',
+                    description:
+                      'Get your alerts here!!! you can subscribe to any of the following:',
+                  },
+                },
+              },
+            },
+          }}
         />
         <NotifiIntercomCard
           darkMode


### PR DESCRIPTION
We already had some fields which were configurable thru the frontend integration. Make some additional fields configurable (and fix some discovered bugs).

For now, we are just passing it through from the top level, but in the future we should consider pulling these values in from the fetched CardConfig.