### PR TITLE
MVP-2612: New eventType createSupportConversationEvent to support intercom using frontendClient

### DIFF
--- a/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
+++ b/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
@@ -120,6 +120,14 @@ export type XMTPTopicTypeItem = {
   XMTPTopics: ValueOrRef<ReadonlyArray<string>>;
 };
 
+export type CreateSupportConversationEventTypeItem = {
+  type: 'createSupportConversation';
+  name: string;
+  sourceType: Gql.SourceType;
+  filterType: string;
+  alertFrequency: AlertFrequency;
+};
+
 export type EventTypeItem =
   | DirectPushEventTypeItem
   | BroadcastEventTypeItem
@@ -130,7 +138,8 @@ export type EventTypeItem =
   | CustomTopicTypeItem
   | FusionToggleEventTypeItem
   | WalletBalanceEventTypeItem
-  | XMTPTopicTypeItem;
+  | XMTPTopicTypeItem
+  | CreateSupportConversationEventTypeItem;
 
 export type EventTypeConfig = ReadonlyArray<EventTypeItem>;
 export type InputType =


### PR DESCRIPTION
1. Have `notifi-forntend-client` package support createSupportConversationEventType
2. In `notifi-react-card` add the following two feature to allow switching between frontendClient and client
   - subscribeAlert
   - createSupportConversation