### PR TITLE
we want to have conditional contexts.

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCard.tsx
@@ -76,6 +76,11 @@ export const NotifiSubscriptionCard: React.FC<
 > = (props: React.PropsWithChildren<NotifiSubscriptionCardProps>) => {
   const { params } = useNotifiClientContext();
 
+  // NOTE: This allows the card to be used with contexts outside of the card
+  if (params?.contextId) {
+    return <NotifiSubscriptionCardContainer {...props} />;
+  }
+
   return (
     <NotifiFormProvider>
       <NotifiSubscriptionContextProvider {...params}>

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCard.tsx
@@ -4,6 +4,7 @@ import {
   NotifiFormProvider,
   NotifiSubscriptionContextProvider,
   useNotifiClientContext,
+  useNotifiSubscriptionContext,
 } from '../../context';
 import { DeepPartialReadonly } from '../../utils';
 import type { NotifiFooterProps } from '../NotifiFooter';
@@ -75,9 +76,10 @@ export const NotifiSubscriptionCard: React.FC<
   React.PropsWithChildren<NotifiSubscriptionCardProps>
 > = (props: React.PropsWithChildren<NotifiSubscriptionCardProps>) => {
   const { params } = useNotifiClientContext();
-
-  // NOTE: This allows the card to be used with contexts outside of the card
-  if (params?.contextId) {
+  const { contextId } = useNotifiSubscriptionContext();
+  // NOTE: This allows the card to be used with contexts outside of the card.
+  // The context already exists at this point
+  if (contextId) {
     return <NotifiSubscriptionCardContainer {...props} />;
   }
 

--- a/packages/notifi-react-card/lib/context/NotifiContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiContext.tsx
@@ -106,6 +106,7 @@ type WalletParams =
 
 export type NotifiParams = Readonly<{
   alertConfigurations?: Record<string, AlertConfiguration | null>;
+  contextId?: string;
   dappAddress: string;
   env: NotifiEnvironment;
   keepSubscriptionData?: boolean;

--- a/packages/notifi-react-card/lib/context/NotifiContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiContext.tsx
@@ -106,7 +106,6 @@ type WalletParams =
 
 export type NotifiParams = Readonly<{
   alertConfigurations?: Record<string, AlertConfiguration | null>;
-  contextId?: string;
   dappAddress: string;
   env: NotifiEnvironment;
   keepSubscriptionData?: boolean;

--- a/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
@@ -5,7 +5,7 @@ import {
   DiscordTargetStatus,
 } from '@notifi-network/notifi-core';
 import { Types } from '@notifi-network/notifi-graphql';
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useMemo } from 'react';
 import React, {
   createContext,
   useCallback,
@@ -96,7 +96,6 @@ const hasKey = <K extends string>(
 ): obj is object & { [k in K]: unknown } => {
   return typeof obj === 'object' && obj !== null && key in obj;
 };
-const contextId = uuid();
 
 export const NotifiSubscriptionContextProvider: React.FC<
   PropsWithChildren<NotifiParams>
@@ -104,6 +103,10 @@ export const NotifiSubscriptionContextProvider: React.FC<
   const {
     canary: { isActive: isCanaryActive, frontendClient },
   } = useNotifiClientContext();
+
+  const contextId = useMemo(() => {
+    return uuid();
+  }, []);
 
   const [conversationId, setConversationId] = useState<string>('');
   const [userId, setUserId] = useState<string>('');

--- a/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
@@ -13,6 +13,7 @@ import React, {
   useEffect,
   useState,
 } from 'react';
+import { v4 as uuid } from 'uuid';
 
 import {
   FetchedCardViewState,
@@ -50,6 +51,7 @@ export type NotifiSubscriptionData = Readonly<{
   telegramConfirmationUrl?: string;
   useHardwareWallet: boolean;
   useDiscord: boolean;
+  contextId: string;
   cardView: FetchedCardViewState;
   setCardView: React.Dispatch<React.SetStateAction<FetchedCardViewState>>;
   intercomCardView: IntercomCardView;
@@ -94,6 +96,7 @@ const hasKey = <K extends string>(
 ): obj is object & { [k in K]: unknown } => {
   return typeof obj === 'object' && obj !== null && key in obj;
 };
+const contextId = uuid();
 
 export const NotifiSubscriptionContextProvider: React.FC<
   PropsWithChildren<NotifiParams>
@@ -101,6 +104,7 @@ export const NotifiSubscriptionContextProvider: React.FC<
   const {
     canary: { isActive: isCanaryActive, frontendClient },
   } = useNotifiClientContext();
+
   const [conversationId, setConversationId] = useState<string>('');
   const [userId, setUserId] = useState<string>('');
 
@@ -358,6 +362,7 @@ export const NotifiSubscriptionContextProvider: React.FC<
     loading,
     params,
     phoneNumber,
+    contextId,
     telegramId,
     cardView,
     telegramConfirmationUrl,


### PR DESCRIPTION
this is primarily to allow users higher level contexts that the subscription card consumes. without it, we might have weird interactions with multiple instances of contexts existing.