### PR TITLE
MVP-2609-patch: 'getCustomFilterOptions' fallback value (frontend-client)

### DIFF
--- a/packages/notifi-frontend-client/lib/client/ensureSource.ts
+++ b/packages/notifi-frontend-client/lib/client/ensureSource.ts
@@ -615,13 +615,18 @@ const getCustomFilterOptions = (
           { type: 'ref', ref: thresholdDirectionKey },
           inputs,
         ) ?? eventType.checkRatios[0].ratio; // Fallback to 1st checkRatios
+
+      if (!healthRatio || !thresholdDirection) {
+        throw new Error('Failed to retrieve health ratio or direction');
+      }
+
       return {
         alertFrequency: eventType.alertFrequency,
         threshold:
           eventType.numberType === 'percentage'
             ? healthRatio / 100
             : healthRatio,
-        thresholdDirection: thresholdDirection === 'below' ? 'below' : 'above',
+        thresholdDirection: thresholdDirection === 'above' ? 'above' : 'below',
       };
     }
   }

--- a/packages/notifi-frontend-client/lib/client/ensureSource.ts
+++ b/packages/notifi-frontend-client/lib/client/ensureSource.ts
@@ -599,21 +599,29 @@ const getCustomFilterOptions = (
     case 'TOGGLE':
       return eventType.filterOptions;
     case 'HEALTH_CHECK': {
-      // Use synthetic ref values to get from input
+      // Use synthetic ref values to get from input (ratio)
       const healthRatioKey = `${eventType.name}__healthRatio`;
-      const healthRatio = resolveNumberRef(
-        healthRatioKey,
-        { type: 'ref', ref: healthRatioKey },
-        inputs,
-      );
-
+      const healthRatio =
+        resolveNumberRef(
+          healthRatioKey,
+          { type: 'ref', ref: healthRatioKey },
+          inputs,
+        ) ?? eventType.checkRatios[0].ratio; // Fallback to 1st checkRatios
+      // Use synthetic ref values to get from input (direction)
+      const thresholdDirectionKey = `${eventType.name}__healthThresholdDirection`;
+      const thresholdDirection =
+        resolveStringRef(
+          thresholdDirectionKey,
+          { type: 'ref', ref: thresholdDirectionKey },
+          inputs,
+        ) ?? eventType.checkRatios[0].ratio; // Fallback to 1st checkRatios
       return {
         alertFrequency: eventType.alertFrequency,
         threshold:
           eventType.numberType === 'percentage'
             ? healthRatio / 100
             : healthRatio,
-        thresholdDirection: eventType.checkRatios[0]?.type ?? 'below',
+        thresholdDirection: thresholdDirection === 'below' ? 'below' : 'above',
       };
     }
   }

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeCustomHealthCheckRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeCustomHealthCheckRow.tsx
@@ -145,6 +145,9 @@ export const EventTypeCustomHealthCheckRow: React.FC<
       if (isCanaryActive) {
         alertDetail.inputs[`${alertDetail.eventType.name}__healthRatio`] =
           ratioNumber;
+        alertDetail.inputs[
+          `${alertDetail.eventType.name}__healthThresholdDirection`
+        ] = thresholdDirection;
         return subscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({


### PR DESCRIPTION
- Add Fallback val in 'getCustomFilterOptions' allows customFilterOption able to fallback to checkRatios[0] if client does not pass in either `threshold` or `value`

- This also helps when dapp wants to ensure multiple alerts at the same time (alternative method of `subscribe` in `useNotifiSubscribe`

**NOTE**
Blocker of MVP-2610
