### PR TITLE
MVP-2537 + MVP- 2538: multi-chain option & DRY

### DIFF
--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -6,7 +6,8 @@ import { Types } from '@notifi-network/notifi-graphql';
 import { NotifiService } from '@notifi-network/notifi-graphql';
 
 import type {
-  NotifiEvmConfiguration,
+  NotifiConfigWithPublicKey,
+  NotifiConfigWithPublicKeyAndAddress,
   NotifiFrontendConfiguration,
 } from '../configuration';
 import type {
@@ -213,6 +214,14 @@ export class NotifiFrontendClient {
     signMessageParams: SignMessageParams;
     timestamp: number;
   }>): Promise<string> {
+    if (
+      this._configuration.walletBlockchain !==
+      signMessageParams.walletBlockchain
+    ) {
+      throw new Error(
+        'Sign message params and configuration must have the same blockchain',
+      );
+    }
     switch (signMessageParams.walletBlockchain) {
       case 'ETHEREUM':
       case 'POLYGON':
@@ -220,15 +229,8 @@ export class NotifiFrontendClient {
       case 'AVALANCHE':
       case 'BINANCE':
       case 'OPTIMISM': {
-        if (
-          this._configuration.walletBlockchain !==
-          signMessageParams.walletBlockchain
-        ) {
-          throw new Error(
-            'Sign message params and configuration must have the same blockchain',
-          );
-        }
-        const { walletPublicKey, tenantId } = this._configuration;
+        const { walletPublicKey, tenantId } = this
+          ._configuration as NotifiConfigWithPublicKey;
         const messageBuffer = new TextEncoder().encode(
           `${SIGNING_MESSAGE}${walletPublicKey}${tenantId}${timestamp.toString()}`,
         );
@@ -240,15 +242,8 @@ export class NotifiFrontendClient {
         return signature;
       }
       case 'INJECTIVE': {
-        if (
-          this._configuration.walletBlockchain !==
-          signMessageParams.walletBlockchain
-        ) {
-          throw new Error(
-            'Sign message params and configuration must have the same blockchain',
-          );
-        }
-        const { authenticationKey, tenantId } = this._configuration;
+        const { authenticationKey, tenantId } = this
+          ._configuration as NotifiConfigWithPublicKeyAndAddress;
         const messageBuffer = new TextEncoder().encode(
           `${SIGNING_MESSAGE}${authenticationKey}${tenantId}${timestamp.toString()}`,
         );
@@ -258,15 +253,8 @@ export class NotifiFrontendClient {
         return signature;
       }
       case 'SOLANA': {
-        if (
-          this._configuration.walletBlockchain !==
-          signMessageParams.walletBlockchain
-        ) {
-          throw new Error(
-            'Sign message params and configuration must have the same blockchain',
-          );
-        }
-        const { walletPublicKey, tenantId } = this._configuration;
+        const { walletPublicKey, tenantId } = this
+          ._configuration as NotifiConfigWithPublicKey;
         const messageBuffer = new TextEncoder().encode(
           `${SIGNING_MESSAGE}${walletPublicKey}${tenantId}${timestamp.toString()}`,
         );
@@ -276,13 +264,8 @@ export class NotifiFrontendClient {
         return signature;
       }
       case 'ACALA': {
-        if (this._configuration.walletBlockchain !== 'ACALA') {
-          throw new Error(
-            'Sign message params and configuration must have the same blockchain',
-          );
-        }
-
-        const { accountAddress, tenantId } = this._configuration;
+        const { accountAddress, tenantId } = this
+          ._configuration as NotifiConfigWithPublicKeyAndAddress;
 
         const message = `${SIGNING_MESSAGE}${accountAddress}${tenantId}${timestamp.toString()}`;
         const signedBuffer = await signMessageParams.signMessage(
@@ -292,11 +275,6 @@ export class NotifiFrontendClient {
         return signedBuffer;
       }
       case 'APTOS': {
-        if (this._configuration.walletBlockchain !== 'APTOS') {
-          throw new Error(
-            'Sign message params and configuration must have the same blockchain',
-          );
-        }
         const signature = await signMessageParams.signMessage(
           SIGNING_MESSAGE,
           timestamp,
@@ -304,12 +282,8 @@ export class NotifiFrontendClient {
         return signature;
       }
       case 'SUI': {
-        if (this._configuration.walletBlockchain !== 'SUI') {
-          throw new Error(
-            'Sign message params and configuration must have the same blockchain',
-          );
-        }
-        const { accountAddress, tenantId } = this._configuration;
+        const { accountAddress, tenantId } = this
+          ._configuration as NotifiConfigWithPublicKeyAndAddress;
         const messageBuffer = new TextEncoder().encode(
           `${SIGNING_MESSAGE}${accountAddress}${tenantId}${timestamp.toString()}`,
         );
@@ -318,14 +292,8 @@ export class NotifiFrontendClient {
         return signature;
       }
       case 'NEAR': {
-        if (this._configuration.walletBlockchain !== 'NEAR') {
-          throw new Error(
-            'Sign message params and configuration must have the same blockchain',
-          );
-        }
-
-        const { authenticationKey, accountAddress, tenantId } =
-          this._configuration;
+        const { authenticationKey, accountAddress, tenantId } = this
+          ._configuration as NotifiConfigWithPublicKeyAndAddress;
 
         const message = `${
           `ed25519:` + authenticationKey

--- a/packages/notifi-frontend-client/lib/client/clientFactory.ts
+++ b/packages/notifi-frontend-client/lib/client/clientFactory.ts
@@ -1,17 +1,7 @@
 import { NotifiService } from '@notifi-network/notifi-graphql';
 import { GraphQLClient } from 'graphql-request';
 
-import {
-  NotifiAcalaConfiguration,
-  NotifiAptosConfiguration,
-  NotifiEvmConfiguration,
-  NotifiFrontendConfiguration,
-  NotifiInjectiveConfiguration,
-  NotifiNearConfiguration,
-  NotifiSolanaConfiguration,
-  NotifiSuiConfiguration,
-  envUrl,
-} from '../configuration';
+import { NotifiFrontendConfiguration, envUrl } from '../configuration';
 import {
   NotifiFrontendStorage,
   createLocalForageStorageDriver,
@@ -29,43 +19,7 @@ export const newNotifiService = (config: NotifiFrontendConfiguration) => {
   return new NotifiService(client);
 };
 
-export const newAcalaClient = (config: NotifiAcalaConfiguration) => {
-  const service = newNotifiService(config);
-  const storage = newNotifiStorage(config);
-  return new NotifiFrontendClient(config, service, storage);
-};
-
-export const newAptosClient = (config: NotifiAptosConfiguration) => {
-  const service = newNotifiService(config);
-  const storage = newNotifiStorage(config);
-  return new NotifiFrontendClient(config, service, storage);
-};
-
-export const newNearClient = (config: NotifiNearConfiguration) => {
-  const service = newNotifiService(config);
-  const storage = newNotifiStorage(config);
-  return new NotifiFrontendClient(config, service, storage);
-};
-
-export const newInjectiveClient = (config: NotifiInjectiveConfiguration) => {
-  const service = newNotifiService(config);
-  const storage = newNotifiStorage(config);
-  return new NotifiFrontendClient(config, service, storage);
-};
-
-export const newSolanaClient = (config: NotifiSolanaConfiguration) => {
-  const service = newNotifiService(config);
-  const storage = newNotifiStorage(config);
-  return new NotifiFrontendClient(config, service, storage);
-};
-
-export const newEvmClient = (config: NotifiEvmConfiguration) => {
-  const service = newNotifiService(config);
-  const storage = newNotifiStorage(config);
-  return new NotifiFrontendClient(config, service, storage);
-};
-
-export const newSuiClient = (config: NotifiSuiConfiguration) => {
+export const newFrontendClient = (config: NotifiFrontendConfiguration) => {
   const service = newNotifiService(config);
   const storage = newNotifiStorage(config);
   return new NotifiFrontendClient(config, service, storage);

--- a/packages/notifi-frontend-client/lib/configuration/NotifiFrontendConfiguration.ts
+++ b/packages/notifi-frontend-client/lib/configuration/NotifiFrontendConfiguration.ts
@@ -9,178 +9,70 @@ export type NotifiEnvironmentConfiguration = Readonly<{
   tenantId: string;
 }>;
 
-export type NotifiAptosConfiguration = Readonly<{
-  walletBlockchain: 'APTOS';
-  authenticationKey: string;
-  accountAddress: string;
-}> &
-  NotifiEnvironmentConfiguration;
-
-export type NotifiFrontendConfiguration =
-  | NotifiSolanaConfiguration
-  | NotifiAptosConfiguration
-  | NotifiEvmConfiguration
-  | NotifiSuiConfiguration
-  | NotifiAcalaConfiguration
-  | NotifiNearConfiguration
-  | NotifiInjectiveConfiguration;
-
-export type NotifiAcalaConfiguration = Readonly<{
-  walletBlockchain: 'ACALA';
-  authenticationKey: string;
-  accountAddress: string;
-}> &
-  NotifiEnvironmentConfiguration;
-
-export const newAcalaConfig = (
-  account: Readonly<{
-    address: string;
-    publicKey: string;
-  }>,
-  tenantId: string,
-  env: NotifiEnvironment | undefined = 'Development',
-): NotifiAcalaConfiguration => {
-  return {
-    tenantId,
-    env,
-    walletBlockchain: 'ACALA',
-    authenticationKey: account.publicKey,
-    accountAddress: account.address,
-  };
-};
-
-export const newAptosConfig = (
-  account: Readonly<{
-    address: string;
-    publicKey: string;
-  }>,
-  tenantId: string,
-  env: NotifiEnvironment | undefined = 'Development',
-): NotifiAptosConfiguration => {
-  return {
-    tenantId,
-    env,
-    walletBlockchain: 'APTOS',
-    authenticationKey: account.publicKey,
-    accountAddress: account.address,
-  };
-};
-
-export type NotifiNearConfiguration = Readonly<{
-  walletBlockchain: 'NEAR';
-  authenticationKey: string;
-  accountAddress: string;
-}> &
-  NotifiEnvironmentConfiguration;
-
-export const newNearConfig = (
-  account: Readonly<{
-    address: string;
-    publicKey: string;
-  }>,
-  tenantId: string,
-  env: NotifiEnvironment | undefined = 'Development',
-): NotifiNearConfiguration => {
-  return {
-    tenantId,
-    env,
-    walletBlockchain: 'NEAR',
-    authenticationKey: account.publicKey,
-    accountAddress: account.address,
-  };
-};
-
-export type NotifiInjectiveConfiguration = Readonly<{
-  walletBlockchain: 'INJECTIVE';
-  authenticationKey: string;
-  accountAddress: string;
-}> &
-  NotifiEnvironmentConfiguration;
-
-export const newInjectiveConfig = (
-  account: Readonly<{
-    address: string;
-    publicKey: string;
-  }>,
-  tenantId: string,
-  env: NotifiEnvironment | undefined = 'Development',
-): NotifiInjectiveConfiguration => {
-  return {
-    tenantId,
-    env,
-    walletBlockchain: 'INJECTIVE',
-    authenticationKey: account.publicKey,
-    accountAddress: account.address,
-  };
-};
-
-export type NotifiSolanaConfiguration = Readonly<{
-  walletBlockchain: 'SOLANA';
-  walletPublicKey: string;
-}> &
-  NotifiEnvironmentConfiguration;
-
-export const newSolanaConfig = (
-  walletPublicKey: string,
-  tenantId: string,
-  env: NotifiEnvironment | undefined = 'Development',
-): NotifiSolanaConfiguration => {
-  return {
-    tenantId,
-    env,
-    walletBlockchain: 'SOLANA',
-    walletPublicKey: walletPublicKey,
-  };
-};
-
-export type NotifiSuiConfiguration = Readonly<{
-  walletBlockchain: 'SUI';
-  authenticationKey: string;
-  accountAddress: string;
-}> &
-  NotifiEnvironmentConfiguration;
-
-export const newSuiConfig = (
-  account: Readonly<{
-    address: string;
-    publicKey: string; // The same as accountAddress
-  }>,
-  tenantId: string,
-  env: NotifiEnvironment | undefined = 'Development',
-): NotifiSuiConfiguration => {
-  return {
-    tenantId,
-    env,
-    walletBlockchain: 'SUI',
-    authenticationKey: account.publicKey,
-    accountAddress: account.address,
-  };
-};
-
-export type NotifiEvmConfiguration = Readonly<{
+export type NotifiConfigWithPublicKey = Readonly<{
   walletBlockchain:
     | 'ETHEREUM'
     | 'POLYGON'
     | 'ARBITRUM'
     | 'AVALANCHE'
     | 'BINANCE'
-    | 'OPTIMISM';
+    | 'OPTIMISM'
+    | 'SOLANA';
   walletPublicKey: string;
 }> &
   NotifiEnvironmentConfiguration;
 
-export const newEvmConfig = (
-  walletBlockchain: NotifiEvmConfiguration['walletBlockchain'],
-  walletPublicKey: string,
-  tenantId: string,
-  env: NotifiEnvironment | undefined = 'Development',
-): NotifiEvmConfiguration => {
-  return {
-    tenantId,
-    env,
-    walletBlockchain,
-    walletPublicKey: walletPublicKey,
-  };
+export type NotifiConfigWithPublicKeyAndAddress = Readonly<{
+  walletBlockchain: 'SUI' | 'NEAR' | 'INJECTIVE' | 'APTOS' | 'ACALA';
+  authenticationKey: string;
+  accountAddress: string;
+}> &
+  NotifiEnvironmentConfiguration;
+
+export type NotifiFrontendConfiguration =
+  | NotifiConfigWithPublicKey
+  | NotifiConfigWithPublicKeyAndAddress;
+
+export type FrontendClientConfigFactory = (args: {
+  account: Readonly<{
+    address?: string;
+    publicKey: string;
+  }>;
+  tenantId: string;
+  env: NotifiEnvironment;
+  walletBlockchain: NotifiFrontendConfiguration['walletBlockchain'];
+}) => NotifiFrontendConfiguration;
+
+export const newFrontendConfig: FrontendClientConfigFactory = (args) => {
+  switch (args.walletBlockchain) {
+    // Chains with only publicKey in account argument
+    case 'ETHEREUM':
+    case 'POLYGON':
+    case 'ARBITRUM':
+    case 'AVALANCHE':
+    case 'BINANCE':
+    case 'OPTIMISM':
+    case 'SOLANA':
+      return {
+        tenantId: args.tenantId,
+        env: args.env,
+        walletBlockchain: args.walletBlockchain,
+        walletPublicKey: args.account.publicKey,
+      };
+    // Chains with publicKey and address in account arguments
+    case 'SUI':
+    case 'NEAR':
+    case 'INJECTIVE':
+    case 'APTOS':
+    case 'ACALA':
+      return {
+        tenantId: args.tenantId,
+        env: args.env,
+        walletBlockchain: args.walletBlockchain,
+        authenticationKey: args.account.publicKey,
+        accountAddress: args.account.publicKey,
+      };
+  }
 };
 
 export const envUrl = (env: NotifiEnvironment): string => {

--- a/packages/notifi-react-example/src/App.tsx
+++ b/packages/notifi-react-example/src/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link, Route, Routes } from 'react-router-dom';
 
 import './App.css';
-import FrontendClient from './FrontendClient/FrontendClient';
+import FrontendClient from './FrontendClient';
 import { NotifiCard } from './NotifiCard/NotifiCard';
 import WalletProviders from './walletProviders';
 

--- a/packages/notifi-react-example/src/FrontendClient/KeplrFrontendClient.tsx
+++ b/packages/notifi-react-example/src/FrontendClient/KeplrFrontendClient.tsx
@@ -1,8 +1,8 @@
 import {
   Uint8SignMessageFunction,
   UserState,
-  newInjectiveClient,
-  newInjectiveConfig,
+  newFrontendClient,
+  newFrontendConfig,
 } from '@notifi-network/notifi-frontend-client';
 import { Types } from '@notifi-network/notifi-graphql';
 import { FC, useMemo, useState } from 'react';
@@ -33,15 +33,16 @@ export const KeplrFrontendClient: FC = () => {
 
   const client = useMemo(() => {
     if (key && keyBase64) {
-      const config = newInjectiveConfig(
-        {
+      const config = newFrontendConfig({
+        account: {
           address: key.bech32Address,
           publicKey: keyBase64,
         },
-        'junitest.xyz',
-        'Development',
-      );
-      return newInjectiveClient(config);
+        tenantId: 'junitest.xyz',
+        env: 'Development',
+        walletBlockchain: 'INJECTIVE',
+      });
+      return newFrontendClient(config);
     }
   }, [key, keyBase64]);
   const [userState, setUserState] = useState<UserState | null>(null);

--- a/packages/notifi-react-example/src/FrontendClient/KeplrFrontendClient.tsx
+++ b/packages/notifi-react-example/src/FrontendClient/KeplrFrontendClient.tsx
@@ -1,0 +1,130 @@
+import {
+  Uint8SignMessageFunction,
+  UserState,
+  newInjectiveClient,
+  newInjectiveConfig,
+} from '@notifi-network/notifi-frontend-client';
+import { Types } from '@notifi-network/notifi-graphql';
+import { FC, useMemo, useState } from 'react';
+
+import { useKeplrContext } from '../walletProviders/KeplrWalletProvider';
+
+export const KeplrFrontendClient: FC = () => {
+  const { key, signArbitrary, connect } = useKeplrContext();
+  const keyBase64 = useMemo(
+    () =>
+      key !== undefined
+        ? Buffer.from(key.pubKey).toString('base64')
+        : undefined,
+    [key],
+  );
+
+  const signMessage: Uint8SignMessageFunction = async (message) => {
+    if (!key) {
+      throw new Error('Key not initialized');
+    }
+    const result = await signArbitrary(
+      'injective-1',
+      key.bech32Address,
+      message,
+    );
+    return Buffer.from(result.signature, 'base64');
+  };
+
+  const client = useMemo(() => {
+    if (key && keyBase64) {
+      const config = newInjectiveConfig(
+        {
+          address: key.bech32Address,
+          publicKey: keyBase64,
+        },
+        'junitest.xyz',
+        'Development',
+      );
+      return newInjectiveClient(config);
+    }
+  }, [key, keyBase64]);
+  const [userState, setUserState] = useState<UserState | null>(null);
+  const [clientData, setClientData] = useState<Types.FetchDataQuery>();
+
+  const initClient = async () => {
+    if (!client) {
+      throw new Error('Client not initialized');
+    }
+    const newUserState = await client.initialize();
+    newUserState && setUserState(newUserState);
+  };
+
+  const login = async () => {
+    if (!client) {
+      throw new Error('Client not initialized');
+    }
+    try {
+      await client?.logIn({
+        walletBlockchain: 'INJECTIVE',
+        signMessage,
+      });
+    } catch (e) {
+      console.log(e);
+    }
+    setUserState(client.userState);
+  };
+
+  const logOut = async () => {
+    if (!client) {
+      throw new Error('Client not initialized');
+    }
+    await client.logOut();
+    const newUserState = await client.initialize();
+    setUserState(newUserState);
+  };
+
+  const fetchData = async () => {
+    if (!userState || userState.status !== 'authenticated' || !client) {
+      throw new Error('Client not initialized or not logged in');
+    }
+    const data = await client.fetchData();
+    setClientData(data);
+  };
+
+  return (
+    <>
+      {key && keyBase64 ? (
+        <div>
+          <h1>Frontend Client Example: Injective (Keplr)</h1>
+          {!!!userState && (
+            <button onClick={initClient}>initialize FrontendClient</button>
+          )}
+          {userState?.status === 'loggedOut' ||
+          userState?.status === 'expired' ? (
+            <button onClick={login}>login</button>
+          ) : null}
+          {!!userState && userState.status === 'authenticated' ? (
+            <>
+              <button onClick={fetchData}>fetch client data</button>
+              <button onClick={logOut}>logout</button>
+            </>
+          ) : null}
+          <h2>User State: {userState?.status}</h2>
+          {!!clientData && userState?.status === 'authenticated' && (
+            <>
+              <h2>Client Data: The logged in user has</h2>
+              {Object.keys(clientData).map((key, id) => {
+                return (
+                  <div key={id}>
+                    {clientData[key as keyof Types.FetchDataQuery]?.length}{' '}
+                    {key}
+                  </div>
+                );
+              })}
+            </>
+          )}
+        </div>
+      ) : (
+        <button onClick={connect}>
+          {key !== undefined ? key.bech32Address : 'Connect'}
+        </button>
+      )}
+    </>
+  );
+};

--- a/packages/notifi-react-example/src/FrontendClient/PolkadotFrontendClient.tsx
+++ b/packages/notifi-react-example/src/FrontendClient/PolkadotFrontendClient.tsx
@@ -1,8 +1,8 @@
 import {
   AcalaSignMessageFunction,
   UserState,
-  newAcalaClient,
-  newAcalaConfig,
+  newFrontendClient,
+  newFrontendConfig,
 } from '@notifi-network/notifi-frontend-client';
 import { Types } from '@notifi-network/notifi-graphql';
 import { FC, useMemo, useState } from 'react';
@@ -29,15 +29,16 @@ export const PolkadotFrontendClient: FC = () => {
 
   const client = useMemo(() => {
     if (acalaAddress && polkadotPublicKey) {
-      const config = newAcalaConfig(
-        {
+      const config = newFrontendConfig({
+        account: {
           address: acalaAddress,
           publicKey: polkadotPublicKey,
         },
-        'junitest.xyz',
-        'Development',
-      );
-      return newAcalaClient(config);
+        tenantId: 'junitest.xyz',
+        env: 'Development',
+        walletBlockchain: 'ACALA',
+      });
+      return newFrontendClient(config);
     }
   }, [acalaAddress, polkadotPublicKey]);
   const [userState, setUserState] = useState<UserState | null>(null);

--- a/packages/notifi-react-example/src/FrontendClient/PolkadotFrontendClient.tsx
+++ b/packages/notifi-react-example/src/FrontendClient/PolkadotFrontendClient.tsx
@@ -1,0 +1,123 @@
+import {
+  AcalaSignMessageFunction,
+  UserState,
+  newAcalaClient,
+  newAcalaConfig,
+} from '@notifi-network/notifi-frontend-client';
+import { Types } from '@notifi-network/notifi-graphql';
+import { FC, useMemo, useState } from 'react';
+
+import {
+  AcalaConnectButton,
+  useAcalaWallet,
+} from '../walletProviders/AcalaWalletContextProvider';
+
+export const PolkadotFrontendClient: FC = () => {
+  const { acalaAddress, connected, requestSignature, polkadotPublicKey } =
+    useAcalaWallet();
+
+  const signMessage: AcalaSignMessageFunction = async (
+    _: string,
+    message: string,
+  ) => {
+    if (!connected) {
+      throw new Error('Wallet not connected');
+    }
+    const signature = await requestSignature(acalaAddress!, message);
+    return signature;
+  };
+
+  const client = useMemo(() => {
+    if (acalaAddress && polkadotPublicKey) {
+      const config = newAcalaConfig(
+        {
+          address: acalaAddress,
+          publicKey: polkadotPublicKey,
+        },
+        'junitest.xyz',
+        'Development',
+      );
+      return newAcalaClient(config);
+    }
+  }, [acalaAddress, polkadotPublicKey]);
+  const [userState, setUserState] = useState<UserState | null>(null);
+  const [clientData, setClientData] = useState<Types.FetchDataQuery>();
+
+  const initClient = async () => {
+    if (!client) {
+      throw new Error('Client not initialized');
+    }
+    const newUserState = await client.initialize();
+    setUserState(newUserState);
+  };
+
+  const login = async () => {
+    if (!client) {
+      throw new Error('Client not initialized');
+    }
+    await client.logIn({
+      walletBlockchain: 'ACALA',
+      signMessage,
+    });
+
+    setUserState(client.userState);
+  };
+
+  const logOut = async () => {
+    if (!client) {
+      throw new Error('Client not initialized');
+    }
+    await client.logOut();
+    const newUserState = await client.initialize();
+    setUserState(newUserState);
+  };
+
+  const fetchData = async () => {
+    if (!client) {
+      throw new Error('Client not initialized');
+    }
+    if (userState && userState.status === 'authenticated') {
+      const data = await client.fetchData();
+      setClientData(data);
+    }
+  };
+
+  return (
+    <>
+      {connected ? (
+        <div>
+          <h1>Frontend Client Example: DOT (Acala)</h1>
+          {!!!userState && (
+            <button onClick={initClient}>initialize FrontendClient</button>
+          )}
+          {userState?.status === 'loggedOut' ||
+          userState?.status === 'expired' ? (
+            <button onClick={login}>login</button>
+          ) : null}
+          {!!userState && userState.status === 'authenticated' ? (
+            <>
+              <button onClick={fetchData}>fetch client data</button>
+              <button onClick={logOut}>logout</button>
+            </>
+          ) : null}
+          <h2>User State: {userState?.status}</h2>
+          {!!clientData && userState?.status === 'authenticated' && (
+            <>
+              <h2>Client Data: The logged in user has</h2>
+              {Object.keys(clientData).map((key, id) => {
+                return (
+                  <div key={id}>
+                    {clientData[key as keyof Types.FetchDataQuery]?.length}{' '}
+                    {key}
+                  </div>
+                );
+              })}
+            </>
+          )}
+        </div>
+      ) : (
+        <AcalaConnectButton />
+      )}
+    </>
+  );
+};

--- a/packages/notifi-react-example/src/FrontendClient/SolanaFrontendClient.tsx
+++ b/packages/notifi-react-example/src/FrontendClient/SolanaFrontendClient.tsx
@@ -1,7 +1,7 @@
 import {
   UserState,
-  newSolanaClient,
-  newSolanaConfig,
+  newFrontendClient,
+  newFrontendConfig,
 } from '@notifi-network/notifi-frontend-client';
 import { Types } from '@notifi-network/notifi-graphql';
 import { useWallet } from '@solana/wallet-adapter-react';
@@ -15,8 +15,16 @@ export const SolanaFrontendClient: FC = () => {
 
   const client = useMemo(() => {
     if (publicKey) {
-      const config = newSolanaConfig(publicKey, 'junitest.xyz', 'Development');
-      return newSolanaClient(config);
+      const config = newFrontendConfig({
+        account: {
+          publicKey,
+        },
+        tenantId: 'junitest.xyz',
+        env: 'Development',
+        walletBlockchain: 'SOLANA',
+      });
+      // const config = newFrontendConfig({}, 'junitest.xyz', 'Development');
+      return newFrontendClient(config);
     }
   }, [publicKey]);
   const [userState, setUserState] = useState<UserState | null>(null);

--- a/packages/notifi-react-example/src/FrontendClient/SolanaFrontendClient.tsx
+++ b/packages/notifi-react-example/src/FrontendClient/SolanaFrontendClient.tsx
@@ -1,0 +1,98 @@
+import {
+  UserState,
+  newSolanaClient,
+  newSolanaConfig,
+} from '@notifi-network/notifi-frontend-client';
+import { Types } from '@notifi-network/notifi-graphql';
+import { useWallet } from '@solana/wallet-adapter-react';
+import { WalletMultiButton } from '@solana/wallet-adapter-react-ui';
+import { FC, useMemo, useState } from 'react';
+
+export const SolanaFrontendClient: FC = () => {
+  const { wallet, signMessage, connected } = useWallet();
+  const adapter = wallet?.adapter;
+  const publicKey = adapter?.publicKey?.toBase58() ?? null;
+
+  const client = useMemo(() => {
+    if (publicKey) {
+      const config = newSolanaConfig(publicKey, 'junitest.xyz', 'Development');
+      return newSolanaClient(config);
+    }
+  }, [publicKey]);
+  const [userState, setUserState] = useState<UserState | null>(null);
+  const [clientData, setClientData] = useState<Types.FetchDataQuery>();
+
+  const initClient = async () => {
+    if (!client) {
+      throw new Error('Client not initialized');
+    }
+    const newUserState = await client.initialize();
+    setUserState(newUserState);
+  };
+
+  const login = async () => {
+    if (signMessage && client) {
+      await client.logIn({
+        walletBlockchain: 'SOLANA',
+        signMessage,
+      });
+      setUserState(client.userState);
+    }
+  };
+
+  const logOut = async () => {
+    if (!client) {
+      throw new Error('Client not initialized');
+    }
+    await client.logOut();
+    const newUserState = await client.initialize();
+    setUserState(newUserState);
+  };
+
+  const fetchData = async () => {
+    if (!userState || userState.status !== 'authenticated' || !client) {
+      throw new Error('Client not initialized or user not authenticated');
+    }
+    const data = await client.fetchData();
+    setClientData(data);
+  };
+
+  return (
+    <>
+      {connected ? (
+        <div>
+          <h1>Frontend Client Example: Solana</h1>
+          {!!!userState && (
+            <button onClick={initClient}>initialize FrontendClient</button>
+          )}
+          {userState?.status === 'loggedOut' ||
+          userState?.status === 'expired' ? (
+            <button onClick={login}>login</button>
+          ) : null}
+          {!!userState && userState.status === 'authenticated' ? (
+            <>
+              <button onClick={fetchData}>fetch client data</button>
+              <button onClick={logOut}>logout</button>
+            </>
+          ) : null}
+          <h2>User State: {userState?.status}</h2>
+          {!!clientData && userState?.status === 'authenticated' && (
+            <>
+              <h2>Client Data: The logged in user has</h2>
+              {Object.keys(clientData).map((key, id) => {
+                return (
+                  <div key={id}>
+                    {clientData[key as keyof Types.FetchDataQuery]?.length}{' '}
+                    {key}
+                  </div>
+                );
+              })}
+            </>
+          )}
+        </div>
+      ) : (
+        <WalletMultiButton />
+      )}
+    </>
+  );
+};

--- a/packages/notifi-react-example/src/FrontendClient/SuiFrontendClient.tsx
+++ b/packages/notifi-react-example/src/FrontendClient/SuiFrontendClient.tsx
@@ -1,8 +1,8 @@
 import { Uint8SignMessageFunction } from '@notifi-network/notifi-core';
 import {
   UserState,
-  newSuiClient,
-  newSuiConfig,
+  newFrontendClient,
+  newFrontendConfig,
 } from '@notifi-network/notifi-frontend-client';
 import { Types } from '@notifi-network/notifi-graphql';
 import { SignInButton, ethos } from 'ethos-connect';
@@ -27,15 +27,16 @@ export const SuiFrontendClient: FC = () => {
 
   const client = useMemo(() => {
     if (wallet && wallet.currentAccount) {
-      const config = newSuiConfig(
-        {
+      const config = newFrontendConfig({
+        account: {
           address: wallet?.currentAccount.address,
           publicKey: wallet?.currentAccount.address,
         },
-        'junitest.xyz',
-        'Development',
-      );
-      return newSuiClient(config);
+        tenantId: 'junitest.xyz',
+        env: 'Development',
+        walletBlockchain: 'SUI',
+      });
+      return newFrontendClient(config);
     }
   }, [wallet?.currentAccount?.address]);
   const [userState, setUserState] = useState<UserState | null>(null);

--- a/packages/notifi-react-example/src/FrontendClient/SuiFrontendClient.tsx
+++ b/packages/notifi-react-example/src/FrontendClient/SuiFrontendClient.tsx
@@ -1,0 +1,120 @@
+import { Uint8SignMessageFunction } from '@notifi-network/notifi-core';
+import {
+  UserState,
+  newSuiClient,
+  newSuiConfig,
+} from '@notifi-network/notifi-frontend-client';
+import { Types } from '@notifi-network/notifi-graphql';
+import { SignInButton, ethos } from 'ethos-connect';
+import { FC, useMemo, useState } from 'react';
+
+export const SuiFrontendClient: FC = () => {
+  const { status, wallet } = ethos.useWallet();
+  const connected = status === 'connected';
+
+  const signMessage: Uint8SignMessageFunction = async (message: Uint8Array) => {
+    if (!wallet) {
+      throw new Error('Wallet not connected');
+    }
+
+    const signature = await wallet.signMessage({
+      message,
+    });
+
+    const signatureBuffer = Buffer.from(signature.signature);
+    return signatureBuffer;
+  };
+
+  const client = useMemo(() => {
+    if (wallet && wallet.currentAccount) {
+      const config = newSuiConfig(
+        {
+          address: wallet?.currentAccount.address,
+          publicKey: wallet?.currentAccount.address,
+        },
+        'junitest.xyz',
+        'Development',
+      );
+      return newSuiClient(config);
+    }
+  }, [wallet?.currentAccount?.address]);
+  const [userState, setUserState] = useState<UserState | null>(null);
+  const [clientData, setClientData] = useState<Types.FetchDataQuery>();
+
+  const initClient = async () => {
+    if (!client) {
+      throw new Error('Client not initialized');
+    }
+    const newUserState = await client.initialize();
+    setUserState(newUserState);
+  };
+
+  const login = async () => {
+    if (!client || !wallet?.signMessage || !wallet?.currentAccount) {
+      throw new Error('Client or wallet not initialized');
+    }
+    await client.logIn({
+      walletBlockchain: 'SUI',
+      signMessage: signMessage,
+    });
+    setUserState(client.userState);
+  };
+
+  const logOut = async () => {
+    if (!client) {
+      throw new Error('Client not initialized');
+    }
+    await client.logOut();
+    const newUserState = await client.initialize();
+    setUserState(newUserState);
+  };
+
+  const fetchData = async () => {
+    if (!client) {
+      throw new Error('Client not initialized');
+    }
+    if (userState && userState.status === 'authenticated') {
+      const data = await client.fetchData();
+      setClientData(data);
+    }
+  };
+
+  return (
+    <>
+      {connected ? (
+        <div>
+          <h1>Frontend Client Example: SUI</h1>
+          {!!!userState && (
+            <button onClick={initClient}>initialize FrontendClient</button>
+          )}
+          {userState?.status === 'loggedOut' ||
+          userState?.status === 'expired' ? (
+            <button onClick={login}>login</button>
+          ) : null}
+          {!!userState && userState.status === 'authenticated' ? (
+            <>
+              <button onClick={fetchData}>fetch client data</button>
+              <button onClick={logOut}>logout</button>
+            </>
+          ) : null}
+          <h2>User State: {userState?.status}</h2>
+          {!!clientData && userState?.status === 'authenticated' && (
+            <>
+              <h2>Client Data: The logged in user has</h2>
+              {Object.keys(clientData).map((key, id) => {
+                return (
+                  <div key={id}>
+                    {clientData[key as keyof Types.FetchDataQuery]?.length}{' '}
+                    {key}
+                  </div>
+                );
+              })}
+            </>
+          )}
+        </div>
+      ) : (
+        <SignInButton />
+      )}
+    </>
+  );
+};

--- a/packages/notifi-react-example/src/FrontendClient/WalletConnectFrontendClient.tsx
+++ b/packages/notifi-react-example/src/FrontendClient/WalletConnectFrontendClient.tsx
@@ -1,8 +1,8 @@
 import { Uint8SignMessageFunction } from '@notifi-network/notifi-core';
 import {
   UserState,
-  newEvmClient,
-  newEvmConfig,
+  newFrontendClient,
+  newFrontendConfig,
 } from '@notifi-network/notifi-frontend-client';
 import { Types } from '@notifi-network/notifi-graphql';
 import { arrayify } from 'ethers/lib/utils.js';
@@ -23,13 +23,13 @@ export const WalletConnectFrontendClient: FC = () => {
 
   const client = useMemo(() => {
     if (address && isConnected) {
-      const config = newEvmConfig(
-        'ETHEREUM',
-        address,
-        'junitest.xyz',
-        'Development',
-      );
-      return newEvmClient(config);
+      const config = newFrontendConfig({
+        walletBlockchain: 'ETHEREUM',
+        account: { publicKey: address },
+        tenantId: 'junitest.xyz',
+        env: 'Development',
+      });
+      return newFrontendClient(config);
     }
   }, [address, isConnected]);
 

--- a/packages/notifi-react-example/src/FrontendClient/index.tsx
+++ b/packages/notifi-react-example/src/FrontendClient/index.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import { KeplrFrontendClient } from './KeplrFrontendClient';
+import { PolkadotFrontendClient } from './PolkadotFrontendClient';
+import { SolanaFrontendClient } from './SolanaFrontendClient';
+import { SuiFrontendClient } from './SuiFrontendClient';
+import { WalletConnectFrontendClient } from './WalletConnectFrontendClient';
+
+enum ESupportedViews {
+  Solana = 'Solana',
+  WalletConnect = 'WalletConnect',
+  Sui = 'Sui',
+  Polkadot = 'Polkadot',
+  Keplr = 'keplr',
+}
+
+const supportedViews: Record<ESupportedViews, React.ReactNode> = {
+  [ESupportedViews.Solana]: <SolanaFrontendClient />,
+  [ESupportedViews.WalletConnect]: <WalletConnectFrontendClient />,
+  [ESupportedViews.Sui]: <SuiFrontendClient />,
+  [ESupportedViews.Polkadot]: <PolkadotFrontendClient />,
+  [ESupportedViews.Keplr]: <KeplrFrontendClient />,
+};
+
+const FrontendClient: React.FC = () => {
+  const [view, setView] = React.useState<React.ReactNode>(
+    <SolanaFrontendClient />,
+  );
+
+  const handleViewChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const selected = event.target.value as ESupportedViews;
+    const v = supportedViews[selected];
+    if (v === undefined) {
+      throw new Error('Unsupported type');
+    }
+
+    setView(v);
+  };
+
+  return (
+    <div className="container">
+      <select onChange={handleViewChange}>
+        {Object.keys(supportedViews).map((key) => (
+          <option key={key} value={key}>
+            {key}
+          </option>
+        ))}
+      </select>
+      {view}
+    </div>
+  );
+};
+
+export default FrontendClient;


### PR DESCRIPTION
# MVP-2537
  - DRY NotifiFrontendConfiguration --> replace the blockchain specific config generator with a common `newFrontendConfig` generator
  - DRY clientFactory --> replace the blockchain specific client factory with a common `newFrontendClient` factory.
  - DRY NotifiFrontendClient --> extract common throw error logic
# MVP-2538
Add multi-chain options in notifi-react-example's FrontendClient section.
See the video demo below:

https://user-images.githubusercontent.com/127958634/235072470-8fb0359a-4d54-4fde-a5c3-6f76918c5cfa.mp4