### PR TITLE
Port PriceChange row

### DIFF
--- a/packages/notifi-core/lib/operations/CreateSource.ts
+++ b/packages/notifi-core/lib/operations/CreateSource.ts
@@ -43,7 +43,8 @@ export type CreateSourceInput = Readonly<{
     | 'POLYGON_WALLET'
     | 'ARBITRUM_WALLET'
     | 'BINANCE_WALLET'
-    | 'AVALANCHE_WALLET';
+    | 'AVALANCHE_WALLET'
+    | 'COIN_PRICE_CHANGES';
 }>;
 
 export type CreateSourceResult = Source;

--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -475,12 +475,14 @@ input::-webkit-inner-spin-button {
 .EventTypeHealthCheckRow__container,
 .EventTypeCustomToggleRow__container,
 .EventTypeWalletBalanceRow__container,
+.EventTypePriceChangeRow__container,
 .BrowserAlertToggle__container {
   display: flex;
   flex-direction: row;
 }
 
 .EventTypeBroadcastRow__label,
+.EventTypePriceChangeRow__label,
 .EventTypeDirectPushRow__label,
 .EventTypeCustomToggleRow_label,
 .EventTypeHealthCheckRow__label,

--- a/packages/notifi-react-card/lib/components/subscription/EventTypePriceChangeRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypePriceChangeRow.tsx
@@ -1,0 +1,145 @@
+import clsx from 'clsx';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { useNotifiSubscriptionContext } from '../../context';
+import { PriceChangeEventTypeItem, useNotifiSubscribe } from '../../hooks';
+import {
+  AlertConfiguration,
+  DeepPartialReadonly,
+  priceChangeConfiguration,
+} from '../../utils';
+import type { NotifiToggleProps } from './NotifiToggle';
+import { NotifiToggle } from './NotifiToggle';
+import { NotifiTooltip, NotifiTooltipProps } from './NotifiTooltip';
+
+export type EventTypePriceChangeRowProps = Readonly<{
+  classNames?: DeepPartialReadonly<{
+    container: string;
+    label: string;
+    toggle: NotifiToggleProps['classNames'];
+    tooltip: NotifiTooltipProps['classNames'];
+  }>;
+  disabled: boolean;
+  config: PriceChangeEventTypeItem;
+  inputs: Record<string, unknown>;
+}>;
+
+export const EventTypePriceChangeRow: React.FC<
+  EventTypePriceChangeRowProps
+> = ({ classNames, disabled, config }: EventTypePriceChangeRowProps) => {
+  const { alerts, loading } = useNotifiSubscriptionContext();
+  const { instantSubscribe } = useNotifiSubscribe({
+    targetGroupName: 'Default',
+  });
+  const [enabled, setEnabled] = useState(false);
+  const [isNotificationLoading, setIsNotificationLoading] =
+    useState<boolean>(false);
+
+  const alertName = useMemo<string>(() => config.name, [config]);
+  const alertConfiguration = useMemo<AlertConfiguration>(() => {
+    return priceChangeConfiguration({
+      tokenIds: config.tokenIds,
+    });
+  }, [alertName, config]);
+  const tooltipContent = config.tooltipContent;
+
+  const didFetch = useRef(false);
+
+  useEffect(() => {
+    if (didFetch.current) {
+      return;
+    }
+
+    const hasAlert = alerts[alertName] !== undefined;
+    setEnabled(hasAlert);
+    didFetch.current = true;
+  }, [alertName, alerts]);
+
+  const handleNewSubscription = useCallback(() => {
+    if (loading || isNotificationLoading) {
+      return;
+    }
+    setIsNotificationLoading(true);
+
+    if (!enabled) {
+      setEnabled(true);
+      instantSubscribe({
+        alertConfiguration: alertConfiguration,
+        alertName: alertName,
+      })
+        .then((res) => {
+          // We update optimistically so we need to check if the alert exists.
+          const responseHasAlert = res.alerts[alertName] !== undefined;
+          if (responseHasAlert !== true) {
+            setEnabled(false);
+          }
+        })
+        .catch(() => {
+          setEnabled(false);
+        })
+        .finally(() => {
+          setIsNotificationLoading(false);
+        });
+    } else {
+      setEnabled(false);
+      instantSubscribe({
+        alertConfiguration: null,
+        alertName: alertName,
+      })
+        .then((res) => {
+          // We update optimistically so we need to check if the alert exists.
+          const responseHasAlert = res.alerts[alertName] !== undefined;
+          if (responseHasAlert !== false) {
+            setEnabled(true);
+          }
+        })
+        .catch(() => {
+          setEnabled(false);
+        })
+        .finally(() => {
+          setIsNotificationLoading(false);
+        });
+    }
+  }, [
+    loading,
+    enabled,
+    instantSubscribe,
+    alertConfiguration,
+    alertName,
+    isNotificationLoading,
+    setIsNotificationLoading,
+  ]);
+
+  return (
+    <div
+      className={clsx(
+        'EventTypePriceChangeRow__container',
+        classNames?.container,
+      )}
+    >
+      <div
+        className={clsx('EventTypePriceChangeRow__label', classNames?.label)}
+      >
+        {config.name}
+        {tooltipContent !== undefined && tooltipContent.length > 0 ? (
+          <NotifiTooltip
+            classNames={classNames?.tooltip}
+            content={tooltipContent}
+          />
+        ) : null}
+      </div>
+      <NotifiToggle
+        checked={enabled}
+        classNames={classNames?.toggle}
+        disabled={disabled || isNotificationLoading}
+        setChecked={handleNewSubscription}
+      />
+    </div>
+  );
+};

--- a/packages/notifi-react-card/lib/components/subscription/index.ts
+++ b/packages/notifi-react-card/lib/components/subscription/index.ts
@@ -6,6 +6,7 @@ export * from './EventTypeCustomToggleRow';
 export * from './EventTypeDirectPushRow';
 export * from './EventTypeHealthCheckRow';
 export * from './EventTypeLabelRow';
+export * from './EventTypePriceChangeRow';
 export * from './EventTypeTradingPairsRow';
 export * from './EventTypeUnsupportedRow';
 export * from './EventTypeWalletBalanceRow';

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/AlertsPanel.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/AlertsPanel.tsx
@@ -23,6 +23,10 @@ import {
   EventTypeLabelRowProps,
 } from '../../EventTypeLabelRow';
 import {
+  EventTypePriceChangeRow,
+  EventTypePriceChangeRowProps,
+} from '../../EventTypePriceChangeRow';
+import {
   EventTypeTradingPairsRow,
   EventTypeTradingPairsRowProps,
 } from '../../EventTypeTradingPairsRow';
@@ -45,6 +49,7 @@ export type AlertsPanelProps = Readonly<{
     EventTypeDirectPushRow?: EventTypeDirectPushRowProps['classNames'];
     EventTypeHealthCheckRow?: EventTypeHealthCheckRowProps['classNames'];
     EventTypeLabelRow?: EventTypeLabelRowProps['classNames'];
+    EventTypePriceChangeRow?: EventTypePriceChangeRowProps['classNames'];
     EventTypeTradingPairsRow?: EventTypeTradingPairsRowProps['classNames'];
     EventTypeUnsupportedRow?: EventTypeUnsupportedRowProps['classNames'];
     EventTypeWalletBalanceRow?: EventTypeWalletBalanceRowProps['classNames'];
@@ -132,6 +137,16 @@ export const AlertsPanel: React.FC<AlertsPanelProps> = ({
               <EventTypeWalletBalanceRow
                 key={eventType.name}
                 classNames={classNames?.EventTypeWalletBalanceRow}
+                disabled={inputDisabled}
+                config={eventType}
+                inputs={inputs}
+              />
+            );
+          case 'priceChange':
+            return (
+              <EventTypePriceChangeRow
+                key={eventType.name}
+                classNames={classNames?.EventTypePriceChangeRow}
                 disabled={inputDisabled}
                 config={eventType}
                 inputs={inputs}

--- a/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
+++ b/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
@@ -68,6 +68,16 @@ export type WalletBalanceEventTypeItem = Readonly<{
   tooltipContent?: string;
 }>;
 
+export type PriceChangeDataSource = 'coingecko';
+
+export type PriceChangeEventTypeItem = Readonly<{
+  type: 'priceChange';
+  name: string;
+  tokenIds: ReadonlyArray<string>;
+  dataSource: PriceChangeDataSource;
+  tooltipContent: string;
+}>;
+
 export type USER_INTERFACE_TYPE = 'TOGGLE' | 'HEALTH_CHECK';
 
 export type NumberTypeSelect = 'percentage' | 'integer';
@@ -106,6 +116,7 @@ export type EventTypeItem =
   | LabelEventTypeItem
   | TradingPairEventTypeItem
   | WalletBalanceEventTypeItem
+  | PriceChangeEventTypeItem
   | CustomTopicTypeItem;
 
 export type EventTypeConfig = ReadonlyArray<EventTypeItem>;

--- a/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
+++ b/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
@@ -203,6 +203,25 @@ export const walletBalanceConfiguration = ({
   };
 };
 
+export const priceChangeConfiguration = ({
+  tokenIds,
+}: Readonly<{
+  tokenIds: ReadonlyArray<string>;
+}>): AlertConfiguration => {
+  return {
+    type: 'multiple',
+    filterType: 'COIN_PRICE_CHANGE_EVENTS',
+    filterOptions: null,
+    sources: tokenIds.map((tokenId) => {
+      return {
+        name: tokenId,
+        type: 'COIN_PRICE_CHANGES',
+        blockchainAddress: tokenId,
+      };
+    }),
+  };
+};
+
 export const createConfigurations = (
   eventTypes: EventTypeConfig,
 ): Record<string, AlertConfiguration> => {


### PR DESCRIPTION
This row was implemented in the Vue integration of Pontem (and thus, in the notifi-frontend-client), but was never ported to the React SDK. Add support for this new row.