### PR TITLE
adds loading state card for edit card

### DIFF
--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -1659,3 +1659,11 @@ input::-webkit-inner-spin-button {
   flex-grow: 1;
   padding: 0 20px;
 }
+
+
+.NotifiInputContainer__LoadingSpinner {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-grow: 1;
+}

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
@@ -106,7 +106,7 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
       onClick={onClick}
     >
       <span className={clsx('NotifiSubscribeButton__label', classNames?.label)}>
-        {buttonText}
+        {loading ? 'Loading' : buttonText}
       </span>
     </button>
   );

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/EditCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/EditCardView.tsx
@@ -2,7 +2,9 @@ import clsx from 'clsx';
 import { DeepPartialReadonly } from 'notifi-react-card/lib/utils';
 import React from 'react';
 
+import { useNotifiSubscriptionContext } from '../../../context/NotifiSubscriptionContext';
 import { CardConfigItemV1 } from '../../../hooks';
+import Spinner from '../../common/Spinner';
 import {
   NotifiSubscribeButton,
   NotifiSubscribeButtonProps,
@@ -47,6 +49,8 @@ export const EditCardView: React.FC<EditCardViewProps> = ({
   inputTextFields,
   inputs,
 }) => {
+  const { loading } = useNotifiSubscriptionContext();
+
   return (
     <div
       className={clsx('NotifiInputContainer', classNames?.NotifiInputContainer)}
@@ -58,14 +62,19 @@ export const EditCardView: React.FC<EditCardViewProps> = ({
           eventTypes={data.eventTypes}
         />
       ) : null}
-
-      <InputFields
-        data={data}
-        allowedCountryCodes={allowedCountryCodes}
-        inputDisabled={inputDisabled}
-        inputSeparators={inputSeparators}
-        inputTextFields={inputTextFields}
-      />
+      {loading ? (
+        <div className="NotifiInputContainer__LoadingSpinner">
+          <Spinner size="100px" />
+        </div>
+      ) : (
+        <InputFields
+          data={data}
+          allowedCountryCodes={allowedCountryCodes}
+          inputDisabled={inputDisabled}
+          inputSeparators={inputSeparators}
+          inputTextFields={inputTextFields}
+        />
+      )}
       <NotifiSubscribeButton
         buttonText={buttonText}
         data={data}

--- a/packages/notifi-react-card/lib/context/NotifiDemoPreviewContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiDemoPreviewContext.tsx
@@ -19,7 +19,7 @@ export type DemoPreview = {
 export const defaultDemoConfigV1: CardConfigItemV1 = {
   version: 'v1',
   id: '@notifi.network', // Shown as dummy telegram id
-  name: 'notofi@notifi.network', // Shown as dummy email field
+  name: 'notifi@notifi.network', // Shown as dummy email field
   eventTypes: [],
   inputs: [],
   contactInfo: {

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -336,7 +336,6 @@ export const useNotifiSubscribe: ({
   const logIn = useCallback(async (): Promise<SubscriptionData> => {
     if (demoPreview)
       throw new Error('Preview card does not support method call');
-    setLoading(true);
     if (!client.isAuthenticated) {
       if (useHardwareWallet) {
         await logInViaHardwareWallet();
@@ -349,7 +348,6 @@ export const useNotifiSubscribe: ({
 
     copyAuths(newData);
     const results = render(newData);
-    setLoading(false);
     return results;
   }, [
     client.isAuthenticated,
@@ -544,8 +542,6 @@ export const useNotifiSubscribe: ({
       if (isValidPhoneNumber(formPhoneNumber)) {
         finalPhoneNumber = formPhoneNumber;
       }
-
-      // if useDiscord is true, we create a random id for the discord target creation
 
       setLoading(true);
 


### PR DESCRIPTION
There was no loading indicator to the user when submitting the card.


also, because we had `logIn` setting loading to false, it'd prematurely flicker back to the card.
https://user-images.githubusercontent.com/105258726/232606571-edf84b91-2041-4f7e-a680-974efd4c39ec.mov

