### PR TITLE
Fix linting issues caused by lack of PropsWithChildren

### DIFF
--- a/packages/notifi-react-card/lib/context/NotifiDemoPreviewContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiDemoPreviewContext.tsx
@@ -1,4 +1,9 @@
-import React, { createContext, useContext, useMemo } from 'react';
+import React, {
+  PropsWithChildren,
+  createContext,
+  useContext,
+  useMemo,
+} from 'react';
 
 import {
   CardConfigItemV1,
@@ -40,11 +45,9 @@ const NotifiDemoPreviewContext = createContext<NotifiDemoPreviewContextData>(
   {} as unknown as NotifiDemoPreviewContextData, // Intentionally empty in default
 );
 
-export const NotifiDemoPreviewContextProvider: React.FC<DemoPreview> = ({
-  children,
-  view,
-  data,
-}) => {
+export const NotifiDemoPreviewContextProvider: React.FC<
+  PropsWithChildren<DemoPreview>
+> = ({ children, view, data }) => {
   const demoPreview = useMemo(() => ({ view, data }), [view, data]);
 
   return (

--- a/packages/notifi-react-card/lib/context/NotifiFormContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiFormContext.tsx
@@ -27,7 +27,9 @@ export type NotifiFormData = Readonly<{
 
 const NotifiFormContext = createContext<NotifiFormData>({} as NotifiFormData);
 
-export const NotifiFormProvider: React.FC = ({ children }) => {
+export const NotifiFormProvider: React.FC<PropsWithChildren> = ({
+  children,
+}) => {
   const [hasChanges, setHasChanges] = useState<boolean>(false);
   const [formState, setFormInput] = useState<DestinationInputs>({
     email: '',


### PR DESCRIPTION
# Problem
Linting error when building
```
lerna ERR! npm run build stderr:
lib/components/intercom/NotifiIntercomCard.tsx(46,8): error TS2559: Type '{ children: Element; }' has no properties in common with type 'IntrinsicAttributes'.
```
# Fix
## Add PropsWithChildren to related components.