### PR TITLE
MVP-2514: Add intercom related services back in notifi-graphql

### DIFF
--- a/packages/notifi-graphql/lib/NotifiService.ts
+++ b/packages/notifi-graphql/lib/NotifiService.ts
@@ -18,6 +18,7 @@ export class NotifiService
     Operations.CreateSmsTargetService,
     Operations.CreateSourceService,
     Operations.CreateSourceGroupService,
+    Operations.CreateSupportConversationService,
     Operations.CreateTargetGroupService,
     Operations.CreateTelegramTargetService,
     Operations.CreateTenantUserService,
@@ -30,6 +31,7 @@ export class NotifiService
     Operations.FindTenantConfigService,
     Operations.GetAlertsService,
     Operations.GetConfigurationForDappService,
+    Operations.GetConversationMessagesService,
     Operations.GetConnectedWalletsService,
     Operations.GetEmailTargetsService,
     Operations.GetFiltersService,
@@ -48,6 +50,7 @@ export class NotifiService
     Operations.LogInFromServiceService,
     Operations.RefreshAuthorizationService,
     Operations.RemoveSourceFromSourceGroupService,
+    Operations.SendConversationMessageService,
     Operations.SendEmailTargetVerificationRequestService,
     Operations.SendMessageService,
     Operations.UpdateSourceGroupService,
@@ -161,6 +164,13 @@ export class NotifiService
     return this._typedClient.createSourceGroup(variables, headers);
   }
 
+  async createSupportConversation(
+    variables: Generated.CreateSupportConversationMutationVariables,
+  ): Promise<Generated.CreateSupportConversationMutation> {
+    const headers = this._requestHeaders();
+    return this._typedClient.createSupportConversation(variables, headers);
+  }
+
   async createTargetGroup(
     variables: Generated.CreateTargetGroupMutationVariables,
   ): Promise<Generated.CreateTargetGroupMutation> {
@@ -257,6 +267,13 @@ export class NotifiService
   ): Promise<Generated.GetConnectedWalletsQuery> {
     const headers = this._requestHeaders();
     return this._typedClient.getConnectedWallets(variables, headers);
+  }
+
+  async getConversationMessages(
+    variables: Generated.GetConversationMessagesQueryVariables,
+  ): Promise<Generated.GetConversationMessagesQuery> {
+    const headers = this._requestHeaders();
+    return this._typedClient.getConversationMessages(variables, headers);
   }
 
   async getEmailTargets(
@@ -400,6 +417,13 @@ export class NotifiService
   ): Promise<Generated.RemoveSourceFromSourceGroupMutation> {
     const headers = this._requestHeaders();
     return this._typedClient.removeSourceFromSourceGroup(variables, headers);
+  }
+
+  async sendConversationMessages(
+    variables: Generated.SendConversationMessageMutationVariables,
+  ): Promise<Generated.SendConversationMessageMutation> {
+    const headers = this._requestHeaders();
+    return this._typedClient.sendConversationMessage(variables, headers);
   }
 
   async sendEmailTargetVerificationRequest(

--- a/packages/notifi-graphql/lib/gql/fragments/ConvMessagePageInfoFragment.gql.ts
+++ b/packages/notifi-graphql/lib/gql/fragments/ConvMessagePageInfoFragment.gql.ts
@@ -1,0 +1,8 @@
+import { gql } from 'graphql-request';
+
+export const ConvMessagePageInfoFragment = gql`
+  fragment ConvMessagePageInfo on PageInfo {
+    hasNextPage
+    endCursor
+  }
+`;

--- a/packages/notifi-graphql/lib/gql/fragments/ConversationMessageFragment.gql.ts
+++ b/packages/notifi-graphql/lib/gql/fragments/ConversationMessageFragment.gql.ts
@@ -1,0 +1,18 @@
+import { gql } from 'graphql-request';
+
+import { ParticipantFragment } from './ParticipantFragment.gql';
+
+export const ConversationMessageFragment = gql`
+  fragment ConversationMessage on ConversationMessage {
+    id
+    userId
+    conversationId
+    createdDate
+    updatedDate
+    message
+    conversationParticipant {
+      ...Participant
+    }
+  }
+  ${ParticipantFragment}
+`;

--- a/packages/notifi-graphql/lib/gql/fragments/ParticipantFragment.gql.ts
+++ b/packages/notifi-graphql/lib/gql/fragments/ParticipantFragment.gql.ts
@@ -1,0 +1,20 @@
+import { gql } from 'graphql-request';
+
+export const ParticipantFragment = gql`
+  fragment Participant on ConversationParticipant {
+    conversationId
+    conversationParticipantType
+    profile {
+      avatarData
+      avatarDataType
+      id
+      preferredAddress
+      preferredBlockchain
+      preferredName
+    }
+    resolvedName
+    userId
+    walletAddress
+    walletBlockchain
+  }
+`;

--- a/packages/notifi-graphql/lib/gql/mutations/createSupportConversation.gql.ts
+++ b/packages/notifi-graphql/lib/gql/mutations/createSupportConversation.gql.ts
@@ -1,0 +1,27 @@
+import { gql } from 'graphql-request';
+
+export const CreateSupportConversation = gql`
+  mutation createSupportConversation {
+    createSupportConversation {
+      id
+      conversationType
+      conversationGates {
+        id
+      }
+      name
+      createdDate
+      participants {
+        conversationParticipantType
+        profile {
+          id
+          preferredAddress
+          preferredName
+          avatarData
+          avatarDataType
+        }
+        resolvedName
+      }
+      backgroundImageUrl
+    }
+  }
+`;

--- a/packages/notifi-graphql/lib/gql/mutations/sendConversationMessages.gql.ts
+++ b/packages/notifi-graphql/lib/gql/mutations/sendConversationMessages.gql.ts
@@ -1,0 +1,16 @@
+import { gql } from 'graphql-request';
+
+import { ConversationMessageFragment } from '../fragments/ConversationMessageFragment.gql';
+
+export const SendConversationMessages = gql`
+  mutation sendConversationMessage(
+    $sendConversationMessageInput: SendConversationMessageInput!
+  ) {
+    sendConversationMessage(
+      sendConversationMessageInput: $sendConversationMessageInput
+    ) {
+      ...ConversationMessage
+    }
+  }
+  ${ConversationMessageFragment}
+`;

--- a/packages/notifi-graphql/lib/gql/queries/getConversationMessages.gql.ts
+++ b/packages/notifi-graphql/lib/gql/queries/getConversationMessages.gql.ts
@@ -1,0 +1,27 @@
+import { gql } from 'graphql-request';
+
+import { ConvMessagePageInfoFragment } from '../fragments/ConvMessagePageInfoFragment.gql';
+import { ConversationMessageFragment } from '../fragments/ConversationMessageFragment.gql';
+
+export const GetConversationMessages = gql`
+  query getConversationMessages(
+    $getConversationMessagesInput: GetConversationMessagesInput!
+    $after: String
+    $first: Int
+  ) {
+    conversationMessages(
+      first: $first
+      after: $after
+      getConversationMessagesInput: $getConversationMessagesInput
+    ) {
+      nodes {
+        ...ConversationMessage
+      }
+      pageInfo {
+        ...ConvMessagePageInfo
+      }
+    }
+  }
+  ${ConvMessagePageInfoFragment}
+  ${ConversationMessageFragment}
+`;

--- a/packages/notifi-graphql/lib/operations/CreateSupportConversation.ts
+++ b/packages/notifi-graphql/lib/operations/CreateSupportConversation.ts
@@ -1,0 +1,10 @@
+import {
+  CreateSupportConversationMutation,
+  CreateSupportConversationMutationVariables,
+} from '../gql/generated';
+
+export type CreateSupportConversationService = Readonly<{
+  createSupportConversation: (
+    variables: CreateSupportConversationMutationVariables,
+  ) => Promise<CreateSupportConversationMutation>;
+}>;

--- a/packages/notifi-graphql/lib/operations/GetConversationMessages.ts
+++ b/packages/notifi-graphql/lib/operations/GetConversationMessages.ts
@@ -1,0 +1,10 @@
+import {
+  GetConversationMessagesQuery,
+  GetConversationMessagesQueryVariables,
+} from '../gql/generated';
+
+export type GetConversationMessagesService = Readonly<{
+  getConversationMessages: (
+    variables: GetConversationMessagesQueryVariables,
+  ) => Promise<GetConversationMessagesQuery>;
+}>;

--- a/packages/notifi-graphql/lib/operations/SendConversationMessages.ts
+++ b/packages/notifi-graphql/lib/operations/SendConversationMessages.ts
@@ -1,0 +1,10 @@
+import {
+  SendConversationMessageMutation,
+  SendConversationMessageMutationVariables,
+} from '../gql/generated';
+
+export type SendConversationMessageService = Readonly<{
+  sendConversationMessages: (
+    variables: SendConversationMessageMutationVariables,
+  ) => Promise<SendConversationMessageMutation>;
+}>;

--- a/packages/notifi-graphql/lib/operations/index.ts
+++ b/packages/notifi-graphql/lib/operations/index.ts
@@ -46,3 +46,6 @@ export * from './UpdateTargetGroup';
 export * from './GetDiscordTargets';
 export * from './ConnectWallet';
 export * from './GetConnectedWallets';
+export * from './GetConversationMessages';
+export * from './SendConversationMessages';
+export * from './CreateSupportConversation';


### PR DESCRIPTION
As title, add back the following 3 services so that FrontendClient can consume the service method.
1. getConversationMessage
2. sendConversationMessages
3. createSupportConversation