### PR TITLE
MVP-2556: frontendClient object accessible in notifi-react-card

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCardContainer.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCardContainer.tsx
@@ -5,7 +5,7 @@ import {
   useNotifiClientContext,
   useNotifiSubscriptionContext,
 } from '../../context';
-import { useSubscriptionCard } from '../../hooks';
+import { useNotifiSubscribe, useSubscriptionCard } from '../../hooks';
 import { NotifiFooter } from '../NotifiFooter';
 import { ErrorStateCard, LoadingStateCard } from '../common';
 import { FetchedStateCard } from './FetchedStateCard';
@@ -27,14 +27,18 @@ export const NotifiSubscriptionCardContainer: React.FC<
   loadingSpinnerSize,
   onClose,
 }: React.PropsWithChildren<NotifiSubscriptionCardProps>) => {
-  const { frontendClient } = useNotifiClientContext();
-  const isFrontendClientInitialized = useMemo(
-    () => !!frontendClient.userState,
-    [frontendClient.userState?.status],
-  );
+  const { isInitialized } = useNotifiSubscribe({ targetGroupName: 'Default' });
+  const {
+    canary: { isActive: canaryIsActive, frontendClient },
+  } = useNotifiClientContext();
+
+  const isClientInitialized = useMemo(() => {
+    return canaryIsActive ? !!frontendClient.userState : isInitialized;
+  }, [frontendClient.userState?.status, isInitialized, canaryIsActive]);
 
   const { loading } = useNotifiSubscriptionContext();
-  const inputDisabled = loading || !isFrontendClientInitialized;
+
+  const inputDisabled = loading || !isClientInitialized;
 
   const card = useSubscriptionCard({
     id: cardId,

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCardContainer.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCardContainer.tsx
@@ -1,8 +1,11 @@
 import clsx from 'clsx';
-import React from 'react';
+import React, { useMemo } from 'react';
 
-import { useNotifiSubscriptionContext } from '../../context';
-import { useNotifiSubscribe, useSubscriptionCard } from '../../hooks';
+import {
+  useNotifiClientContext,
+  useNotifiSubscriptionContext,
+} from '../../context';
+import { useSubscriptionCard } from '../../hooks';
 import { NotifiFooter } from '../NotifiFooter';
 import { ErrorStateCard, LoadingStateCard } from '../common';
 import { FetchedStateCard } from './FetchedStateCard';
@@ -24,9 +27,14 @@ export const NotifiSubscriptionCardContainer: React.FC<
   loadingSpinnerSize,
   onClose,
 }: React.PropsWithChildren<NotifiSubscriptionCardProps>) => {
-  const { isInitialized } = useNotifiSubscribe({ targetGroupName: 'Default' });
+  const { frontendClient } = useNotifiClientContext();
+  const isFrontendClientInitialized = useMemo(
+    () => !!frontendClient.userState,
+    [frontendClient.userState?.status],
+  );
+
   const { loading } = useNotifiSubscriptionContext();
-  const inputDisabled = loading || !isInitialized;
+  const inputDisabled = loading || !isFrontendClientInitialized;
 
   const card = useSubscriptionCard({
     id: cardId,

--- a/packages/notifi-react-card/lib/context/NotifiClientContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiClientContext.tsx
@@ -2,7 +2,6 @@ import {
   ConfigFactoryInput,
   NotifiFrontendClient,
   newFrontendClient,
-  newFrontendConfig,
 } from '@notifi-network/notifi-frontend-client';
 import { useNotifiClient } from '@notifi-network/notifi-react-hooks';
 import React, { createContext, useContext, useEffect, useMemo } from 'react';
@@ -53,8 +52,7 @@ export const NotifiClientContextProvider: React.FC<NotifiParams> = ({
 
   const frontendClient = useMemo(() => {
     const configInput = getFrontendConfigInput(params);
-    const config = newFrontendConfig(configInput);
-    return newFrontendClient(config);
+    return newFrontendClient(configInput);
   }, [
     params.dappAddress,
     params.env,

--- a/packages/notifi-react-card/lib/context/NotifiClientContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiClientContext.tsx
@@ -11,7 +11,10 @@ import { NotifiParams } from './NotifiContext';
 
 export type NotifiClientContextData = Readonly<{
   client: ReturnType<typeof useNotifiClient>;
-  frontendClient: NotifiFrontendClient;
+  canary: {
+    isActive: boolean;
+    frontendClient: NotifiFrontendClient;
+  };
   params: NotifiParams;
 }>;
 
@@ -64,10 +67,16 @@ export const NotifiClientContextProvider: React.FC<NotifiParams> = ({
     if (!frontendClient.userState) {
       frontendClient.initialize();
     }
-  }, [frontendClient.userState?.status]);
+  }, [frontendClient]);
 
   return (
-    <NotifiClientContext.Provider value={{ client, params, frontendClient }}>
+    <NotifiClientContext.Provider
+      value={{
+        client,
+        params,
+        canary: { isActive: params.enableCanary ?? false, frontendClient },
+      }}
+    >
       {children}
     </NotifiClientContext.Provider>
   );

--- a/packages/notifi-react-card/lib/context/NotifiContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiContext.tsx
@@ -110,6 +110,7 @@ export type NotifiParams = Readonly<{
   env: NotifiEnvironment;
   keepSubscriptionData?: boolean;
   multiWallet?: MultiWalletParams;
+  enableCanary?: boolean;
 }> &
   WalletParams;
 


### PR DESCRIPTION

1. Make fronttendClient object accessible in NotifiClientContext: for now both client object will be available until frontendClient can completely replace hooks' client.
2. Replace old `isInitalized` method in `NotifiSubscriptionCardContainer` using frontendClient