### PR TITLE
Add fallback renderer/ Filter out unsupported notification (MVP-2289)

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
@@ -11,7 +11,11 @@ import { useNotifiClientContext } from '../../../context';
 import { DeepPartialReadonly } from '../../../utils';
 import { MESSAGES_PER_PAGE } from '../../../utils/constants';
 import { AccountBalanceChangedRenderer } from '../../AlertHistory/AccountBalanceChangedRenderer';
-import { AlertNotificationViewProps } from '../../AlertHistory/AlertNotificationRow';
+import { AlertIcon } from '../../AlertHistory/AlertIcon';
+import {
+  AlertNotificationRow,
+  AlertNotificationViewProps,
+} from '../../AlertHistory/AlertNotificationRow';
 import { BroadcastMessageChangedRenderer } from '../../AlertHistory/BroadcastMessageChangedRenderer';
 import { ChatMessageReceivedRenderer } from '../../AlertHistory/ChatMessageReceivedRenderer';
 import { GenericDetailRenderer } from '../../AlertHistory/GenericDetailRenderer';
@@ -115,8 +119,20 @@ export const AlertCard: React.FC<{
           walletAddress={notification.sourceAddress ?? ''}
         />
       );
+    default:
+      // It should never come here because exception should be filtered out before. https://virtuoso.dev/troubleshooting/
+      return (
+        <AlertNotificationRow
+          handleAlertEntrySelection={handleAlertEntrySelection}
+          notificationTitle={'Unsupported notification'}
+          notificationImage={<AlertIcon icon={'INFO'} />}
+          notificationSubject={'Alert not supported yet'}
+          notificationDate={''}
+          notificationMessage={''}
+          classNames={classNames}
+        />
+      );
   }
-  return null;
 };
 
 export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
@@ -176,6 +192,22 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
     }
   }, [client]);
 
+  const validateSupportedDetailType = useCallback(
+    (entry?: NotificationHistoryEntry): boolean => {
+      const supportedEntryDetailTypes = [
+        'BroadcastMessageEventDetails',
+        'HealthValueOverThresholdEventDetails',
+        'GenericEventDetails',
+        'ChatMessageReceivedEventDetails',
+        'AccountBalanceChangedEventDetails',
+      ];
+      if (supportedEntryDetailTypes.includes(entry?.detail?.__typename ?? ''))
+        return true;
+      return false;
+    },
+    [],
+  );
+
   return (
     <div
       className={clsx(
@@ -202,9 +234,7 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
               });
             }
           }}
-          data={allNodes.filter(
-            (notification) => notification.detail != undefined,
-          )}
+          data={allNodes.filter(validateSupportedDetailType)}
           itemContent={(_index, notification) => {
             return (
               <AlertCard

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
@@ -127,12 +127,28 @@ export const AlertCard: React.FC<{
           notificationTitle={'Unsupported notification'}
           notificationImage={<AlertIcon icon={'INFO'} />}
           notificationSubject={'Alert not supported yet'}
-          notificationDate={''}
-          notificationMessage={''}
+          notificationDate={notification.createdDate}
+          notificationMessage={'Alert not supported yet'}
           classNames={classNames}
         />
       );
   }
+};
+
+// TODO: need to sync `supportedEntryDetailTypes` with switch statement in `AlertCard`.
+const validateSupportedDetailType = (
+  entry?: NotificationHistoryEntry,
+): boolean => {
+  const supportedEntryDetailTypes = [
+    'BroadcastMessageEventDetails',
+    'HealthValueOverThresholdEventDetails',
+    'GenericEventDetails',
+    'ChatMessageReceivedEventDetails',
+    'AccountBalanceChangedEventDetails',
+  ];
+  if (supportedEntryDetailTypes.includes(entry?.detail?.__typename ?? ''))
+    return true;
+  return false;
 };
 
 export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
@@ -191,22 +207,6 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
       });
     }
   }, [client]);
-
-  const validateSupportedDetailType = useCallback(
-    (entry?: NotificationHistoryEntry): boolean => {
-      const supportedEntryDetailTypes = [
-        'BroadcastMessageEventDetails',
-        'HealthValueOverThresholdEventDetails',
-        'GenericEventDetails',
-        'ChatMessageReceivedEventDetails',
-        'AccountBalanceChangedEventDetails',
-      ];
-      if (supportedEntryDetailTypes.includes(entry?.detail?.__typename ?? ''))
-        return true;
-      return false;
-    },
-    [],
-  );
 
   return (
     <div


### PR DESCRIPTION
# MVP-2289: Add fallback renderers for EventDetails

Add a new hook, useNotificationHistory, for the following 3 purposes:

1. Filter out the unsupported detailEntryType so that unsupported Entry will not be shown on historyCard. 
> *[Recommended approach](https://virtuoso.dev/troubleshooting/) from Virtuoso:*
> ```
> If you have zero-height items, you need to filter those out before passing them to the component. 
> The internal data structure needs a distinct position for each item. There's no way to fix this.
> ```

2. Add the fallback renderer (But this should never happen):
<img width="347" alt="Screenshot 2023-03-16 at 13 23 49" src="https://user-images.githubusercontent.com/127958634/225514460-2ab56f97-0d5b-47f0-b63b-8cf900d1ee2a.png">

3. Consolidate all the custom EventDetailRenderer components: we can get the associated props to pass into AlertNotificationRow by using this hook.