### PR TITLE
Copy Authorization when using multi-wallet

### DIFF
--- a/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
+++ b/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
@@ -221,6 +221,7 @@ const useNotifiClient = (
     isInitialized: boolean;
     isTokenExpired: boolean;
     expiry: string | null;
+    copyAuthorization: (publicKey: string) => Promise<void>;
   }> => {
   const { env, dappAddress, walletPublicKey, walletBlockchain } = config;
   const [isInitialized, setIsInitialized] = useState<boolean>(false);
@@ -1469,6 +1470,23 @@ const useNotifiClient = (
     }
   }, [setLoading, setError, service]);
 
+  const copyAuthorization = useCallback(
+    async (publicKey: string) => {
+      const [auth, roles] = await Promise.all([getAuthorization(), getRoles()]);
+      const otherStorage = storage({
+        walletPublicKey: publicKey,
+        jwtPrefix: notifiConfig.storagePrefix,
+        dappAddress,
+      });
+
+      await Promise.all([
+        otherStorage.setAuthorization(auth),
+        otherStorage.setRoles(roles),
+      ]);
+    },
+    [storage, notifiConfig, dappAddress],
+  );
+
   const client: NotifiClient = {
     beginLoginViaTransaction,
     broadcastMessage,
@@ -1503,6 +1521,7 @@ const useNotifiClient = (
     isAuthenticated,
     isInitialized,
     loading,
+    copyAuthorization,
     ...client,
   };
 };


### PR DESCRIPTION
There are various places where we want to copy the authorization to various keys. For every connected wallet, we should copy the authorization token to the storage of that wallet