### PR TITLE
MVP-2537-patch: Move newFrontendConfig as internal call

### DIFF
--- a/packages/notifi-frontend-client/lib/client/clientFactory.ts
+++ b/packages/notifi-frontend-client/lib/client/clientFactory.ts
@@ -1,7 +1,12 @@
 import { NotifiService } from '@notifi-network/notifi-graphql';
 import { GraphQLClient } from 'graphql-request';
 
-import { NotifiFrontendConfiguration, envUrl } from '../configuration';
+import {
+  ConfigFactoryInput,
+  NotifiFrontendConfiguration,
+  envUrl,
+  newFrontendConfig,
+} from '../configuration';
 import {
   NotifiFrontendStorage,
   createLocalForageStorageDriver,
@@ -19,7 +24,8 @@ export const newNotifiService = (config: NotifiFrontendConfiguration) => {
   return new NotifiService(client);
 };
 
-export const newFrontendClient = (config: NotifiFrontendConfiguration) => {
+export const newFrontendClient = (args: ConfigFactoryInput) => {
+  const config = newFrontendConfig(args);
   const service = newNotifiService(config);
   const storage = newNotifiStorage(config);
   return new NotifiFrontendClient(config, service, storage);

--- a/packages/notifi-react-example/src/FrontendClient/KeplrFrontendClient.tsx
+++ b/packages/notifi-react-example/src/FrontendClient/KeplrFrontendClient.tsx
@@ -33,7 +33,7 @@ export const KeplrFrontendClient: FC = () => {
 
   const client = useMemo(() => {
     if (key && keyBase64) {
-      const config = newFrontendConfig({
+      return newFrontendClient({
         account: {
           address: key.bech32Address,
           publicKey: keyBase64,
@@ -42,7 +42,6 @@ export const KeplrFrontendClient: FC = () => {
         env: 'Development',
         walletBlockchain: 'INJECTIVE',
       });
-      return newFrontendClient(config);
     }
   }, [key, keyBase64]);
   const [userState, setUserState] = useState<UserState | null>(null);

--- a/packages/notifi-react-example/src/FrontendClient/PolkadotFrontendClient.tsx
+++ b/packages/notifi-react-example/src/FrontendClient/PolkadotFrontendClient.tsx
@@ -29,7 +29,7 @@ export const PolkadotFrontendClient: FC = () => {
 
   const client = useMemo(() => {
     if (acalaAddress && polkadotPublicKey) {
-      const config = newFrontendConfig({
+      return newFrontendClient({
         account: {
           address: acalaAddress,
           publicKey: polkadotPublicKey,
@@ -38,7 +38,6 @@ export const PolkadotFrontendClient: FC = () => {
         env: 'Development',
         walletBlockchain: 'ACALA',
       });
-      return newFrontendClient(config);
     }
   }, [acalaAddress, polkadotPublicKey]);
   const [userState, setUserState] = useState<UserState | null>(null);

--- a/packages/notifi-react-example/src/FrontendClient/SolanaFrontendClient.tsx
+++ b/packages/notifi-react-example/src/FrontendClient/SolanaFrontendClient.tsx
@@ -15,7 +15,7 @@ export const SolanaFrontendClient: FC = () => {
 
   const client = useMemo(() => {
     if (publicKey) {
-      const config = newFrontendConfig({
+      return newFrontendClient({
         account: {
           publicKey,
         },
@@ -23,8 +23,6 @@ export const SolanaFrontendClient: FC = () => {
         env: 'Development',
         walletBlockchain: 'SOLANA',
       });
-      // const config = newFrontendConfig({}, 'junitest.xyz', 'Development');
-      return newFrontendClient(config);
     }
   }, [publicKey]);
   const [userState, setUserState] = useState<UserState | null>(null);

--- a/packages/notifi-react-example/src/FrontendClient/SuiFrontendClient.tsx
+++ b/packages/notifi-react-example/src/FrontendClient/SuiFrontendClient.tsx
@@ -27,7 +27,7 @@ export const SuiFrontendClient: FC = () => {
 
   const client = useMemo(() => {
     if (wallet && wallet.currentAccount) {
-      const config = newFrontendConfig({
+      return newFrontendClient({
         account: {
           address: wallet?.currentAccount.address,
           publicKey: wallet?.currentAccount.address,
@@ -36,7 +36,6 @@ export const SuiFrontendClient: FC = () => {
         env: 'Development',
         walletBlockchain: 'SUI',
       });
-      return newFrontendClient(config);
     }
   }, [wallet?.currentAccount?.address]);
   const [userState, setUserState] = useState<UserState | null>(null);

--- a/packages/notifi-react-example/src/FrontendClient/WalletConnectFrontendClient.tsx
+++ b/packages/notifi-react-example/src/FrontendClient/WalletConnectFrontendClient.tsx
@@ -23,13 +23,12 @@ export const WalletConnectFrontendClient: FC = () => {
 
   const client = useMemo(() => {
     if (address && isConnected) {
-      const config = newFrontendConfig({
+      return newFrontendClient({
         walletBlockchain: 'ETHEREUM',
         account: { publicKey: address },
         tenantId: 'junitest.xyz',
         env: 'Development',
       });
-      return newFrontendClient(config);
     }
   }, [address, isConnected]);
 


### PR DESCRIPTION
Instead of two-step operation (get config by newFrontendConfig and pass it into newFrontendClient), It might be more intuitive for user to just call "newFrontendClient" to get client object.
So change the newFrontendConfig as an internal call into newFrontendClient.
