### PR TITLE
no longer need to include phantom

### DIFF
--- a/packages/notifi-react-example/src/walletProviders/SolanaWalletProvider.tsx
+++ b/packages/notifi-react-example/src/walletProviders/SolanaWalletProvider.tsx
@@ -7,7 +7,6 @@ import {
   WalletModalProvider,
 } from '@solana/wallet-adapter-react-ui';
 import {
-  PhantomWalletAdapter,
   SolflareWalletAdapter,
 } from '@solana/wallet-adapter-wallets';
 import { clusterApiUrl } from '@solana/web3.js';
@@ -35,7 +34,6 @@ export const SolanaWalletProvider: FC<PropsWithChildren<{}>> = ({
        * will be compiled into your application, and only the dependencies of wallets that
        * your users connect to will be loaded.
        */
-      new PhantomWalletAdapter({ network }),
       new SolflareWalletAdapter({ network }),
     ],
     [network],


### PR DESCRIPTION
phantom was added directly to the wallet standard kit.

wanted to remove. here's the warning:
act_devtools_backend.js:2655 Phantom was registered as a Standard Wallet. The Wallet Adapter for Phantom can be removed from your app.