### PR TITLE
eric/MVP-2257-patch: Auto re-render dummy preview when config data is changed

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
@@ -150,6 +150,7 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
     setCardView,
     cardView.state,
     isInitialized,
+    demoPreview,
   ]);
 
   const rightIcon: NotifiAlertBoxButtonProps | undefined = useMemo(() => {

--- a/packages/notifi-react-card/lib/hooks/useSubscriptionCard.ts
+++ b/packages/notifi-react-card/lib/hooks/useSubscriptionCard.ts
@@ -69,7 +69,7 @@ export const useSubscriptionCard = (
           });
         }
       });
-  }, [input.id, input.type]);
+  }, [input.id, input.type, demoPreview]);
 
   return state;
 };


### PR DESCRIPTION
This patch makes the dummy preview card re-render when the demoPreview args passed in is changed. 
See below demonstration.

https://user-images.githubusercontent.com/127958634/230322096-e49c4c2e-d396-429a-929b-6260b0265ca9.mov

