### PR TITLE
MVP-2511: Add GetConnectedWalletsService back in notifi-graphql

### DIFF
--- a/packages/notifi-graphql/lib/NotifiService.ts
+++ b/packages/notifi-graphql/lib/NotifiService.ts
@@ -30,6 +30,7 @@ export class NotifiService
     Operations.FindTenantConfigService,
     Operations.GetAlertsService,
     Operations.GetConfigurationForDappService,
+    Operations.GetConnectedWalletsService,
     Operations.GetEmailTargetsService,
     Operations.GetFiltersService,
     Operations.GetNotificationHistoryService,
@@ -249,6 +250,13 @@ export class NotifiService
   ): Promise<Generated.GetConfigurationForDappQuery> {
     const headers = this._requestHeaders();
     return this._typedClient.getConfigurationForDapp(variables, headers);
+  }
+
+  async getConnectedWallets(
+    variables: Generated.GetConnectedWalletsQueryVariables,
+  ): Promise<Generated.GetConnectedWalletsQuery> {
+    const headers = this._requestHeaders();
+    return this._typedClient.getConnectedWallets(variables, headers);
   }
 
   async getEmailTargets(

--- a/packages/notifi-graphql/lib/gql/queries/getConnectedWallets.gql.ts
+++ b/packages/notifi-graphql/lib/gql/queries/getConnectedWallets.gql.ts
@@ -1,0 +1,12 @@
+import { gql } from 'graphql-request';
+
+import { ConnectedWalletFragment } from '../fragments/ConnectedWalletFragment.gql';
+
+export const GetConnectedWallets = gql`
+  query getConnectedWallets {
+    connectedWallet {
+      ...ConnectedWalletFragment
+    }
+  }
+  ${ConnectedWalletFragment}
+`;

--- a/packages/notifi-graphql/lib/operations/GetConnectedWallets.ts
+++ b/packages/notifi-graphql/lib/operations/GetConnectedWallets.ts
@@ -1,0 +1,10 @@
+import {
+  GetConnectedWalletsQuery,
+  GetConnectedWalletsQueryVariables,
+} from '../gql/generated';
+
+export type GetConnectedWalletsService = Readonly<{
+  getConnectedWallets: (
+    variables: GetConnectedWalletsQueryVariables,
+  ) => Promise<GetConnectedWalletsQuery>;
+}>;

--- a/packages/notifi-graphql/lib/operations/index.ts
+++ b/packages/notifi-graphql/lib/operations/index.ts
@@ -45,3 +45,4 @@ export * from './UpdateSourceGroup';
 export * from './UpdateTargetGroup';
 export * from './GetDiscordTargets';
 export * from './ConnectWallet';
+export * from './GetConnectedWallets';


### PR DESCRIPTION
Add `getConnectedWallets` service back in notifi-graphql