### PR TITLE
Remove the error sample

### DIFF
--- a/packages/notifi-react-example/src/NotifiCard/DemoPreviewCard.tsx
+++ b/packages/notifi-react-example/src/NotifiCard/DemoPreviewCard.tsx
@@ -21,18 +21,6 @@ export const DemoPrviewCard = () => {
           <NotifiSubscriptionCard darkMode cardId="" />
         </NotifiContext>
       </NotifiDemoPreviewContextProvider>
-      <NotifiDemoPreviewContextProvider view="error" data={JSON.parse(data)}>
-        <NotifiContext
-          dappAddress=""
-          env="Development"
-          walletBlockchain="SOLANA"
-          walletPublicKey="string"
-          signMessage={async (msg: Uint8Array) => msg}
-          hardwareLoginPlugin={{ sendMessage: async (msg: string) => msg }}
-        >
-          <NotifiSubscriptionCard darkMode cardId="" />
-        </NotifiContext>
-      </NotifiDemoPreviewContextProvider>
       Dummy Demo NotifiSubscriptionCard: Edit page
       <NotifiDemoPreviewContextProvider view="edit" data={JSON.parse(data)}>
         <NotifiContext


### PR DESCRIPTION
This sample is no longer valid, since 'error' is not a valid value for DemoPreviewContextProvider `view`