### PR TITLE
Make Alert history title / description take up two rows (MVP-2286)

### DIFF
--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -324,9 +324,12 @@ input::-webkit-inner-spin-button {
   overflow: hidden;
   color: var(--notifi-font-color);
   font-weight: bold;
-  text-overflow: ellipsis;
-  width: 50%;
-  white-space: nowrap;
+  width: 100%;
+  white-space: pre-line;
+  word-wrap: break-word;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 .NotifiAlertHistory__notificationImage {
@@ -348,9 +351,12 @@ input::-webkit-inner-spin-button {
   font-size: 12px;
   line-height: 14px;
   color: var(--notifi-font-color);
-  text-overflow: ellipsis;
-  display: block;
   overflow: hidden;
+  white-space: pre-line;
+  word-wrap: break-word;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 .NotifiAlertHistory__manageAlertLink {


### PR DESCRIPTION
If title or description is long, let it take up to two rows. See the following example of Direct Push notification alert.
## Before:
<img width="351" alt="Screenshot 2023-03-20 at 13 56 38" src="https://user-images.githubusercontent.com/127958634/226250923-c4c3c417-eb84-47a7-b65c-bda04771c9fa.png">

## After:
<img width="347" alt="Screenshot 2023-03-20 at 13 48 51" src="https://user-images.githubusercontent.com/127958634/226250937-50e0d5e0-99f0-402f-971e-eb583ec9b644.png">
