### PR TITLE
Add support for displayName on ownedWallets

### DIFF
--- a/packages/notifi-core/lib/NotifiClient.ts
+++ b/packages/notifi-core/lib/NotifiClient.ts
@@ -316,7 +316,7 @@ export type WalletParams =
       walletPublicKey: string;
     }>;
 
-export type WalletWithSignParams =
+export type WalletWithSignMessage =
   | Readonly<{
       walletBlockchain: 'SOLANA';
       walletPublicKey: string;
@@ -350,6 +350,11 @@ export type WalletWithSignParams =
       walletPublicKey: string;
       signMessage: Uint8SignMessageFunction;
     }>;
+
+export type WalletWithSignParams = Readonly<{
+  displayName?: string;
+}> &
+  WalletWithSignMessage;
 
 export type ConnectWalletParams = Readonly<{
   walletParams: WalletWithSignParams;

--- a/packages/notifi-react-card/lib/components/WalletList/ConnectWalletRow.tsx
+++ b/packages/notifi-react-card/lib/components/WalletList/ConnectWalletRow.tsx
@@ -38,6 +38,7 @@ const findError = <C extends string>(
 
 export const ConnectWalletRow: React.FC<ConnectWalletRowProps> = ({
   connectedWallets,
+  displayName,
   ...walletParams
 }: ConnectWalletRowProps) => {
   const { subscribeWallet } = useNotifiSubscribe({
@@ -102,7 +103,9 @@ export const ConnectWalletRow: React.FC<ConnectWalletRowProps> = ({
   return (
     <div className="ConnectWalletRow__container">
       <div className="ConnectWalletRow__topRow">
-        <p className="ConnectWalletRow__publicKey">{shortenedAddress}</p>
+        <p className="ConnectWalletRow__publicKey">
+          {displayName ?? shortenedAddress}
+        </p>
         {isConnected || isConnectedElsewhere ? null : (
           <button
             disabled={isLoading || isConnectedElsewhere}

--- a/packages/notifi-react-example/src/MultiWalletTest/MultiWalletTest.tsx
+++ b/packages/notifi-react-example/src/MultiWalletTest/MultiWalletTest.tsx
@@ -61,6 +61,7 @@ export const MultiWalletTest: React.FC = () => {
               signMessage: requestSignature,
               walletPublicKey: polkadotPublicKey,
               accountAddress: acalaAccount,
+              displayName: 'My Acala wallet',
             },
           ],
         }}


### PR DESCRIPTION
Allow the consumer to specify an optional displayName for each ownedWallet