### PR TITLE
Split subscription in multi-wallet flow

### DIFF
--- a/packages/notifi-react-card/lib/components/WalletList/ConnectWalletRow.tsx
+++ b/packages/notifi-react-card/lib/components/WalletList/ConnectWalletRow.tsx
@@ -11,6 +11,7 @@ import { useNotifiSubscribe } from '../../hooks';
 export type ConnectWalletRowProps = WalletWithSignParams &
   Readonly<{
     connectedWallets: ReadonlyArray<ConnectedWallet>;
+    disabled: boolean;
   }>;
 
 const hasKey = <K extends string>(
@@ -39,6 +40,7 @@ const findError = <C extends string>(
 export const ConnectWalletRow: React.FC<ConnectWalletRowProps> = ({
   connectedWallets,
   displayName,
+  disabled,
   ...walletParams
 }: ConnectWalletRowProps) => {
   const { subscribeWallet } = useNotifiSubscribe({
@@ -108,7 +110,7 @@ export const ConnectWalletRow: React.FC<ConnectWalletRowProps> = ({
         </p>
         {isConnected || isConnectedElsewhere ? null : (
           <button
-            disabled={isLoading || isConnectedElsewhere}
+            disabled={disabled || isLoading || isConnectedElsewhere}
             className="ConnectWalletRow__button"
             onClick={() => {
               connectWallet('FAIL').catch((e) => {
@@ -132,7 +134,7 @@ export const ConnectWalletRow: React.FC<ConnectWalletRowProps> = ({
           </div>
           <div className="ConnectWalletRow__bottomRow">
             <button
-              disabled={isLoading}
+              disabled={disabled || isLoading}
               className="ConnectWalletRow__connectAnywayButton"
               onClick={() => {
                 connectWallet('DISCONNECT_AND_CLOSE_OLD_ACCOUNT').catch((e) => {

--- a/packages/notifi-react-card/lib/components/WalletList/WalletList.tsx
+++ b/packages/notifi-react-card/lib/components/WalletList/WalletList.tsx
@@ -13,11 +13,13 @@ import { ConnectWalletRow } from './ConnectWalletRow';
 export type WalletListInternalProps = Readonly<{
   connectedWallets: ReadonlyArray<ConnectedWallet>;
   ownedWallets: ReadonlyArray<WalletWithSignParams>;
+  disabled: boolean;
 }>;
 
 export const WalletListInternal: React.FC<WalletListInternalProps> = ({
   connectedWallets,
   ownedWallets,
+  disabled,
 }: WalletListInternalProps) => {
   return (
     <ul>
@@ -27,18 +29,18 @@ export const WalletListInternal: React.FC<WalletListInternalProps> = ({
             key={wallet.walletPublicKey}
             {...wallet}
             connectedWallets={connectedWallets}
+            disabled={disabled}
           />
         );
       })}
     </ul>
   );
 };
-
 export const WalletList: React.FC = () => {
   const {
     params: { multiWallet },
   } = useNotifiClientContext();
-  const { connectedWallets } = useNotifiSubscriptionContext();
+  const { connectedWallets, loading } = useNotifiSubscriptionContext();
   const owned = multiWallet?.ownedWallets;
   if (owned === undefined || owned.length === 0) {
     return null;
@@ -48,6 +50,7 @@ export const WalletList: React.FC = () => {
     <WalletListInternal
       ownedWallets={owned}
       connectedWallets={connectedWallets}
+      disabled={loading}
     />
   );
 };

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
@@ -54,7 +54,7 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
     const isFirstTimeUser = targetGroupLength === 0;
 
     let success = false;
-    if (isFirstTimeUser) {
+    if (isFirstTimeUser && !isMultiWallet) {
       const alertConfigs = createConfigurations(
         eventTypes,
         inputs,

--- a/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
@@ -246,6 +246,8 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
           </NotifiAlertBox>
           <VerifyWalletView
             classNames={classNames?.VerifyWalletView}
+            data={data}
+            inputs={inputs}
             buttonText={
               cardView.state === 'verifyonboarding' ? 'Next' : 'Confirm'
             }


### PR DESCRIPTION
In the multi-wallet flow, we cannot actually subscribe until after the verifyonboarding step, as the user may connect additional wallets during this step.

Split up the two functions and make a network call on the Confirm button inside verify view