### PR TITLE
Set module on react-card

### DIFF
--- a/packages/notifi-react-card/package.json
+++ b/packages/notifi-react-card/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://github.com/notifi-network/notifi-sdk-ts#readme",
   "license": "MIT",
   "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -20,7 +21,7 @@
   "scripts": {
     "build": "npm run clean && npm run compile",
     "clean": "rimraf ./dist",
-    "compile": "tsup lib/index.ts --format cjs,esm --dts --clean --external react",
+    "compile": "tsup lib/index.ts --sourcemap --format cjs,esm --dts --clean --external react",
     "format": "prettier --config .prettierrc **/*.ts --write",
     "lint": "eslint ."
   },


### PR DESCRIPTION
We are already generating .mjs files, we should allow customers to use them so we can better support tree-shaking (e.g. date-fns)