### PR TITLE
MVP-2558: HealthCheckEventTypeItem event type and its related methods in FrontendClient

### DIFF
--- a/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
+++ b/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
@@ -27,6 +27,14 @@ export type BroadcastEventTypeItem = Readonly<{
   tooltipContent?: string;
 }>;
 
+export type HealthCheckEventTypeItem = Readonly<{
+  type: 'healthCheck';
+  name: string;
+  checkRatios: ValueOrRef<CheckRatio[]>;
+  alertFrequency: AlertFrequency;
+  tooltipContent?: string;
+}>;
+
 export type LabelEventTypeItem = Readonly<{
   type: 'label';
   name: string;
@@ -107,6 +115,7 @@ export type XMTPTopicTypeItem = {
 export type EventTypeItem =
   | DirectPushEventTypeItem
   | BroadcastEventTypeItem
+  | HealthCheckEventTypeItem
   | TradingPairEventTypeItem
   | LabelEventTypeItem
   | PriceChangeEventTypeItem

--- a/packages/notifi-frontend-client/lib/utils/resolveRef.ts
+++ b/packages/notifi-frontend-client/lib/utils/resolveRef.ts
@@ -1,4 +1,4 @@
-import { ValueOrRef } from '../models';
+import { CheckRatio, ValueOrRef } from '../models';
 
 type Validator<T> = (item: unknown) => item is T;
 type ResolveFunc<T> = (
@@ -47,6 +47,21 @@ export const resolveStringArrayRef = createRefResolver(
     return (
       Array.isArray(item) &&
       item.every((element) => typeof element === 'string')
+    );
+  },
+);
+
+export const resolveCheckRatioArrayRef = createRefResolver(
+  (item: unknown): item is ReadonlyArray<CheckRatio> => {
+    return (
+      Array.isArray(item) &&
+      item.every(
+        (element) =>
+          typeof element === 'object' &&
+          typeof element.type === 'string' &&
+          typeof element.ratio === 'number' &&
+          !Number.isNaN(element.ratio),
+      )
     );
   },
 );


### PR DESCRIPTION
Implement missing HealthCheckEventTypeItem type and its related helper functions that will be consumed by notifi-react-card