### PR TITLE
MVP-2575: 'IntercomCardConfigV1' added (notifi-frontend-client)

### DIFF
--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -15,6 +15,7 @@ import type {
   EventTypeItem,
   WalletBalanceEventTypeItem,
 } from '../models';
+import { IntercomCardConfigItemV1 } from '../models/IntercomCardConfig';
 import type { Authorization, NotifiStorage, Roles } from '../storage';
 import { notNullOrEmpty, packFilterOptions } from '../utils';
 import { areIdsEqual } from '../utils/areIdsEqual';
@@ -40,6 +41,8 @@ export type AcalaSignMessageFunction = (
   acalaAddress: string,
   message: string,
 ) => Promise<hexString>;
+
+export type CardConfigType = CardConfigItemV1 | IntercomCardConfigItemV1;
 
 type BeginLoginProps = Omit<Types.BeginLogInByTransactionInput, 'dappAddress'>;
 
@@ -642,7 +645,7 @@ export class NotifiFrontendClient {
 
   async fetchSubscriptionCard(
     variables: FindSubscriptionCardParams,
-  ): Promise<SupportedCardConfigType> {
+  ): Promise<CardConfigType> {
     const query = await this._service.findTenantConfig({
       input: {
         ...variables,
@@ -660,11 +663,14 @@ export class NotifiFrontendClient {
     }
 
     const obj = JSON.parse(value);
-    let card: SupportedCardConfigType | undefined = undefined;
+    let card: CardConfigType | undefined = undefined;
     switch (obj.version) {
       case 'v1': {
         card = obj as CardConfigItemV1;
         break;
+      }
+      case 'IntercomV1': {
+        card = obj as IntercomCardConfigItemV1;
       }
     }
 

--- a/packages/notifi-frontend-client/lib/models/IntercomCardConfig.ts
+++ b/packages/notifi-frontend-client/lib/models/IntercomCardConfig.ts
@@ -1,0 +1,38 @@
+import { ContactInfoConfig } from './SubscriptionCardConfig';
+
+type LabelItemConfigs<Config> = Readonly<{
+  [K in LabelType]: Config;
+}>;
+
+export const LABEL_TYPE_MENU_LABELS: LabelItemConfigs<string> = {
+  ChatCompanyName: 'Chat Company Name',
+  ChatFTUTitle: 'Chat FTU Title',
+  ChatFTUDescription: 'Chat FTU Description',
+  ChatFTUSubTitle: 'Chat FTU Sub Title',
+  ChatBannerTitle: 'Chat Banner Title',
+  ChatIntroQuestion: 'Chat Intro Question',
+};
+
+export type LabelType =
+  | 'ChatCompanyName'
+  | 'ChatFTUTitle'
+  | 'ChatFTUDescription'
+  | 'ChatFTUSubTitle'
+  | 'ChatBannerTitle'
+  | 'ChatIntroQuestion';
+
+export type LabelItem = {
+  name: string | null;
+  type: LabelType;
+  label: keyof typeof LABEL_TYPE_MENU_LABELS;
+};
+
+export type LabelsConfig = Array<LabelItem>;
+
+export type IntercomCardConfigItemV1 = Readonly<{
+  version: 'IntercomV1';
+  id: string | null;
+  name: string;
+  labels: LabelsConfig;
+  contactInfo: ContactInfoConfig;
+}>;

--- a/packages/notifi-frontend-client/lib/models/index.ts
+++ b/packages/notifi-frontend-client/lib/models/index.ts
@@ -1,2 +1,3 @@
 export * from './FilterOptions';
 export * from './SubscriptionCardConfig';
+export * from './IntercomCardConfig';

--- a/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
@@ -1,13 +1,11 @@
+import { IntercomCardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import { useNotifiClientContext } from 'notifi-react-card/lib/context';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { useNotifiForm, useNotifiSubscriptionContext } from '../../context/';
 import { useNotifiSubscribe } from '../../hooks';
-import {
-  IntercomCardConfigItemV1,
-  LabelType,
-} from '../../hooks/IntercomCardConfig';
+import { LabelType } from '../../hooks/IntercomCardConfig';
 import { chatConfiguration } from '../../utils/AlertConfiguration';
 import {
   NotifiInputFieldsText,

--- a/packages/notifi-react-card/lib/components/intercom/NotifiIntercomFTUNotificationTargetSection.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/NotifiIntercomFTUNotificationTargetSection.tsx
@@ -1,7 +1,7 @@
+import { IntercomCardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import React from 'react';
 
-import { IntercomCardConfigItemV1 } from '../../hooks/IntercomCardConfig';
 import { NotifiEmailInput, NotifiEmailInputProps } from '../NotifiEmailInput';
 import { NotifiSmsInput, NotifiSmsInputProps } from '../NotifiSmsInput';
 import {

--- a/packages/notifi-react-card/lib/hooks/useIntercomCard.ts
+++ b/packages/notifi-react-card/lib/hooks/useIntercomCard.ts
@@ -1,7 +1,7 @@
+import { IntercomCardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
 import { useEffect, useState } from 'react';
 
 import { useNotifiClientContext } from '../context';
-import { IntercomCardConfigItemV1 } from './IntercomCardConfig';
 
 export type Data = IntercomCardConfigItemV1;
 
@@ -26,27 +26,32 @@ export const useIntercomCard = (cardId: string): IntercomCardState => {
     state: 'loading',
   });
 
-  const { client } = useNotifiClientContext();
+  const {
+    client,
+    canary: { isActive: isCanaryEnabled, frontendClient },
+  } = useNotifiClientContext();
 
   useEffect(() => {
     setState({ state: 'loading' });
-    client
+    let card: IntercomCardConfigItemV1 | undefined;
+    (isCanaryEnabled ? frontendClient : client)
       .fetchSubscriptionCard({
         type: 'INTERCOM_CARD',
         id: cardId,
       })
       .then((result) => {
-        const value = result.dataJson;
-        if (value === null) {
-          return Promise.reject(new Error('Failed to fetch data'));
+        if ('dataJson' in result) {
+          if (!result.dataJson) {
+            return Promise.reject(new Error('Failed to fetch data'));
+          }
+          card = JSON.parse(result.dataJson);
+        } else if ('version' in result) {
+          card = result as IntercomCardConfigItemV1;
         }
 
-        const obj = JSON.parse(value);
-        if (obj.version !== 'IntercomV1') {
+        if (card?.version !== 'IntercomV1') {
           return Promise.reject(new Error('Unsupported config format'));
         }
-
-        const card = obj as IntercomCardConfigItemV1;
 
         setState({
           state: 'fetched',


### PR DESCRIPTION

1. Add 'IntercomCardConfig' type into frontendClient package
2.  Migrate the all intercomCardConfig related types to use frontendClient 
3.  Implement optional 'fetchSubscriptionCard' using frontendClient in 'useIntercomCard.