### PR TITLE
MVP-2660: Consolidate targetGroup types in notifi-core and notifi-graphql

### DIFF
--- a/packages/notifi-core/lib/NotifiClient.ts
+++ b/packages/notifi-core/lib/NotifiClient.ts
@@ -111,11 +111,11 @@ export type CompleteLoginViaTransactionResult = Readonly<User>;
  */
 export type ClientUpdateAlertInput = Readonly<{
   alertId: string;
-  emailAddress: string | null;
-  phoneNumber: string | null;
-  telegramId: string | null;
+  emailAddress: string | undefined;
+  phoneNumber: string | undefined;
+  telegramId: string | undefined;
   webhook?: ClientCreateWebhookParams;
-  discordId: string | null;
+  discordId: string | undefined;
 }>;
 
 /**
@@ -140,15 +140,15 @@ export type ClientCreateAlertInput = Readonly<{
   sourceId: string;
   filterId: string;
   filterOptions?: Readonly<FilterOptions>;
-  emailAddress: string | null;
-  phoneNumber: string | null;
-  telegramId: string | null;
+  emailAddress: string | undefined;
+  phoneNumber: string | undefined;
+  telegramId: string | undefined;
   groupName?: string;
   targetGroupName?: string;
   webhook?: ClientCreateWebhookParams;
   sourceIds?: ReadonlyArray<string>;
   sourceGroupName?: string;
-  discordId: string | null;
+  discordId: string | undefined;
 }>;
 
 export type ClientCreateWebhookParams = Omit<CreateWebhookTargetInput, 'name'>;
@@ -208,11 +208,11 @@ export type ClientDeleteAlertInput = Readonly<{
  */
 export type ClientEnsureTargetGroupInput = Readonly<{
   name: string;
-  emailAddress: string | null;
-  phoneNumber: string | null;
-  telegramId: string | null;
+  emailAddress: string | undefined;
+  phoneNumber: string | undefined;
+  telegramId: string | undefined;
   webhook?: ClientCreateWebhookParams;
-  discordId: string | null;
+  discordId: string | undefined;
 }>;
 
 /**
@@ -440,5 +440,5 @@ export type NotifiClient = Readonly<{
   getConversationMessages: (
     input: GetConversationMessagesFullInput,
   ) => Promise<ConversationMessages>;
-  createDiscordTarget: (input: string) => Promise<string | null>;
+  createDiscordTarget: (input: string) => Promise<string | undefined>;
 }>;

--- a/packages/notifi-core/lib/models/ConnectedWallet.ts
+++ b/packages/notifi-core/lib/models/ConnectedWallet.ts
@@ -13,6 +13,6 @@ import { Types } from '@notifi-network/notifi-graphql';
 export type ConnectedWallet =
   Types.FetchDataQuery['connectedWallet'] extends infer R
     ? R extends Array<infer V>
-      ? V
+      ? NonNullable<V>
       : never
     : never;

--- a/packages/notifi-core/lib/models/ConversationMessages.ts
+++ b/packages/notifi-core/lib/models/ConversationMessages.ts
@@ -1,3 +1,5 @@
+import { Types } from '@notifi-network/notifi-graphql';
+
 export type ConversationMessages = Readonly<{
   nodes?: Array<ConversationMessagesEntry> | undefined;
   pageInfo: {
@@ -6,16 +8,9 @@ export type ConversationMessages = Readonly<{
   };
 }>;
 
-export type ConversationMessagesEntry = Readonly<{
-  __typename?: 'ConversationMessage';
-  conversationParticipant: Participant;
-  id: string;
-  message: string;
-  userId: string;
-  createdDate: string;
-  updatedDate: string;
-  conversationId: string;
-}>;
+export type ConversationMessagesEntry = NonNullable<
+  NonNullable<Types.ConversationMessageFragment>
+>;
 
 export type Participant = Readonly<{
   __typename?: 'Participant';

--- a/packages/notifi-core/lib/models/ConversationMessages.ts
+++ b/packages/notifi-core/lib/models/ConversationMessages.ts
@@ -8,9 +8,8 @@ export type ConversationMessages = Readonly<{
   };
 }>;
 
-export type ConversationMessagesEntry = NonNullable<
-  NonNullable<Types.ConversationMessageFragment>
->;
+export type ConversationMessagesEntry =
+  NonNullable<Types.ConversationMessageFragment>;
 
 export type Participant = Readonly<{
   __typename?: 'Participant';

--- a/packages/notifi-core/lib/models/EmailTarget.ts
+++ b/packages/notifi-core/lib/models/EmailTarget.ts
@@ -1,3 +1,5 @@
+import { Types } from '@notifi-network/notifi-graphql';
+
 /**
  * Target object for email addresses
  *
@@ -10,9 +12,8 @@
  * @property {boolean} isConfirmed - Is email address confirmed? After adding an email address, it must be confirmed
  *
  */
-export type EmailTarget = Readonly<{
-  emailAddress: string | null;
-  id: string | null;
-  isConfirmed: boolean;
-  name: string | null;
-}>;
+export type EmailTarget = Types.FetchDataQuery['emailTarget'] extends infer R
+  ? R extends Array<infer V>
+    ? NonNullable<V>
+    : never
+  : never;

--- a/packages/notifi-core/lib/models/SmsTarget.ts
+++ b/packages/notifi-core/lib/models/SmsTarget.ts
@@ -1,3 +1,5 @@
+import { Types } from '@notifi-network/notifi-graphql';
+
 /**
  * Target object for SMS/phone numbers
  *
@@ -10,9 +12,8 @@
  * @property {boolean} isConfirmed - Is confirmed? After adding it will be auto-confirmed. Users can opt-out with STOP codes
  *
  */
-export type SmsTarget = Readonly<{
-  id: string | null;
-  isConfirmed: boolean;
-  name: string | null;
-  phoneNumber: string | null;
-}>;
+export type SmsTarget = Types.FetchDataQuery['smsTarget'] extends infer R
+  ? R extends Array<infer V>
+    ? NonNullable<V>
+    : never
+  : never;

--- a/packages/notifi-core/lib/models/TelegramTarget.ts
+++ b/packages/notifi-core/lib/models/TelegramTarget.ts
@@ -1,3 +1,5 @@
+import { Types } from '@notifi-network/notifi-graphql';
+
 /**
  * Target object for Telegram accounts
  *
@@ -11,10 +13,9 @@
  * @property {string | null} confirmationUrl - If not confirmed, use this URL to allow the user to start the Telegram bot
  *
  */
-export type TelegramTarget = Readonly<{
-  id: string | null;
-  isConfirmed: boolean;
-  name: string | null;
-  telegramId: string | null;
-  confirmationUrl: string | null;
-}>;
+export type TelegramTarget =
+  Types.FetchDataQuery['telegramTarget'] extends infer R
+    ? R extends Array<infer V>
+      ? NonNullable<V>
+      : never
+    : never;

--- a/packages/notifi-react-card/lib/components/WalletList/WalletList.tsx
+++ b/packages/notifi-react-card/lib/components/WalletList/WalletList.tsx
@@ -1,7 +1,5 @@
-import {
-  ConnectedWallet,
-  WalletWithSignParams,
-} from '@notifi-network/notifi-core';
+import { WalletWithSignParams } from '@notifi-network/notifi-core';
+import { Types } from '@notifi-network/notifi-graphql';
 import React from 'react';
 
 import {
@@ -11,7 +9,7 @@ import {
 import { ConnectWalletRow } from './ConnectWalletRow';
 
 export type WalletListInternalProps = Readonly<{
-  connectedWallets: ReadonlyArray<ConnectedWallet>;
+  connectedWallets: ReadonlyArray<Types.ConnectedWallet>;
   ownedWallets: ReadonlyArray<WalletWithSignParams>;
   disabled: boolean;
 }>;
@@ -49,7 +47,9 @@ export const WalletList: React.FC = () => {
   return (
     <WalletListInternal
       ownedWallets={owned}
-      connectedWallets={connectedWallets}
+      connectedWallets={connectedWallets.filter(
+        (wallet): wallet is Types.ConnectedWallet => !!wallet,
+      )}
       disabled={loading}
     />
   );

--- a/packages/notifi-react-card/lib/components/intercom/MessageGroup.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/MessageGroup.tsx
@@ -57,7 +57,7 @@ export const MessageGroup: React.FC<MessageGroupProps> = ({
                     classNames?.sender,
                   )}
                 >
-                  {message.conversationParticipant.resolvedName}
+                  {message.conversationParticipant?.resolvedName}
                 </div>
               ) : null}
               <div key={index}>{message.message}</div>

--- a/packages/notifi-react-card/lib/components/intercom/MessageList.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/MessageList.tsx
@@ -18,7 +18,7 @@ export const MessageList: React.FC<MessageListProps> = ({
   feed,
 }) => {
   const isIncoming = feed.direction === 'INCOMING';
-  const participantProfile = feed.messages[0].conversationParticipant.profile;
+  const participantProfile = feed.messages[0].conversationParticipant?.profile;
   return (
     <div
       className={clsx(
@@ -35,7 +35,7 @@ export const MessageList: React.FC<MessageListProps> = ({
         >
           <img
             src={
-              participantProfile.avatarDataType === 'URL'
+              participantProfile?.avatarDataType === 'URL'
                 ? participantProfile.avatarData
                 : ''
             }

--- a/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
@@ -250,7 +250,11 @@ export const NotifiSubscriptionContextProvider: React.FC<
       });
       setAlerts(alerts);
 
-      setConnectedWallets(newData.connectedWallet ?? []);
+      setConnectedWallets(
+        newData.connectedWallet?.filter(
+          (wallet): wallet is Types.ConnectedWallet => !!wallet,
+        ) ?? [],
+      );
       const emailTarget = targetGroup?.emailTargets?.[0] ?? null;
       const emailToSet = emailTarget?.emailAddress ?? '';
 

--- a/packages/notifi-react-card/lib/hooks/useIntercomChat.ts
+++ b/packages/notifi-react-card/lib/hooks/useIntercomChat.ts
@@ -1,5 +1,4 @@
 import { ConversationMessagesEntry } from '@notifi-network/notifi-core';
-import { Participant } from 'notifi-core/lib/models/ConversationMessages';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ListRange } from 'react-virtuoso';
 
@@ -9,15 +8,7 @@ import {
   sortByDate,
 } from '../utils/datetimeUtils';
 
-export type ChatMessage = Readonly<{
-  id: string;
-  message: string;
-  userId: string;
-  createdDate: string;
-  updatedDate: string;
-  conversationId: string;
-  conversationParticipant: Participant;
-}>;
+export type ChatMessage = ConversationMessagesEntry;
 
 type MessageDirection = 'INCOMING' | 'OUTGOING';
 

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -364,10 +364,10 @@ export const useNotifiSubscribe: ({
       alertParams: InstantSubscribe,
       data: ClientData,
       contacts: Readonly<{
-        finalEmail: string | null;
-        finalPhoneNumber: string | null;
-        finalTelegramId: string | null;
-        finalDiscordId: string | null;
+        finalEmail: string | undefined;
+        finalPhoneNumber: string | undefined;
+        finalTelegramId: string | undefined;
+        finalDiscordId: string | undefined;
       }>,
     ): Promise<Alert | null> => {
       if (demoPreview) throw Error('Preview card does not support method call');
@@ -532,13 +532,13 @@ export const useNotifiSubscribe: ({
 
       const names = Object.keys(configurations);
 
-      const finalEmail = formEmail === '' ? null : formEmail;
+      const finalEmail = formEmail === '' ? undefined : formEmail;
       const finalTelegramId =
         formTelegram === ''
-          ? null
+          ? undefined
           : formatTelegramForSubscription(formTelegram);
 
-      let finalPhoneNumber = null;
+      let finalPhoneNumber = undefined;
       if (isValidPhoneNumber(formPhoneNumber)) {
         finalPhoneNumber = formPhoneNumber;
       }
@@ -556,7 +556,7 @@ export const useNotifiSubscribe: ({
       // "refresh" or "fetchData" to obtain existing settings first
       //
 
-      let finalDiscordId = null;
+      let finalDiscordId = undefined;
 
       if (useDiscord === true) {
         finalDiscordId = await client.createDiscordTarget('Default');
@@ -617,14 +617,16 @@ export const useNotifiSubscribe: ({
       throw new Error('Preview card does not support method call');
     }
 
-    const finalEmail = formEmail === '' ? null : formEmail;
+    const finalEmail = formEmail === '' ? undefined : formEmail;
 
     const finalTelegramId =
-      formTelegram === '' ? null : formatTelegramForSubscription(formTelegram);
+      formTelegram === ''
+        ? undefined
+        : formatTelegramForSubscription(formTelegram);
 
-    let finalPhoneNumber = null;
+    let finalPhoneNumber = undefined;
 
-    let finalDiscordId = null;
+    let finalDiscordId = undefined;
 
     if (useDiscord === true) {
       finalDiscordId =
@@ -667,20 +669,20 @@ export const useNotifiSubscribe: ({
     async (alertData: InstantSubscribe) => {
       if (demoPreview)
         throw new Error('Preview card does not support method call');
-      const finalEmail = formEmail === '' ? null : formEmail;
+      const finalEmail = formEmail === '' ? undefined : formEmail;
 
       const finalTelegramId =
         formTelegram === ''
-          ? null
+          ? undefined
           : formatTelegramForSubscription(formTelegram);
-      let finalPhoneNumber = null;
+      let finalPhoneNumber = undefined;
       if (isValidPhoneNumber(formPhoneNumber)) {
         finalPhoneNumber = formPhoneNumber;
       }
 
       const finalDiscordId =
         useDiscord === false || !discordTargetDatafromSubscriptionContext?.id
-          ? null
+          ? undefined
           : discordTargetDatafromSubscriptionContext?.id;
 
       setLoading(true);

--- a/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
+++ b/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
@@ -1,7 +1,4 @@
-import type {
-  ConnectedWallet,
-  FilterOptions,
-} from '@notifi-network/notifi-core';
+import type { FilterOptions } from '@notifi-network/notifi-core';
 import { EventTypeConfig } from '@notifi-network/notifi-frontend-client';
 import type { Types } from '@notifi-network/notifi-graphql';
 
@@ -241,13 +238,15 @@ export const tradingPairConfiguration = ({
 export const walletBalanceConfiguration = ({
   connectedWallets,
 }: Readonly<{
-  connectedWallets: ReadonlyArray<ConnectedWallet>;
+  connectedWallets: ReadonlyArray<Types.ConnectedWallet>;
 }>): AlertConfiguration => {
   return {
     type: 'multiple',
     filterType: 'BALANCE',
     filterOptions: null,
-    sources: connectedWallets.map(walletToSource),
+    sources: connectedWallets
+      .filter((wallet): wallet is Types.ConnectedWallet => !!wallet)
+      .map(walletToSource),
     sourceGroupName: 'User Wallets',
   };
 };
@@ -344,7 +343,9 @@ export const createConfigurations = (
       }
       case 'walletBalance': {
         configs[eventType.name] = walletBalanceConfiguration({
-          connectedWallets,
+          connectedWallets: connectedWallets.filter(
+            (wallet): wallet is Types.ConnectedWallet => !!wallet,
+          ),
         });
         break;
       }

--- a/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
+++ b/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
@@ -602,7 +602,7 @@ const useNotifiClient = (
 
   // when calling ensureDiscordTarget, a discord id should be returned
   const createDiscordTarget = useCallback(
-    async (input: string): Promise<string | null> => {
+    async (input: string): Promise<string | undefined> => {
       setLoading(true);
       const newData = await fetchDataImpl(service, Date, fetchDataRef.current);
 
@@ -657,11 +657,17 @@ const useNotifiClient = (
           newData.targetGroups,
           {
             name: input.name,
-            emailTargetIds,
-            smsTargetIds,
-            telegramTargetIds,
-            webhookTargetIds,
-            discordTargetIds,
+            emailTargetIds: emailTargetIds.filter((id): id is string => !!id),
+            smsTargetIds: smsTargetIds.filter((id): id is string => !!id),
+            telegramTargetIds: telegramTargetIds.filter(
+              (id): id is string => !!id,
+            ),
+            webhookTargetIds: webhookTargetIds.filter(
+              (id): id is string => !!id,
+            ),
+            discordTargetIds: discordTargetIds.filter(
+              (id): id is string => !!id,
+            ),
           },
         );
 
@@ -782,11 +788,17 @@ const useNotifiClient = (
           newData.targetGroups,
           {
             name: existingAlert.targetGroup.name ?? name,
-            emailTargetIds,
-            smsTargetIds,
-            telegramTargetIds,
-            webhookTargetIds,
-            discordTargetIds,
+            emailTargetIds: emailTargetIds.filter((id): id is string => !!id),
+            smsTargetIds: smsTargetIds.filter((id): id is string => !!id),
+            telegramTargetIds: telegramTargetIds.filter(
+              (id): id is string => !!id,
+            ),
+            webhookTargetIds: webhookTargetIds.filter(
+              (id): id is string => !!id,
+            ),
+            discordTargetIds: discordTargetIds.filter(
+              (id): id is string => !!id,
+            ),
           },
         );
 
@@ -958,11 +970,17 @@ const useNotifiClient = (
           newData.targetGroups,
           {
             name: targetGroupName ?? name,
-            emailTargetIds,
-            smsTargetIds,
-            telegramTargetIds,
-            webhookTargetIds,
-            discordTargetIds,
+            emailTargetIds: emailTargetIds.filter((id): id is string => !!id),
+            smsTargetIds: smsTargetIds.filter((id): id is string => !!id),
+            telegramTargetIds: telegramTargetIds.filter(
+              (id): id is string => !!id,
+            ),
+            webhookTargetIds: webhookTargetIds.filter(
+              (id): id is string => !!id,
+            ),
+            discordTargetIds: discordTargetIds.filter(
+              (id): id is string => !!id,
+            ),
           },
         );
 

--- a/packages/notifi-react-hooks/lib/utils/ensureTarget.spec.ts
+++ b/packages/notifi-react-hooks/lib/utils/ensureTarget.spec.ts
@@ -16,7 +16,7 @@ import ensureTarget, {
 describe('ensureTarget', () => {
   const createSpy = jest.fn();
 
-  type TestTarget = Readonly<{ id: string | null }>;
+  type TestTarget = Readonly<{ id: string | undefined }>;
   const service = {};
   const ensureTestTarget = ensureTarget(createSpy, (it) => it.id);
 
@@ -25,7 +25,7 @@ describe('ensureTarget', () => {
   });
 
   it('returns null when the value is null', async () => {
-    const result = await ensureTestTarget(service, [], null);
+    const result = await ensureTestTarget(service, [], undefined);
     expect(result).toBeNull();
     expect(createSpy).not.toHaveBeenCalled();
   });
@@ -135,11 +135,11 @@ describe('ensureEmail', () => {
   const nullItem = {
     id: null,
     emailAddress: null,
-  } as EmailTarget;
+  } as unknown as EmailTarget;
 
   let existing = [existingItem, nullItem];
 
-  const subject = async (value: string | null) =>
+  const subject = async (value: string | undefined) =>
     ensureEmail(service, existing, value);
 
   beforeEach(() => {
@@ -224,7 +224,7 @@ describe('ensureSms', () => {
   } as SmsTarget;
   let existing = [existingItem];
 
-  const subject = async (value: string | null) =>
+  const subject = async (value: string | undefined) =>
     ensureSms(service, existing, value);
 
   beforeEach(() => {
@@ -292,13 +292,13 @@ describe('ensureTelegram', () => {
   } as TelegramTarget;
 
   const nullItem = {
-    id: null,
-    telegramId: null,
-  } as TelegramTarget;
+    id: undefined,
+    telegramId: undefined,
+  } as unknown as TelegramTarget;
 
   let existing = [existingItem, nullItem];
 
-  const subject = async (value: string | null) =>
+  const subject = async (value: string | undefined) =>
     ensureTelegram(service, existing, value);
 
   beforeEach(() => {

--- a/packages/notifi-react-hooks/lib/utils/ensureTarget.ts
+++ b/packages/notifi-react-hooks/lib/utils/ensureTarget.ts
@@ -16,21 +16,21 @@ export type CreateFunc<Service, T> = (
   service: Service,
   value: string,
 ) => Promise<T>;
-export type IdentifyFunc<T> = (arg: T) => string | null;
+export type IdentifyFunc<T> = (arg: T) => string | undefined;
 export type ValueTransformFunc = (value: string) => string;
 
-const ensureTarget = <Service, T extends Readonly<{ id: string | null }>>(
+const ensureTarget = <Service, T extends Readonly<{ id: string | undefined }>>(
   create: CreateFunc<Service, T>,
   identify: IdentifyFunc<T>,
   valueTransform?: ValueTransformFunc,
 ): ((
   service: Service,
   existing: Array<T> | undefined,
-  value: string | null,
-) => Promise<string | null>) => {
+  value: string | undefined,
+) => Promise<string | undefined>) => {
   return async (service, existing, value) => {
-    if (value === null) {
-      return null;
+    if (value === undefined) {
+      return undefined;
     }
 
     const transformedValue =
@@ -54,7 +54,7 @@ const ensureEmail = ensureTarget(
       name: value.toLowerCase(),
       value: value.toLowerCase(),
     }),
-  (arg: EmailTarget) => arg.emailAddress?.toLowerCase() ?? null,
+  (arg: EmailTarget) => arg.emailAddress?.toLowerCase() ?? undefined,
   (value: string) => value.toLowerCase(),
 );
 

--- a/packages/notifi-react-hooks/lib/utils/ensureTargetIds.ts
+++ b/packages/notifi-react-hooks/lib/utils/ensureTargetIds.ts
@@ -36,11 +36,11 @@ const ensureTargetIds = async (
     CreateDiscordTargetService,
   existing: ExistingData,
   input: Readonly<{
-    emailAddress: string | null;
-    phoneNumber: string | null;
-    telegramId: string | null;
+    emailAddress: string | undefined;
+    phoneNumber: string | undefined;
+    telegramId: string | undefined;
     webhook?: ClientCreateWebhookParams;
-    discordId: string | null;
+    discordId: string | undefined;
   }>,
 ) => {
   const { emailAddress, phoneNumber, telegramId, webhook, discordId } = input;


### PR DESCRIPTION
In order to being able to completely deprecate notifi-core in notifi-react-card, firstly we need to consolidate types of notifi-core and notifi-graphql (targets).
Accordingly, also adjust corresponding parts