### PR TITLE
MVP-2585-patch: re-render data after subscribe/ unsubscribe alter

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/EventTypeBroadcastRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeBroadcastRow.tsx
@@ -49,7 +49,7 @@ export const EventTypeBroadcastRow: React.FC<EventTypeBroadcastRowProps> = ({
   disabled,
   inputs,
 }: EventTypeBroadcastRowProps) => {
-  const { alerts, loading } = useNotifiSubscriptionContext();
+  const { alerts, loading, render } = useNotifiSubscriptionContext();
   const { instantSubscribe } = useNotifiSubscribe({
     targetGroupName: 'Default',
   });
@@ -149,6 +149,7 @@ export const EventTypeBroadcastRow: React.FC<EventTypeBroadcastRowProps> = ({
           if (responseHasAlert !== true) {
             setEnabled(false);
           }
+          isCanaryActive && frontendClient.fetchData().then(render);
         })
         .catch(() => {
           setEnabled(false);
@@ -171,6 +172,7 @@ export const EventTypeBroadcastRow: React.FC<EventTypeBroadcastRowProps> = ({
             }
           }
           // Else, ensured by frontendClient
+          isCanaryActive && frontendClient.fetchData().then(render);
         })
         .catch(() => {
           setEnabled(false);

--- a/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
@@ -81,6 +81,7 @@ export type NotifiSubscriptionData = Readonly<{
   setDiscordTargetData: React.Dispatch<
     React.SetStateAction<DiscordTarget | undefined>
   >;
+  render: (newData: Types.FetchDataQuery) => SubscriptionData;
 }>;
 
 const NotifiSubscriptionContext = createContext<NotifiSubscriptionData>(
@@ -388,6 +389,7 @@ export const NotifiSubscriptionContextProvider: React.FC<
     setUseDiscord,
     discordTargetData,
     setDiscordTargetData,
+    render,
   };
 
   return (


### PR DESCRIPTION
1. Expose render method from `NotifiSubscriptionContext`
2. render after alter is subscribed / unsubscribed