### PR TITLE
Refactor AlertDetails Markup

### DIFF
--- a/packages/notifi-react-card/lib/components/AlertHistory/AlertDetailsCard.tsx
+++ b/packages/notifi-react-card/lib/components/AlertHistory/AlertDetailsCard.tsx
@@ -2,15 +2,14 @@ import { NotificationHistoryEntry } from '@notifi-network/notifi-core';
 import clsx from 'clsx';
 import React, { useMemo } from 'react';
 
-import { BackArrowIcon } from '../../assets/BackArrowIcon';
 import {
   formatAlertDetailsTimestamp,
   formatAmount,
 } from '../../utils/AlertHistoryUtils';
+import NotifiAlertBox from '../NotifiAlertBox';
 
 export type AlertDetailsProps = Readonly<{
   notificationEntry: NotificationHistoryEntry;
-  handleClose: () => void;
   classNames?: Readonly<{
     detailsContainer?: string;
     BackArrowIcon?: string;
@@ -18,7 +17,6 @@ export type AlertDetailsProps = Readonly<{
 }>;
 export const AlertDetailsCard: React.FC<AlertDetailsProps> = ({
   notificationEntry,
-  handleClose,
   classNames,
 }) => {
   const timestamp = notificationEntry.createdDate;
@@ -84,31 +82,12 @@ export const AlertDetailsCard: React.FC<AlertDetailsProps> = ({
         classNames?.detailsContainer,
       )}
     >
-      <div
-        className={clsx(
-          'NotifiAlertDetails__backArrow',
-          classNames?.BackArrowIcon,
-        )}
-        onClick={handleClose}
-      >
-        <BackArrowIcon />
-      </div>
-      <div className="NotifiAlertDetails__dialogHeader">
-        <span className="NotifiAlertDetails__headerLabel">
-          <label className="NotifiAlertDetails__headerContent">
-            Alert Details
-          </label>
-        </span>
-      </div>
-      <div className={clsx('NotifiAlertDetails__dividerLine')} />
-      <div className={clsx('NotifiAlertDetails__contentContainer')}>
-        <div className={clsx('NotifiAlertDetails__topContentContainer')}>
-          <div className={clsx('NotifiAlertDetails__topContent')}>
-            {content.topContent}
-          </div>
-          <div className={clsx('NotifiAlertDetails__timestamp')}>
-            {formatAlertDetailsTimestamp(timestamp)}
-          </div>
+      <div className={clsx('NotifiAlertDetails__topContentContainer')}>
+        <div className={clsx('NotifiAlertDetails__topContent')}>
+          {content.topContent}
+        </div>
+        <div className={clsx('NotifiAlertDetails__timestamp')}>
+          {formatAlertDetailsTimestamp(timestamp)}
         </div>
       </div>
       <div className={clsx('NotifiAlertDetails__bottomContent')}>

--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -98,6 +98,13 @@ input::-webkit-inner-spin-button {
   margin-bottom: 10px;
 }
 
+.NotifiSubscriptionCardV1__alertContainer {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
 .NotifiVerifyContainer {
   display: flex;
   flex-direction: column;
@@ -860,46 +867,10 @@ input::-webkit-inner-spin-button {
 
 /* ALERT DETAILS CARD */
 .NotifiAlertDetails__container {
-  position: absolute;
-  z-index: 10;
-  top: 0px;
-  left: 0px;
-  max-height: 525px;
-  background-color: var(--notifi-card-background);
-  width: 360px;
-  height: 100%;
-  border-radius: 24px;
-  padding-left: 20px;
-  padding-right: 20px;
-}
-
-.NotifiAlertDetails__dialogHeader {
   display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  padding: 30px 20px 5px 20px;
-}
-
-.NotifiAlertDetails__dialogHeader {
-  justify-content: center;
-  font-size: 16px;
-  padding-bottom: 10px;
-  color: var(--notifi-font-color);
-  text-align: center;
-}
-
-.NotifiAlertDetails__dividerLine {
-  border-top: 2px solid var(--notifi-font-color);
-  border-radius: 5px;
-}
-
-.NotifiAlertDetails__backArrow {
-  position: absolute;
-  top: 30px;
-  height: 20px;
-  width: 20px;
-  cursor: pointer;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: stretch;
 }
 
 .NotifiAlertDetails__topContentContainer {
@@ -914,7 +885,6 @@ input::-webkit-inner-spin-button {
   text-align: start;
   font-weight: 700;
   font-size: 16px;
-  max-width: 275px;
   overflow-wrap: break-word;
 }
 
@@ -1527,6 +1497,17 @@ input::-webkit-inner-spin-button {
   cursor: default;
   color: var(--notifi-secondary-font-color);
   background-color: var(--notifi-button-disabled-color);
+}
+
+.NotifiAlertHistory__container {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  visibility: visible;
+}
+
+.NotifiAlertHistory__container.NotifiAlertHistory__container--hidden {
+  visibility: hidden;
 }
 
 .NotifiAlertHistory__virtuoso {

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
@@ -11,10 +11,6 @@ import { useNotifiClientContext } from '../../../context';
 import { DeepPartialReadonly } from '../../../utils';
 import { MESSAGES_PER_PAGE } from '../../../utils/constants';
 import { AccountBalanceChangedRenderer } from '../../AlertHistory/AccountBalanceChangedRenderer';
-import {
-  AlertDetailsCard,
-  AlertDetailsProps,
-} from '../../AlertHistory/AlertDetailsCard';
 import { AlertNotificationViewProps } from '../../AlertHistory/AlertNotificationRow';
 import { BroadcastMessageChangedRenderer } from '../../AlertHistory/BroadcastMessageChangedRenderer';
 import { ChatMessageReceivedRenderer } from '../../AlertHistory/ChatMessageReceivedRenderer';
@@ -23,6 +19,7 @@ import { HealthValueOverThresholdEventRenderer } from '../../AlertHistory/Health
 
 export type AlertHistoryViewProps = Readonly<{
   noAlertDescription?: string;
+  isHidden: boolean;
   classNames?: DeepPartialReadonly<{
     title: string;
     header: string;
@@ -35,10 +32,13 @@ export type AlertHistoryViewProps = Readonly<{
     notificationImage: string;
     notificationList: string;
     emptyAlertsBellIcon: string;
+    historyContainer: string;
     virtuoso: string;
-    AlertDetailsCard: AlertDetailsProps['classNames'];
     AlertCard: AlertNotificationViewProps['classNames'];
   }>;
+  setAlertEntry: React.Dispatch<
+    React.SetStateAction<NotificationHistoryEntry | undefined>
+  >;
 }>;
 
 export const AlertCard: React.FC<{
@@ -121,15 +121,13 @@ export const AlertCard: React.FC<{
 
 export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
   classNames,
+  isHidden,
   noAlertDescription,
+  setAlertEntry,
 }) => {
   noAlertDescription = noAlertDescription
     ? noAlertDescription
     : 'You haven’t received any notifications yet';
-
-  const [selectedAlertEntry, setAlertEntry] = useState<
-    NotificationHistoryEntry | undefined
-  >(undefined);
 
   const [endCursor, setEndCursor] = useState<string | undefined>();
   const [hasNextPage, setHasNextPage] = useState<boolean | null>(null);
@@ -179,20 +177,19 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
   }, [client]);
 
   return (
-    <>
+    <div
+      className={clsx(
+        'NotifiAlertHistory__container',
+        classNames?.historyContainer,
+        { 'NotifiAlertHistory__container--hidden': isHidden },
+      )}
+    >
       <div
         className={clsx(
           'NotifiAlertHistory__dividerLine',
           classNames?.dividerLine,
         )}
       />
-      {selectedAlertEntry !== undefined ? (
-        <AlertDetailsCard
-          classNames={classNames?.AlertDetailsCard}
-          notificationEntry={selectedAlertEntry}
-          handleClose={() => setAlertEntry(undefined)}
-        />
-      ) : null}
       {allNodes.length > 0 ? (
         <Virtuoso
           className={clsx('NotifiAlertHistory__virtuoso', classNames?.virtuoso)}
@@ -237,6 +234,6 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
           </span>
         </div>
       )}
-    </>
+    </div>
   );
 };


### PR DESCRIPTION
Before, we were rendering a full-sized card over the whole thing.

Instead, extract the state up to the SubscriptionCard and alter the rendering to be conditional on this state.

This drastically improves the flexibility, because it results in simpler, cleaner CSS and allows us to use the layout engine rather than having to pixel-push to match the container size.

<img width="406" alt="Screen Shot 2023-03-12 at 1 44 53 PM" src="https://user-images.githubusercontent.com/100658137/224572847-860c48f7-b5fb-405c-8dd5-8c19f0e3e91f.png">
