### PR TITLE
MVP-2527: Add TradingPairEventTypeItem type in notifi-frontend-client

### DIFF
--- a/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
+++ b/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
@@ -33,6 +33,13 @@ export type LabelEventTypeItem = Readonly<{
   tooltipContent?: string;
 }>;
 
+export type TradingPairEventTypeItem = Readonly<{
+  type: 'tradingPair';
+  name: string;
+  tooltipContent?: string;
+  tradingPairs: ValueOrRef<ReadonlyArray<string>>;
+}>;
+
 export type PriceChangeDataSource = 'coingecko';
 
 export type PriceChangeEventTypeItem = Readonly<{
@@ -85,6 +92,7 @@ export type CustomTopicTypeItem = CustomTypeBase &
 export type EventTypeItem =
   | DirectPushEventTypeItem
   | BroadcastEventTypeItem
+  | TradingPairEventTypeItem
   | LabelEventTypeItem
   | PriceChangeEventTypeItem
   | CustomTopicTypeItem;

--- a/packages/notifi-frontend-client/lib/utils/resolveRef.ts
+++ b/packages/notifi-frontend-client/lib/utils/resolveRef.ts
@@ -41,3 +41,12 @@ export const resolveNumberRef = createRefResolver(
     return typeof item === 'number' && !Number.isNaN(item);
   },
 );
+
+export const resolveStringArrayRef = createRefResolver(
+  (item: unknown): item is ReadonlyArray<string> => {
+    return (
+      Array.isArray(item) &&
+      item.every((element) => typeof element === 'string')
+    );
+  },
+);


### PR DESCRIPTION
Implement missing TradingPairEventTypeItem type and its related helper functions that will be consumed by notifi-react-card