### PR TITLE
MVP-2557: Migrate to use frontendClient's CardConfigItemV1

### DIFF
--- a/packages/notifi-core/lib/NotifiClient.ts
+++ b/packages/notifi-core/lib/NotifiClient.ts
@@ -1,13 +1,13 @@
+import { Types } from '@notifi-network/notifi-graphql';
+
 import {
   Alert,
   ClientConfiguration,
   ConnectedWallet,
   DiscordTarget,
   EmailTarget,
-  Filter,
   NotificationHistory,
   SmsTarget,
-  Source,
   SourceGroup,
   TargetGroup,
   TelegramTarget,
@@ -34,9 +34,9 @@ export type ClientData = Readonly<{
   alerts: ReadonlyArray<Alert>;
   connectedWallets: ReadonlyArray<ConnectedWallet>;
   emailTargets: ReadonlyArray<EmailTarget>;
-  filters: ReadonlyArray<Filter>;
+  filters: ReadonlyArray<Types.Filter>;
   smsTargets: ReadonlyArray<SmsTarget>;
-  sources: ReadonlyArray<Source>;
+  sources: ReadonlyArray<Types.Source>;
   targetGroups: ReadonlyArray<TargetGroup>;
   telegramTargets: ReadonlyArray<TelegramTarget>;
   discordTargets: ReadonlyArray<DiscordTarget>;
@@ -407,14 +407,14 @@ export type NotifiClient = Readonly<{
   logOut: () => Promise<void>;
   connectWallet: (input: ConnectWalletParams) => Promise<ConnectedWallet>;
   createAlert: (input: ClientCreateAlertInput) => Promise<Alert>;
-  createSource: (input: CreateSourceInput) => Promise<Source>;
+  createSource: (input: Types.CreateSourceInput) => Promise<Types.Source>;
   createSupportConversation: () => Promise<SupportConversation>;
   createMetaplexAuctionSource: (
     input: ClientCreateMetaplexAuctionSourceInput,
-  ) => Promise<Source>;
+  ) => Promise<Types.Source>;
   createBonfidaAuctionSource: (
     input: ClientCreateBonfidaAuctionSourceInput,
-  ) => Promise<Source>;
+  ) => Promise<Types.Source>;
   deleteAlert: (input: ClientDeleteAlertInput) => Promise<string>;
   getConfiguration: () => Promise<ClientConfiguration>;
   getNotificationHistory: (

--- a/packages/notifi-core/lib/models/Alert.ts
+++ b/packages/notifi-core/lib/models/Alert.ts
@@ -1,6 +1,4 @@
-import { Filter } from './Filter';
-import { SourceGroup } from './SourceGroup';
-import { TargetGroup } from './TargetGroup';
+import { Types } from '@notifi-network/notifi-graphql';
 
 /**
  * Object describing an Alert
@@ -17,12 +15,10 @@ import { TargetGroup } from './TargetGroup';
  * @property {string | null} groupName - The group associated with this alert
  *
  */
-export type Alert = Readonly<{
-  id: string | null;
-  name: string | null;
-  filter: Filter;
-  filterOptions: string | null;
-  sourceGroup: SourceGroup;
-  targetGroup: TargetGroup;
-  groupName: string | null;
-}>;
+
+// Infer the fetched Alter type (Reason: the underlying type of target element ans sourceGroup not matching Gql types)
+export type Alert = NonNullable<Types.FetchDataQuery['alert']> extends Array<
+  infer U
+>
+  ? NonNullable<U>
+  : never;

--- a/packages/notifi-core/lib/models/DiscordTarget.ts
+++ b/packages/notifi-core/lib/models/DiscordTarget.ts
@@ -11,6 +11,7 @@
  * @property {boolean} isConfirmed - Is discord confirmed? After adding a discord account, it must be confirmed
  *
  */
+import { Types } from '@notifi-network/notifi-graphql';
 
 export enum DiscordTargetStatus {
   UNVERIFIED = 'UNVERIFIED',
@@ -18,13 +19,7 @@ export enum DiscordTargetStatus {
   COMPLETE = 'COMPLETE',
 }
 
-export type DiscordTarget = Readonly<{
-  discordAccountId: string | null;
-  discriminator: string | null;
-  id: string | null;
-  isConfirmed: boolean;
-  name: string | null;
-  username: string | null;
-  userStatus: DiscordTargetStatus;
-  verificationLink: string;
-}>;
+export type DiscordTarget = Omit<
+  Types.DiscordTarget,
+  'createdDate' | 'updatedDate'
+>;

--- a/packages/notifi-core/lib/models/SourceGroup.ts
+++ b/packages/notifi-core/lib/models/SourceGroup.ts
@@ -1,4 +1,4 @@
-import { Source } from './Source';
+import { Types } from '@notifi-network/notifi-graphql';
 
 /**
  * Object describing a SourceGroup
@@ -11,8 +11,9 @@ import { Source } from './Source';
  * @property {Source[]} sources - The Sources associated with the SourceGroup
  *
  */
-export type SourceGroup = Readonly<{
-  id: string | null;
-  name: string | null;
-  sources: ReadonlyArray<Source>;
-}>;
+
+// Infer the fetched Alter type (Reason: the underlying type of targetGroup element not matching Types.TargetGroup)
+export type SourceGroup = Omit<
+  Types.SourceGroup,
+  'createdDate' | 'updatedDate'
+>;

--- a/packages/notifi-core/lib/models/TargetGroup.ts
+++ b/packages/notifi-core/lib/models/TargetGroup.ts
@@ -1,8 +1,4 @@
-import { DiscordTarget } from './DiscordTarget';
-import { EmailTarget } from './EmailTarget';
-import { SmsTarget } from './SmsTarget';
-import { TelegramTarget } from './TelegramTarget';
-import { WebhookTarget } from './WebhookTarget';
+import { Types } from '@notifi-network/notifi-graphql';
 
 /**
  * Object describing a TargetGroup
@@ -18,12 +14,4 @@ import { WebhookTarget } from './WebhookTarget';
  * @property {DiscordTarget[] | null} discordTargets - Array of discordTargets
  *
  */
-export type TargetGroup = Readonly<{
-  emailTargets: ReadonlyArray<EmailTarget>;
-  id: string | null;
-  name: string | null;
-  smsTargets: ReadonlyArray<SmsTarget>;
-  telegramTargets: ReadonlyArray<TelegramTarget>;
-  webHookTargets: ReadonlyArray<WebhookTarget>;
-  discordTargets: ReadonlyArray<DiscordTarget>;
-}>;
+export type TargetGroup = Types.TargetGroup;

--- a/packages/notifi-core/lib/operations/CreateSource.ts
+++ b/packages/notifi-core/lib/operations/CreateSource.ts
@@ -1,4 +1,6 @@
-import { Operation, Source } from '../models';
+import { Types } from '@notifi-network/notifi-graphql';
+
+import { Operation } from '../models';
 
 /**
  * Input param for creating a Source
@@ -13,45 +15,12 @@ import { Operation, Source } from '../models';
  * <br>
  * See [Alert Creation Guide]{@link https://docs.notifi.network} for more information on creating Alerts
  */
-export type CreateSourceInput = Readonly<{
-  name: string;
-  blockchainAddress: string;
-  type:
-    | 'SOLANA_WALLET'
-    | 'TERRA_WALLET'
-    | 'ETHEREUM_WALLET'
-    | 'TRIBECA_PROPOSALS'
-    | 'REALM_PROPOSALS'
-    | 'DIRECT_PUSH'
-    | 'SOLANA_METAPLEX_AUCTION'
-    | 'SOLANA_BONFIDA_AUCTION'
-    | 'DIRECT_PUBLISH'
-    | 'HEDGE_PROTOCOL'
-    | 'BROADCAST'
-    | 'SHARKY_PROTOCOL'
-    | 'PORT_FINANCE'
-    | 'METAPLEX_AUCTION_HOUSE'
-    | 'ORCA'
-    | 'BONFIDA_NAME_OFFERS'
-    | 'BONFIDA_NAME_AUCTIONING'
-    | 'TOPAZ'
-    | 'SOLANA_SNOWFLAKE'
-    | 'NOTIFI_CHAT'
-    | 'BENQI'
-    | 'APTOS_WALLET'
-    | 'ACALA_WALLET'
-    | 'POLYGON_WALLET'
-    | 'ARBITRUM_WALLET'
-    | 'BINANCE_WALLET'
-    | 'OPTIMISM_WALLET'
-    | 'AVALANCHE_WALLET'
-    | 'COIN_PRICE_CHANGES'
-    | 'XMTP'
-    | 'SUI_WALLET';
-}>;
 
-export type CreateSourceResult = Source;
+// TODO: Finally will be deprecated and replaced with automatically generated types
+export type CreateSourceInput = Types.CreateSourceInput;
+
+export type CreateSourceResult = Types.Source;
 
 export type CreateSourceService = Readonly<{
-  createSource: Operation<CreateSourceInput, CreateSourceResult>;
+  createSource: Operation<Types.CreateSourceInput, CreateSourceResult>;
 }>;

--- a/packages/notifi-core/lib/operations/GetSources.ts
+++ b/packages/notifi-core/lib/operations/GetSources.ts
@@ -1,6 +1,8 @@
-import { ParameterLessOperation, Source } from '../models';
+import { Types } from '@notifi-network/notifi-graphql';
 
-export type GetSourcesResult = ReadonlyArray<Source>;
+import { ParameterLessOperation } from '../models';
+
+export type GetSourcesResult = ReadonlyArray<Types.Source>;
 
 export type GetSourcesService = Readonly<{
   getSources: ParameterLessOperation<GetSourcesResult>;

--- a/packages/notifi-core/package.json
+++ b/packages/notifi-core/package.json
@@ -27,6 +27,9 @@
   "bugs": {
     "url": "https://github.com/notifi-network/notifi-sdk-ts/issues"
   },
+  "dependencies": {
+    "@notifi-network/notifi-graphql": "^0.64.0"
+  },
   "devDependencies": {
     "rimraf": "^3.0.2"
   },

--- a/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
+++ b/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
@@ -141,6 +141,7 @@ export type ContactInfo = Readonly<{
   active: boolean;
 }>;
 export type EmailContactInfo = ContactInfo;
+export type DiscordContactInfo = ContactInfo;
 
 export type CountryCode = string;
 
@@ -164,6 +165,7 @@ export type ContactInfoConfig = Readonly<{
   sms: SmsContactInfo;
   telegram: TelegramContactInfo;
   webhook: WebhookContactInfo;
+  discord: DiscordContactInfo;
 }>;
 
 export type CardConfigItemV1 = Readonly<{
@@ -173,4 +175,22 @@ export type CardConfigItemV1 = Readonly<{
   eventTypes: EventTypeConfig;
   inputs: InputsConfig;
   contactInfo: ContactInfoConfig;
+  titles?: TitleSubtitleConfig;
 }>;
+
+export type TitleSubtitleConfigInactive = Readonly<{ active: false }>;
+
+export type TitleSubtitleConfigActive = Readonly<{
+  active: true;
+  editView: string;
+  previewView: string;
+  historyView: string;
+  signupView: string;
+  expiredView: string;
+  alertDetailsView: string;
+  verifyWalletsView: string;
+}>;
+
+export type TitleSubtitleConfig =
+  | TitleSubtitleConfigActive
+  | TitleSubtitleConfigInactive;

--- a/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
@@ -99,16 +99,16 @@ export const IntercomCard: React.FC<
       if (!alert) continue;
       const { targetGroup } = alert;
 
-      const confirmedEmailTarget = targetGroup.emailTargets.find(
-        (email) => email.isConfirmed === true,
+      const confirmedEmailTarget = targetGroup.emailTargets?.find(
+        (email) => email?.isConfirmed === true,
       );
 
       if (confirmedEmailTarget?.emailAddress) {
         setFormEmail(confirmedEmailTarget.emailAddress);
       }
 
-      const confirmedTelegramTarget = targetGroup.telegramTargets.find(
-        (telegram) => telegram.isConfirmed === true,
+      const confirmedTelegramTarget = targetGroup.telegramTargets?.find(
+        (telegram) => telegram?.isConfirmed === true,
       );
 
       if (confirmedTelegramTarget?.telegramId) {
@@ -119,13 +119,13 @@ export const IntercomCard: React.FC<
         break;
       }
 
-      const unconfirmedEmailTarget = targetGroup.emailTargets.find(
-        (email) => email.isConfirmed === false,
+      const unconfirmedEmailTarget = targetGroup.emailTargets?.find(
+        (email) => email?.isConfirmed === false,
       );
 
       setFormEmail(unconfirmedEmailTarget?.emailAddress ?? '');
-      const unconfirmedTelegramTarget = targetGroup.telegramTargets.find(
-        (telegram) => telegram.isConfirmed === false,
+      const unconfirmedTelegramTarget = targetGroup.telegramTargets?.find(
+        (telegram) => telegram?.isConfirmed === false,
       );
 
       setFormTelegram(unconfirmedTelegramTarget?.telegramId ?? '');

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeCustomHealthCheckRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeCustomHealthCheckRow.tsx
@@ -1,4 +1,5 @@
 import { ThresholdDirection } from '@notifi-network/notifi-core';
+import { CustomTopicTypeItem } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import React, {
   useCallback,
@@ -9,7 +10,7 @@ import React, {
 } from 'react';
 
 import { useNotifiSubscriptionContext } from '../../context';
-import { CustomTopicTypeItem, useNotifiSubscribe } from '../../hooks';
+import { useNotifiSubscribe } from '../../hooks';
 import { DeepPartialReadonly, customThresholdConfiguration } from '../../utils';
 import type { NotifiToggleProps } from './NotifiToggle';
 import { NotifiToggle } from './NotifiToggle';

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeCustomToggleRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeCustomToggleRow.tsx
@@ -1,3 +1,4 @@
+import { CustomTopicTypeItem } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import React, {
   useCallback,
@@ -8,7 +9,7 @@ import React, {
 } from 'react';
 
 import { useNotifiSubscriptionContext } from '../../context';
-import { CustomTopicTypeItem, useNotifiSubscribe } from '../../hooks';
+import { useNotifiSubscribe } from '../../hooks';
 import { DeepPartialReadonly, customToggleConfiguration } from '../../utils';
 import type { NotifiToggleProps } from './NotifiToggle';
 import { NotifiToggle } from './NotifiToggle';

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeXMTPRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeXMTPRow.tsx
@@ -1,3 +1,4 @@
+import { XMTPTopicTypeItem } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import React, {
   useCallback,
@@ -8,7 +9,7 @@ import React, {
 } from 'react';
 
 import { useNotifiSubscriptionContext } from '../../context';
-import { XMTPTopicTypeItem, useNotifiSubscribe } from '../../hooks';
+import { useNotifiSubscribe } from '../../hooks';
 import {
   AlertConfiguration,
   DeepPartialReadonly,

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
@@ -1,3 +1,4 @@
+import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import React, { useCallback } from 'react';
 
@@ -6,7 +7,7 @@ import {
   useNotifiForm,
   useNotifiSubscriptionContext,
 } from '../../context';
-import { CardConfigItemV1, useNotifiSubscribe } from '../../hooks';
+import { useNotifiSubscribe } from '../../hooks';
 import { createConfigurations } from '../../utils';
 
 export type NotifiSubscribeButtonProps = Readonly<{

--- a/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
@@ -1,4 +1,5 @@
 import { NotificationHistoryEntry } from '@notifi-network/notifi-core';
+import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import React, {
   useCallback,
@@ -13,7 +14,7 @@ import {
   useNotifiForm,
   useNotifiSubscriptionContext,
 } from '../../context';
-import { CardConfigItemV1, useNotifiSubscribe } from '../../hooks';
+import { useNotifiSubscribe } from '../../hooks';
 import { DeepPartialReadonly } from '../../utils';
 import {
   AlertDetailsCard,

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/AlertListPreview.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/AlertListPreview.tsx
@@ -1,5 +1,5 @@
+import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
-import { CardConfigItemV1 } from 'notifi-react-card/lib/hooks';
 import { DeepPartialReadonly } from 'notifi-react-card/lib/utils';
 import React from 'react';
 

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/EditCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/EditCardView.tsx
@@ -1,9 +1,9 @@
+import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import { DeepPartialReadonly } from 'notifi-react-card/lib/utils';
 import React from 'react';
 
 import { useNotifiSubscriptionContext } from '../../../context/NotifiSubscriptionContext';
-import { CardConfigItemV1 } from '../../../hooks';
 import Spinner from '../../common/Spinner';
 import {
   NotifiSubscribeButton,

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/InputFields.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/InputFields.tsx
@@ -1,9 +1,9 @@
+import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import React from 'react';
 
 import { NotifiInputFieldsText, NotifiInputSeparators } from '..';
 import { useNotifiClientContext } from '../../../context';
-import { CardConfigItemV1 } from '../../../hooks';
 import {
   NotifiDiscordToggle,
   NotifiDiscordToggleProps,

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/PreviewCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/PreviewCard.tsx
@@ -1,7 +1,7 @@
+import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import React from 'react';
 
-import { CardConfigItemV1 } from '../../../hooks';
 import { DeepPartialReadonly } from '../../../utils';
 import { AlertsPanel, AlertsPanelProps } from './preview-panel/AlertsPanel';
 import {

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/VerifyWalletView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/VerifyWalletView.tsx
@@ -1,3 +1,4 @@
+import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import React, { useCallback, useState } from 'react';
 
@@ -5,7 +6,7 @@ import {
   useNotifiClientContext,
   useNotifiSubscriptionContext,
 } from '../../../context';
-import { CardConfigItemV1, useNotifiSubscribe } from '../../../hooks';
+import { useNotifiSubscribe } from '../../../hooks';
 import { createConfigurations } from '../../../utils';
 import { WalletList } from '../../WalletList';
 import NotifiCardButton, {

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/AlertsPanel.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/AlertsPanel.tsx
@@ -121,16 +121,15 @@ export const AlertsPanel: React.FC<AlertsPanelProps> = ({
                 inputs={inputs}
               />
             );
-          // TODO: Enable after MVP-2558 is merged
-          // case 'healthCheck':
-          //   return (
-          //     <EventTypeHealthCheckRow
-          //       key={eventType.name}
-          //       classNames={classNames?.EventTypeHealthCheckRow}
-          //       disabled={inputDisabled}
-          //       config={eventType}
-          //     />
-          //   );
+          case 'healthCheck':
+            return (
+              <EventTypeHealthCheckRow
+                key={eventType.name}
+                classNames={classNames?.EventTypeHealthCheckRow}
+                disabled={inputDisabled}
+                config={eventType}
+              />
+            );
           case 'label':
             return (
               <EventTypeLabelRow

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/AlertsPanel.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/AlertsPanel.tsx
@@ -1,6 +1,6 @@
+import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
 import React from 'react';
 
-import { CardConfigItemV1 } from '../../../../hooks';
 import {
   EventTypeBroadcastRow,
   EventTypeBroadcastRowProps,
@@ -121,15 +121,16 @@ export const AlertsPanel: React.FC<AlertsPanelProps> = ({
                 inputs={inputs}
               />
             );
-          case 'healthCheck':
-            return (
-              <EventTypeHealthCheckRow
-                key={eventType.name}
-                classNames={classNames?.EventTypeHealthCheckRow}
-                disabled={inputDisabled}
-                config={eventType}
-              />
-            );
+          // TODO: Enable after MVP-2558 is merged
+          // case 'healthCheck':
+          //   return (
+          //     <EventTypeHealthCheckRow
+          //       key={eventType.name}
+          //       classNames={classNames?.EventTypeHealthCheckRow}
+          //       disabled={inputDisabled}
+          //       config={eventType}
+          //     />
+          //   );
           case 'label':
             return (
               <EventTypeLabelRow

--- a/packages/notifi-react-card/lib/context/NotifiDemoPreviewContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiDemoPreviewContext.tsx
@@ -1,3 +1,4 @@
+import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
 import React, {
   PropsWithChildren,
   createContext,
@@ -5,11 +6,7 @@ import React, {
   useMemo,
 } from 'react';
 
-import {
-  CardConfigItemV1,
-  FetchedCardViewState,
-  WebhookContactInfo,
-} from '../hooks';
+import { FetchedCardViewState, WebhookContactInfo } from '../hooks';
 
 export type DemoPreview = {
   view: FetchedCardViewState['state'];

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -140,14 +140,14 @@ export const useNotifiSubscribe: ({
 
       const alerts: Record<string, Alert> = {};
       newData?.alerts.forEach((alert) => {
-        if (alert.name !== null) {
+        if (alert?.name) {
           alerts[alert.name] = alert;
         }
       });
 
       setAlerts(alerts);
       setConnectedWallets(newData?.connectedWallets ?? []);
-      const emailTarget = targetGroup?.emailTargets[0] ?? null;
+      const emailTarget = targetGroup?.emailTargets?.[0] ?? null;
       const emailToSet = emailTarget?.emailAddress ?? '';
 
       if (emailTarget !== null && emailTarget?.isConfirmed === false) {
@@ -165,10 +165,10 @@ export const useNotifiSubscribe: ({
       setFormEmail(emailToSet);
       setEmail(emailToSet);
 
-      const phoneNumber = targetGroup?.smsTargets[0]?.phoneNumber ?? null;
+      const phoneNumber = targetGroup?.smsTargets?.[0]?.phoneNumber ?? null;
 
       const isPhoneNumberConfirmed =
-        targetGroup?.smsTargets[0]?.isConfirmed ?? null;
+        targetGroup?.smsTargets?.[0]?.isConfirmed ?? null;
 
       const phoneNumberToSet = phoneNumber ?? '';
 
@@ -185,7 +185,7 @@ export const useNotifiSubscribe: ({
       setFormPhoneNumber(phoneNumberToSet);
       setPhoneNumber(phoneNumberToSet);
 
-      const telegramTarget = targetGroup?.telegramTargets[0];
+      const telegramTarget = targetGroup?.telegramTargets?.[0];
       const telegramId = telegramTarget?.telegramId;
 
       const telegramIdWithSymbolAdded =
@@ -210,7 +210,7 @@ export const useNotifiSubscribe: ({
         });
       }
 
-      const discordTarget = targetGroup?.discordTargets[0];
+      const discordTarget = targetGroup?.discordTargets?.[0];
 
       const discordId = discordTarget?.id;
 
@@ -375,7 +375,7 @@ export const useNotifiSubscribe: ({
       const { finalEmail, finalPhoneNumber, finalTelegramId, finalDiscordId } =
         contacts;
       const existingAlert = data.alerts.find(
-        (alert) => alert.name === alertName,
+        (alert) => alert?.name === alertName,
       );
 
       const deleteThisAlert = async () => {

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -2,11 +2,10 @@ import {
   Alert,
   ClientData,
   ConnectWalletParams,
-  CreateSourceInput,
   DiscordTarget,
   DiscordTargetStatus,
-  Source,
 } from '@notifi-network/notifi-core';
+import { Types } from '@notifi-network/notifi-graphql';
 import { isValidPhoneNumber } from 'libphonenumber-js';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -390,8 +389,8 @@ export const useNotifiSubscribe: ({
       };
 
       const ensureSource = async (
-        params: CreateSourceInput,
-      ): Promise<Source> => {
+        params: Types.CreateSourceInput,
+      ): Promise<Types.Source> => {
         const existing = data.sources.find(
           (s) =>
             s.type === params.type &&
@@ -417,7 +416,7 @@ export const useNotifiSubscribe: ({
         const sources = await Promise.all(sourcesInput.map(ensureSource));
         const filter = sources
           .flatMap((s) => s.applicableFilters)
-          .find((f) => f.filterType === filterType);
+          .find((f) => f?.filterType === filterType);
         if (filter === undefined || filter.id === null) {
           await deleteThisAlert();
           return null;
@@ -458,7 +457,7 @@ export const useNotifiSubscribe: ({
           sourceGroupName,
         } = alertConfiguration;
 
-        let source: Source | undefined;
+        let source: Types.Maybe<Types.Source>;
 
         if (createSourceParam !== undefined) {
           source = await ensureSource({
@@ -470,8 +469,8 @@ export const useNotifiSubscribe: ({
           source = data.sources.find((s) => s.type === sourceType);
         }
 
-        const filter = source?.applicableFilters.find(
-          (f) => f.filterType === filterType,
+        const filter = source?.applicableFilters?.find(
+          (f) => f?.filterType === filterType,
         );
 
         if (

--- a/packages/notifi-react-card/lib/hooks/useSubscriptionCard.ts
+++ b/packages/notifi-react-card/lib/hooks/useSubscriptionCard.ts
@@ -1,11 +1,11 @@
 import { ClientFetchSubscriptionCardInput } from '@notifi-network/notifi-core';
+import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
 import { useEffect, useState } from 'react';
 
 import {
   useNotifiClientContext,
   useNotifiDemoPreviewContext,
 } from '../context';
-import { CardConfigItemV1 } from './SubscriptionCardConfig';
 import { ErrorViewState } from './useFetchedCardState';
 
 export type LoadingState = Readonly<{

--- a/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
+++ b/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
@@ -1,17 +1,18 @@
 import type {
   ConnectedWallet,
-  CreateSourceInput,
   FilterOptions,
 } from '@notifi-network/notifi-core';
+import { EventTypeConfig } from '@notifi-network/notifi-frontend-client';
+import type { Types } from '@notifi-network/notifi-graphql';
 
 import { resolveStringRef } from '../components/subscription/resolveRef';
 import { NotifiSubscriptionData } from '../context';
-import { EventTypeConfig } from './../hooks/SubscriptionCardConfig';
+// import { EventTypeConfig } from './../hooks/SubscriptionCardConfig';
 import { walletToSource } from './walletUtils';
 
 export type SingleSourceAlertConfiguration = Readonly<{
   type: 'single';
-  sourceType: CreateSourceInput['type'];
+  sourceType: Types.CreateSourceInput['type'];
   createSource?: Readonly<{
     address: string;
   }>;
@@ -22,7 +23,7 @@ export type SingleSourceAlertConfiguration = Readonly<{
 
 export type MultipleSourceAlertConfiguration = Readonly<{
   type: 'multiple';
-  sources: ReadonlyArray<CreateSourceInput>;
+  sources: ReadonlyArray<Types.CreateSourceInput>;
   filterType: string;
   filterOptions: FilterOptions | null;
   sourceGroupName?: string;
@@ -58,7 +59,7 @@ export const customThresholdConfiguration = ({
   threshold: number;
   filterType: string;
   thresholdDirection: FilterOptions['thresholdDirection'];
-  sourceType: CreateSourceInput['type'];
+  sourceType: Types.CreateSourceInput['type'];
   sourceAddress: string;
 }>): AlertConfiguration => {
   return {
@@ -84,7 +85,7 @@ export const customToggleConfiguration = ({
 }: Readonly<{
   filterType: string;
   filterOptions: FilterOptions;
-  sourceType: CreateSourceInput['type'];
+  sourceType: Types.CreateSourceInput['type'];
   sourceAddress: string;
 }>): AlertConfiguration => {
   return {
@@ -103,7 +104,7 @@ export type XMTPTopic = Readonly<{
   walletBlockchain: string;
 }>;
 
-const topicToSource = (topic: string): CreateSourceInput => {
+const topicToSource = (topic: string): Types.CreateSourceInput => {
   return {
     name: topic,
     blockchainAddress: topic,

--- a/packages/notifi-react-example/src/FrontendClient/KeplrFrontendClient.tsx
+++ b/packages/notifi-react-example/src/FrontendClient/KeplrFrontendClient.tsx
@@ -2,7 +2,6 @@ import {
   Uint8SignMessageFunction,
   UserState,
   newFrontendClient,
-  newFrontendConfig,
 } from '@notifi-network/notifi-frontend-client';
 import { Types } from '@notifi-network/notifi-graphql';
 import { FC, useMemo, useState } from 'react';

--- a/packages/notifi-react-example/src/FrontendClient/PolkadotFrontendClient.tsx
+++ b/packages/notifi-react-example/src/FrontendClient/PolkadotFrontendClient.tsx
@@ -2,7 +2,6 @@ import {
   AcalaSignMessageFunction,
   UserState,
   newFrontendClient,
-  newFrontendConfig,
 } from '@notifi-network/notifi-frontend-client';
 import { Types } from '@notifi-network/notifi-graphql';
 import { FC, useMemo, useState } from 'react';

--- a/packages/notifi-react-example/src/FrontendClient/SolanaFrontendClient.tsx
+++ b/packages/notifi-react-example/src/FrontendClient/SolanaFrontendClient.tsx
@@ -1,7 +1,6 @@
 import {
   UserState,
   newFrontendClient,
-  newFrontendConfig,
 } from '@notifi-network/notifi-frontend-client';
 import { Types } from '@notifi-network/notifi-graphql';
 import { useWallet } from '@solana/wallet-adapter-react';

--- a/packages/notifi-react-example/src/FrontendClient/SuiFrontendClient.tsx
+++ b/packages/notifi-react-example/src/FrontendClient/SuiFrontendClient.tsx
@@ -2,7 +2,6 @@ import { Uint8SignMessageFunction } from '@notifi-network/notifi-core';
 import {
   UserState,
   newFrontendClient,
-  newFrontendConfig,
 } from '@notifi-network/notifi-frontend-client';
 import { Types } from '@notifi-network/notifi-graphql';
 import { SignInButton, ethos } from 'ethos-connect';

--- a/packages/notifi-react-example/src/FrontendClient/WalletConnectFrontendClient.tsx
+++ b/packages/notifi-react-example/src/FrontendClient/WalletConnectFrontendClient.tsx
@@ -2,7 +2,6 @@ import { Uint8SignMessageFunction } from '@notifi-network/notifi-core';
 import {
   UserState,
   newFrontendClient,
-  newFrontendConfig,
 } from '@notifi-network/notifi-frontend-client';
 import { Types } from '@notifi-network/notifi-graphql';
 import { arrayify } from 'ethers/lib/utils.js';

--- a/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
+++ b/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
@@ -773,7 +773,7 @@ const useNotifiClient = (
           throw new Error(`Unable to find alert ${alertId}`);
         }
         const name = existingAlert.name;
-        if (name === null) {
+        if (!name) {
           throw new Error(`Invalid Alert ${alertId}`);
         }
 

--- a/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
+++ b/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
@@ -18,13 +18,11 @@ import {
   CompleteLoginViaTransactionResult,
   ConnectWalletParams,
   ConnectedWallet,
-  CreateSourceInput,
   GetConversationMessagesFullInput,
   GetNotificationHistoryInput,
   NotifiClient,
   SendConversationMessageInput,
   SignMessageParams,
-  Source,
   SourceGroup,
   TargetGroup,
   TargetType,
@@ -33,6 +31,7 @@ import {
   UserTopic,
   WalletParams,
 } from '@notifi-network/notifi-core';
+import { Types } from '@notifi-network/notifi-graphql';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import ensureSource, {
@@ -926,7 +925,7 @@ const useNotifiClient = (
         }
 
         let sourceIds: ReadonlyArray<string> = [];
-        let sourceToUse: Source | undefined = undefined;
+        let sourceToUse: Types.Maybe<Types.Source>;
         if (sourceId === '' && sourceIdsInput !== undefined) {
           sourceToUse = newData.sources.find((s) => s.id === sourceIdsInput[0]);
           sourceIds = sourceIdsInput;
@@ -939,8 +938,8 @@ const useNotifiClient = (
           throw new Error(`Invalid source id ${sourceId}`);
         }
 
-        const existingFilter = sourceToUse.applicableFilters.find(
-          (f) => f.id === filterId,
+        const existingFilter = sourceToUse.applicableFilters?.find(
+          (f) => f?.id === filterId,
         );
         if (existingFilter === undefined) {
           throw new Error(`Invalid filter id ${filterId}`);
@@ -1105,7 +1104,7 @@ const useNotifiClient = (
    * See [Alert Creation Guide]{@link https://docs.notifi.network} for more information on creating Alerts
    */
   const createSource = useCallback(
-    async (input: CreateSourceInput): Promise<Source> => {
+    async (input: Types.CreateSourceInput): Promise<Types.Source> => {
       setLoading(true);
       try {
         const newData = await fetchDataImpl(
@@ -1115,12 +1114,12 @@ const useNotifiClient = (
         );
         const source = await ensureSource(service, newData.sources, input);
 
-        source.applicableFilters.forEach((applicableFilter) => {
+        source.applicableFilters?.forEach((applicableFilter) => {
           const existing = newData.filters.find(
-            (existingFilter) => applicableFilter.id === existingFilter.id,
+            (existingFilter) => applicableFilter?.id === existingFilter?.id,
           );
           if (existing !== undefined) {
-            newData.filters.push(applicableFilter);
+            newData.filters.push(applicableFilter!);
           }
         });
 
@@ -1153,7 +1152,9 @@ const useNotifiClient = (
    * See [Alert Creation Guide]{@link https://docs.notifi.network} for more information on creating Alerts
    */
   const createBonfidaAuctionSource = useCallback(
-    async (input: ClientCreateBonfidaAuctionSourceInput): Promise<Source> => {
+    async (
+      input: ClientCreateBonfidaAuctionSourceInput,
+    ): Promise<Types.Source> => {
       setLoading(true);
       try {
         const newData = await fetchDataImpl(
@@ -1195,7 +1196,9 @@ const useNotifiClient = (
    * See [Alert Creation Guide]{@link https://docs.notifi.network} for more information on creating Alerts
    */
   const createMetaplexAuctionSource = useCallback(
-    async (input: ClientCreateMetaplexAuctionSourceInput): Promise<Source> => {
+    async (
+      input: ClientCreateMetaplexAuctionSourceInput,
+    ): Promise<Types.Source> => {
       setLoading(true);
       try {
         const newData = await fetchDataImpl(

--- a/packages/notifi-react-hooks/lib/utils/ensureSource.ts
+++ b/packages/notifi-react-hooks/lib/utils/ensureSource.ts
@@ -1,10 +1,9 @@
 import type {
   ClientCreateBonfidaAuctionSourceInput,
   ClientCreateMetaplexAuctionSourceInput,
-  CreateSourceInput,
   CreateSourceService,
-  Source,
 } from '@notifi-network/notifi-core';
+import { Types } from '@notifi-network/notifi-graphql';
 
 export type CreateFunc<Service, T> = (
   service: Service,
@@ -15,9 +14,9 @@ export type ValueTransformFunc = (value: string) => string;
 
 const ensureSource = async (
   service: CreateSourceService,
-  existing: Source[],
-  input: CreateSourceInput,
-): Promise<Source> => {
+  existing: Types.Source[],
+  input: Types.CreateSourceInput,
+): Promise<Types.Source> => {
   const found = existing.find((it) => input.name === it.name);
   if (found !== undefined) {
     return found;
@@ -31,9 +30,9 @@ const ensureSource = async (
 
 const ensureBonfidaAuctionSource = async (
   service: CreateSourceService,
-  existing: Source[],
+  existing: Types.Source[],
   input: ClientCreateBonfidaAuctionSourceInput,
-): Promise<Source> => {
+): Promise<Types.Source> => {
   const { auctionAddressBase58, auctionName } = input;
   const underlyingAddress = `${auctionName}:;:${auctionAddressBase58}`;
 
@@ -46,9 +45,9 @@ const ensureBonfidaAuctionSource = async (
 
 const ensureMetaplexAuctionSource = async (
   service: CreateSourceService,
-  existing: Source[],
+  existing: Types.Source[],
   input: ClientCreateMetaplexAuctionSourceInput,
-): Promise<Source> => {
+): Promise<Types.Source> => {
   const { auctionAddressBase58, auctionWebUrl } = input;
   const underlyingAddress = `${auctionWebUrl}:;:${auctionAddressBase58}`;
 

--- a/packages/notifi-react-hooks/lib/utils/fetchDataImpl.ts
+++ b/packages/notifi-react-hooks/lib/utils/fetchDataImpl.ts
@@ -3,7 +3,6 @@ import {
   ConnectedWallet,
   DiscordTarget,
   EmailTarget,
-  Filter,
   GetAlertsService,
   GetConnectedWalletsService,
   GetDiscordTargetsService,
@@ -16,18 +15,18 @@ import {
   GetTopicsService,
   GetWebhookTargetsService,
   SmsTarget,
-  Source,
   SourceGroup,
   TargetGroup,
   TelegramTarget,
   WebhookTarget,
 } from '@notifi-network/notifi-core';
+import { Types } from '@notifi-network/notifi-graphql';
 
 export type InternalData = {
   alerts: Alert[];
   connectedWallets: ConnectedWallet[];
-  filters: Filter[];
-  sources: Source[];
+  filters: Types.Filter[];
+  sources: Types.Source[];
   sourceGroups: SourceGroup[];
   targetGroups: TargetGroup[];
   emailTargets: EmailTarget[];
@@ -85,12 +84,12 @@ const doFetchData = async (service: Service): Promise<InternalData> => {
   ]);
 
   const filterIds = new Set<string | null>();
-  const filters: Filter[] = [];
+  const filters: Types.Filter[] = [];
   sources.forEach((source) => {
-    source.applicableFilters.forEach((filter) => {
-      if (!filterIds.has(filter.id)) {
-        filters.push(filter);
-        filterIds.add(filter.id);
+    source.applicableFilters?.forEach((filter) => {
+      if (!filterIds.has(filter?.id ?? '')) {
+        filters.push(filter!); // ensured by `has`
+        filterIds.add(filter!.id); // ensured by `has`
       }
     });
   });


### PR DESCRIPTION
# Commit 1 (d2480cd)

- Add missing discord related types to FrontendClient SubscriptionCardConfig

- Add missing TitleSubtitleConfig related types to FrontendClient SubscriptionConfig

- Migrate CardConfigItemV1 and related type from “card” to “frontendClient”  (graphql auto generated types: Source and Filter)

# Commit 2 (2e2d51d)

more consolidated types:

- Alert

- DiscordTarget

- SourceGroup

- TargetGroup

DO NOT MERAGE until MVP-2558 is merged into main