### PR TITLE
MVP-2496:  Add `connectWallet` service method back in `notifi-graphql`

### DIFF
--- a/packages/notifi-graphql/lib/NotifiService.ts
+++ b/packages/notifi-graphql/lib/NotifiService.ts
@@ -11,6 +11,7 @@ export class NotifiService
     Operations.BeginLogInByTransactionService,
     Operations.BroadcastMessageService,
     Operations.CompleteLogInByTransactionService,
+    Operations.ConnectWalletService,
     Operations.CreateAlertService,
     Operations.CreateDirectPushAlertService,
     Operations.CreateEmailTargetService,
@@ -102,6 +103,13 @@ export class NotifiService
       this._jwt = token;
     }
     return result;
+  }
+
+  async connectWallet(
+    variables: Generated.ConnectWalletMutationVariables,
+  ): Promise<Generated.ConnectWalletMutation> {
+    const headers = this._requestHeaders();
+    return await this._typedClient.connectWallet(variables, headers);
   }
 
   async createAlert(

--- a/packages/notifi-graphql/lib/gql/fragments/ConnectedWalletFragment.gql.ts
+++ b/packages/notifi-graphql/lib/gql/fragments/ConnectedWalletFragment.gql.ts
@@ -1,0 +1,8 @@
+import { gql } from 'graphql-request';
+
+export const ConnectedWalletFragment = gql`
+  fragment ConnectedWalletFragment on ConnectedWallet {
+    address
+    walletBlockchain
+  }
+`;

--- a/packages/notifi-graphql/lib/gql/mutations/connectWallet.gql.ts
+++ b/packages/notifi-graphql/lib/gql/mutations/connectWallet.gql.ts
@@ -1,0 +1,28 @@
+import { gql } from 'graphql-request';
+
+import { ConnectedWalletFragment } from '../fragments/ConnectedWalletFragment.gql';
+
+export const ConnectWallet = gql`
+  mutation connectWallet(
+    $walletPublicKey: String!
+    $timestamp: Long!
+    $signature: String!
+    $walletBlockchain: WalletBlockchain!
+    $accountId: String
+    $connectWalletConflictResolutionTechnique: ConnectWalletConflictResolutionTechnique
+  ) {
+    connectWallet(
+      connectWalletInput: {
+        walletPublicKey: $walletPublicKey
+        timestamp: $timestamp
+        walletBlockchain: $walletBlockchain
+        accountId: $accountId
+        connectWalletConflictResolutionTechnique: $connectWalletConflictResolutionTechnique
+      }
+      signature: $signature
+    ) {
+      ...ConnectedWalletFragment
+    }
+  }
+  ${ConnectedWalletFragment}
+`;

--- a/packages/notifi-graphql/lib/operations/ConnectWallet.ts
+++ b/packages/notifi-graphql/lib/operations/ConnectWallet.ts
@@ -1,0 +1,10 @@
+import {
+  ConnectWalletMutation,
+  ConnectWalletMutationVariables,
+} from '../gql/generated';
+
+export type ConnectWalletService = Readonly<{
+  connectWallet: (
+    variables: ConnectWalletMutationVariables,
+  ) => Promise<ConnectWalletMutation>;
+}>;

--- a/packages/notifi-graphql/lib/operations/index.ts
+++ b/packages/notifi-graphql/lib/operations/index.ts
@@ -44,3 +44,4 @@ export * from './SendEmailTargetVerificationRequest';
 export * from './UpdateSourceGroup';
 export * from './UpdateTargetGroup';
 export * from './GetDiscordTargets';
+export * from './ConnectWallet';


### PR DESCRIPTION
# Add `connectWallet` service method back in `notifi-graphql`
`connectWallet` services method is missing inside the `notifi-graphql`. 
Add it back it