### PR TITLE
updates url not needing state

### DIFF
--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -221,10 +221,9 @@ export const useNotifiSubscribe: ({
           client
             .getDiscordTargetVerificationLink(discordId)
             .then((discordURL) => {
-              const updatedDiscordURLWithId = `${discordURL}state=${discordId}`;
               setDiscordErrorMessage({
                 type: 'recoverableError',
-                onClick: () => window.open(updatedDiscordURLWithId, '_blank'),
+                onClick: () => window.open(discordURL, '_blank'),
                 message: 'Enable Bot',
               });
             })


### PR DESCRIPTION
URL already included a state for the target id being returned.