### PR TITLE
Add support for disconnecting ConnectedWallet

### DIFF
--- a/packages/notifi-react-card/lib/components/WalletList/ConnectWalletRow.tsx
+++ b/packages/notifi-react-card/lib/components/WalletList/ConnectWalletRow.tsx
@@ -103,7 +103,7 @@ export const ConnectWalletRow: React.FC<ConnectWalletRowProps> = ({
     <div className="ConnectWalletRow__container">
       <div className="ConnectWalletRow__topRow">
         <p className="ConnectWalletRow__publicKey">{shortenedAddress}</p>
-        {isConnected ? null : (
+        {isConnected || isConnectedElsewhere ? null : (
           <button
             disabled={isLoading || isConnectedElsewhere}
             className="ConnectWalletRow__button"
@@ -113,9 +113,12 @@ export const ConnectWalletRow: React.FC<ConnectWalletRowProps> = ({
               });
             }}
           >
-            Connect
+            Verify
           </button>
         )}
+        {isConnected ? (
+          <p className="ConnectWalletRow__verified">Verified</p>
+        ) : null}
       </div>
       {isConnectedElsewhere ? (
         <>
@@ -134,7 +137,7 @@ export const ConnectWalletRow: React.FC<ConnectWalletRowProps> = ({
                 });
               }}
             >
-              Connect anyway
+              Verify anyway
             </button>
           </div>
         </>

--- a/packages/notifi-react-card/lib/components/WalletList/ConnectWalletRow.tsx
+++ b/packages/notifi-react-card/lib/components/WalletList/ConnectWalletRow.tsx
@@ -2,8 +2,9 @@ import {
   ConnectedWallet,
   WalletWithSignParams,
 } from '@notifi-network/notifi-core';
+import { GqlError } from '@notifi-network/notifi-react-hooks';
 import { addressEllipsis } from 'notifi-react-card/lib/utils/stringUtils';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import { useNotifiSubscribe } from '../../hooks';
 
@@ -12,11 +13,26 @@ export type ConnectWalletRowProps = WalletWithSignParams &
     connectedWallets: ReadonlyArray<ConnectedWallet>;
   }>;
 
-const hasKey = <T,>(obj: T, prop: PropertyKey): prop is keyof T => {
-  return (
-    typeof obj === 'object' &&
-    obj !== null &&
-    Object.prototype.hasOwnProperty.call(obj, prop)
+const hasKey = <K extends string>(
+  obj: object,
+  key: K,
+): obj is object & { [k in K]: unknown } => {
+  return typeof obj === 'object' && obj !== null && key in obj;
+};
+
+const findError = <C extends string>(
+  errors: ReadonlyArray<unknown>,
+  code: C,
+): unknown | undefined => {
+  return errors.find(
+    (err) =>
+      typeof err === 'object' &&
+      err !== null &&
+      hasKey(err, 'extensions') &&
+      typeof err.extensions === 'object' &&
+      err.extensions !== null &&
+      hasKey(err.extensions, 'code') &&
+      code === err.extensions.code,
   );
 };
 
@@ -47,31 +63,82 @@ export const ConnectWalletRow: React.FC<ConnectWalletRowProps> = ({
     return addressEllipsis(walletParams.walletPublicKey);
   }, [walletParams]);
 
-  const connectWallet = useCallback(async () => {
-    await subscribeWallet({
-      walletParams,
-      connectWalletConflictResolutionTechnique: 'FAIL',
-    });
-  }, [subscribeWallet, walletParams]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isConnectedElsewhere, setIsConnectedElsewhere] = useState(false);
 
-  if (isConnected) {
-    return (
-      <div className="NotifiVerifyItem">
-        <p className="NotifiVerifyPublicKey">{shortenedAddress}</p>
-      </div>
-    );
-  }
+  const connectWallet = useCallback(
+    async (technique: 'FAIL' | 'DISCONNECT_AND_CLOSE_OLD_ACCOUNT') => {
+      setIsLoading(true);
+      try {
+        await subscribeWallet({
+          walletParams,
+          connectWalletConflictResolutionTechnique: technique,
+        });
+        setIsConnectedElsewhere(false);
+      } catch (e: unknown) {
+        if (e instanceof GqlError) {
+          const alreadyConnectedError =
+            findError(
+              e.errors,
+              'ERROR_WALLETCONNECT_ALREADY_CONNECTED_TO_ANOTHER_ACCOUNT_AND_LAST',
+            ) ??
+            findError(
+              e.errors,
+              'ERROR_WALLETCONNECT_ALREADY_CONNECTED_TO_ANOTHER_ACCOUNT',
+            );
+          if (alreadyConnectedError !== undefined) {
+            setIsConnectedElsewhere(true);
+          }
+        }
+
+        throw e;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [subscribeWallet, walletParams],
+  );
+
   return (
-    <div className="NotifiVerifyItem">
-      <p className="NotifiVerifyPublicKey">{shortenedAddress}</p>
-      <button
-        className="NotifiVerifyButton"
-        onClick={() => {
-          connectWallet();
-        }}
-      >
-        Connect
-      </button>
+    <div className="ConnectWalletRow__container">
+      <div className="ConnectWalletRow__topRow">
+        <p className="ConnectWalletRow__publicKey">{shortenedAddress}</p>
+        {isConnected ? null : (
+          <button
+            disabled={isLoading || isConnectedElsewhere}
+            className="ConnectWalletRow__button"
+            onClick={() => {
+              connectWallet('FAIL').catch((e) => {
+                console.log('Error connecting wallet', e);
+              });
+            }}
+          >
+            Connect
+          </button>
+        )}
+      </div>
+      {isConnectedElsewhere ? (
+        <>
+          <div className="ConnectWalletRow__messageRow">
+            This wallet is already connected to another Notifi Hub account. If
+            you continue, this wallet can only be used to access this account.
+            You will lose access to the subscriptions in your other account.
+          </div>
+          <div className="ConnectWalletRow__bottomRow">
+            <button
+              disabled={isLoading}
+              className="ConnectWalletRow__connectAnywayButton"
+              onClick={() => {
+                connectWallet('DISCONNECT_AND_CLOSE_OLD_ACCOUNT').catch((e) => {
+                  console.log('Error connecting wallet', e);
+                });
+              }}
+            >
+              Connect anyway
+            </button>
+          </div>
+        </>
+      ) : null}
     </div>
   );
 };

--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -143,6 +143,7 @@ input::-webkit-inner-spin-button {
   justify-content: flex-end;
 }
 
+.ConnectWalletRow__verified,
 .ConnectWalletRow__publicKey,
 .ConnectWalletRow__container,
 .ConnectWalletRow__bottomRow {
@@ -771,6 +772,12 @@ input::-webkit-inner-spin-button {
 .NotifiUserInfoPanel__telegramConfirmation {
   flex-shrink: 0;
   margin-left: 8px;
+}
+
+.ConnectWalletRow__verified {
+  display: block;
+  font-size: 14px;
+  color: var(--notifi-secondary-font-color);
 }
 
 .ConnectWalletRow__button,

--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -110,18 +110,42 @@ input::-webkit-inner-spin-button {
   margin: 0;
 }
 
-.NotifiVerifyItem {
+.ConnectWalletRow__container {
   padding: 16px 0;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: stretch;
   margin-bottom: 0 !important;
   margin-top: 0 !important;
   border-bottom: 1px solid var(--notifi-input-border);
 }
 
-.NotifiVerifyPublicKey,
-.NotifiVerifyItem {
+.ConnectWalletRow__topRow {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.ConnectWalletRow__messageRow {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  color: var(--notifi-secondary-font-color);
+  text-align: justify;
+  line-height: 1.25em;
+}
+
+.ConnectWalletRow__bottomRow {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.ConnectWalletRow__publicKey,
+.ConnectWalletRow__container,
+.ConnectWalletRow__bottomRow {
   margin: 0 !important;
 }
 
@@ -749,7 +773,8 @@ input::-webkit-inner-spin-button {
   margin-left: 8px;
 }
 
-.NotifiVerifyButton,
+.ConnectWalletRow__button,
+.ConnectWalletRow__connectAnywayButton,
 .NotifiUserInfoPanel__myWalletConfirmation,
 .NotifiUserInfoPanel__emailConfirmationLabel,
 .NotifiUserInfoPanel__telegramConfirmationLabel {
@@ -762,6 +787,12 @@ input::-webkit-inner-spin-button {
   border: 0;
   box-shadow: 0;
   outline: none;
+}
+
+.ConnectWalletRow__connectAnywayButton:disabled,
+.ConnectWalletRow__button:disabled {
+  cursor: default;
+  color: var(--notifi-secondary-font-color);
 }
 
 .NotifiUserInfoPanel__myWallet,

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -532,14 +532,17 @@ export const useNotifiSubscribe: ({
     async (params: ConnectWalletParams) => {
       setLoading(true);
 
-      if (!client.isAuthenticated) {
-        await logIn();
-      }
+      try {
+        if (!client.isAuthenticated) {
+          await logIn();
+        }
 
-      await client.connectWallet(params);
-      const newData = await client.fetchData();
-      setConnectedWallets(newData.connectedWallets);
-      setLoading(false);
+        await client.connectWallet(params);
+        const newData = await client.fetchData();
+        setConnectedWallets(newData.connectedWallets);
+      } finally {
+        setLoading(false);
+      }
     },
     [client, logIn, setLoading, setConnectedWallets],
   );

--- a/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
+++ b/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
@@ -757,7 +757,6 @@ const useNotifiClient = (
 
         return result;
       } catch (e: unknown) {
-        setIsAuthenticated(false);
         if (e instanceof Error) {
           setError(e);
         } else {


### PR DESCRIPTION
We have an error handling flow for ConnectWallet where the user is prompted when the wallet they are trying to connect is already associated with another Notifi account.

Implement this as an in-line error message and secondary action link.

The copy is taken from the Notifi Hub copy


|verify|connected elsewhere|verified|
|---|---|---|
|<img width="404" alt="Screen Shot 2023-03-12 at 2 01 23 PM" src="https://user-images.githubusercontent.com/100658137/224573620-a3a192e9-7742-42db-930b-59fc19e1e36f.png">|<img width="403" alt="Screen Shot 2023-03-12 at 2 02 50 PM" src="https://user-images.githubusercontent.com/100658137/224573636-22fa798f-1591-4407-aaee-6ffd7383aa3c.png">|<img width="405" alt="Screen Shot 2023-03-12 at 2 00 52 PM" src="https://user-images.githubusercontent.com/100658137/224573651-f22ad4d4-069f-4ce2-aa7b-9949fdd2a2ad.png">|