### PR TITLE
Add a name when the id is parameterized

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48061,14 +48061,14 @@
         "@types/react-dom": "^18.0.0",
         "buffer": "^6.0.3",
         "crypto-browserify": "^3.12.0",
-        "ethers": "^5",
+        "ethers": "^5.7.2",
         "react": "^18.2.0",
         "react-app-rewired": "^2.2.1",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
         "stream-browserify": "^3.0.0",
         "typescript": "^4.6.3",
-        "wagmi": "*",
+        "wagmi": "^0.12.8",
         "web-vitals": "^2.1.4"
       },
       "dependencies": {

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeBroadcastRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeBroadcastRow.tsx
@@ -45,9 +45,19 @@ export const EventTypeBroadcastRow: React.FC<EventTypeBroadcastRowProps> = ({
   const [isNotificationLoading, setIsNotificationLoading] =
     useState<boolean>(false);
 
-  const alertName = useMemo<string>(() => config.name, [config]);
+  const broadcastId = useMemo(
+    () => resolveStringRef(config.name, config.broadcastId, inputs),
+    [config, inputs],
+  );
+
+  const alertName = useMemo<string>(() => {
+    if (config.broadcastId.type === 'value') {
+      return config.name;
+    }
+    return `${config.name}:${broadcastId}`;
+  }, [config, broadcastId]);
+
   const alertConfiguration = useMemo<AlertConfiguration>(() => {
-    const broadcastId = resolveStringRef(alertName, config.broadcastId, inputs);
     return broadcastMessageConfiguration({
       topicName: broadcastId,
     });
@@ -95,7 +105,7 @@ export const EventTypeBroadcastRow: React.FC<EventTypeBroadcastRowProps> = ({
       setEnabled(false);
       instantSubscribe({
         alertConfiguration: null,
-        alertName: alertName,
+        alertName,
       })
         .then((res) => {
           // We update optimistically so we need to check if the alert exists.

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeDirectPushRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeDirectPushRow.tsx
@@ -38,9 +38,18 @@ export const EventTypeDirectPushRow: React.FC<EventTypeDirectPushRowProps> = ({
   });
   const [enabled, setEnabled] = useState(false);
 
-  const alertName = useMemo<string>(() => config.name, [config]);
+  const pushId = useMemo(
+    () => resolveStringRef(config.name, config.directPushId, inputs),
+    [config, inputs],
+  );
+  const alertName = useMemo<string>(() => {
+    if (config.directPushId.type === 'value') {
+      return config.name;
+    }
+
+    return `${config.name}:${pushId}`;
+  }, [config, pushId]);
   const alertConfiguration = useMemo<AlertConfiguration>(() => {
-    const pushId = resolveStringRef(alertName, config.directPushId, inputs);
     return directMessageConfiguration({
       type: pushId,
     });

--- a/packages/notifi-react-card/lib/context/NotifiFormContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiFormContext.tsx
@@ -27,7 +27,7 @@ export type NotifiFormData = Readonly<{
 
 const NotifiFormContext = createContext<NotifiFormData>({} as NotifiFormData);
 
-export const NotifiFormProvider: React.FC<PropsWithChildren> = ({
+export const NotifiFormProvider: React.FC<PropsWithChildren<unknown>> = ({
   children,
 }) => {
   const [hasChanges, setHasChanges] = useState<boolean>(false);


### PR DESCRIPTION
We want to use the same card in multiple pages on the dApp, parameterized by some value, to provide notifications.

When we use the same alert name, the configurations will step on each other, resulting in one page's settings overriding another page's.

If the ID is an input value, parameterize the alert name in order to avoid this situation