### PR TITLE
MVP-2585:  'subscribeAlter' with frontendClient in EventTypeBroadCastRow (notifi-react-card)

### DIFF
--- a/packages/notifi-react-card/lib/utils/frontendClient.ts
+++ b/packages/notifi-react-card/lib/utils/frontendClient.ts
@@ -1,0 +1,61 @@
+import { Alert } from '@notifi-network/notifi-core';
+import {
+  EventTypeItem,
+  NotifiFrontendClient,
+} from '@notifi-network/notifi-frontend-client';
+
+import { SubscriptionData } from '../hooks';
+
+export const subscribeAlertByFrontendClient = async (
+  frontendClient: NotifiFrontendClient,
+  alertDetail: Readonly<{
+    eventType: EventTypeItem;
+    inputs: Record<string, unknown>;
+  }>,
+): Promise<SubscriptionData> => {
+  await frontendClient.ensureAlert(alertDetail);
+  const updatedData = await frontendClient.fetchData();
+  const updatedTgs = updatedData.targetGroup;
+  if (!(updatedTgs && updatedTgs.length > 0)) {
+    throw new Error('No target groups found');
+  }
+  const updatedTg = {
+    // adopt the first target group
+    ...updatedTgs[0],
+    name: updatedTgs[0]?.name ?? '',
+  };
+
+  const alerts: Record<string, Alert> = {};
+
+  updatedData.alert?.forEach((alert) => {
+    if (alert && alert.name) {
+      alerts[alert.name] = alert;
+    }
+  });
+
+  return {
+    alerts,
+    email: updatedTg.emailTargets?.[0]?.emailAddress ?? '',
+    phoneNumber: updatedTg.smsTargets?.[0]?.phoneNumber ?? '',
+    isPhoneNumberConfirmed: updatedTg.smsTargets?.[0]?.isConfirmed ?? false,
+    telegramId: updatedTg.telegramTargets?.[0]?.telegramId ?? '',
+    telegramConfirmationUrl:
+      updatedTg.telegramTargets?.[0]?.confirmationUrl ?? '',
+    discordId: updatedTg.discordTargets?.[0]?.id ?? '',
+  };
+};
+
+export const unsubscribeAlertByFrontendClient = async (
+  frontendClient: NotifiFrontendClient,
+  alertDetail: Readonly<{
+    eventType: EventTypeItem;
+    inputs: Record<string, unknown>;
+  }>,
+): Promise<void> => {
+  const alerts = await frontendClient.getAlerts();
+  const existing = alerts.find(
+    (alert) => alert.name === alertDetail.eventType.name,
+  );
+  if (!existing || !existing?.id) throw new Error('Alert not found');
+  await frontendClient.deleteAlert({ id: existing.id });
+};


### PR DESCRIPTION
 Implement alternative 'subscribeAlter' method using frontendClient in EventTypeBroadcastRow component