### PR TITLE
MVP-2556-patch: Fix frontendClient initalize() does not update userstate

### DIFF
--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -99,19 +99,23 @@ export class NotifiFrontendClient {
     let authorization = storedAuthorization;
     if (authorization === null) {
       this._service.setJwt(undefined);
-      return {
+      const logOutStatus: UserState = {
         status: 'loggedOut',
       };
+      this._userState = logOutStatus;
+      return logOutStatus;
     }
 
     const expiryDate = new Date(authorization.expiry);
     const now = new Date();
     if (expiryDate <= now) {
       this._service.setJwt(undefined);
-      return {
+      const expiredStatus: UserState = {
         status: 'expired',
         authorization,
       };
+      this._userState = expiredStatus;
+      return expiredStatus;
     }
 
     const refreshTime = new Date();


### PR DESCRIPTION
# Problem:
The userState is not updated in the following two initialized case :
- 'logOut'
- 'expired'

# Solution
Update the userState when .initialize() return 'logOut' or 'expired'