### PR TITLE
MVP-2660-patch: follow graphql-codegen convention using Fragment type

### DIFF
--- a/packages/notifi-core/lib/NotifiClient.ts
+++ b/packages/notifi-core/lib/NotifiClient.ts
@@ -4,13 +4,9 @@ import {
   Alert,
   ClientConfiguration,
   ConnectedWallet,
-  DiscordTarget,
-  EmailTarget,
   NotificationHistory,
-  SmsTarget,
   SourceGroup,
   TargetGroup,
-  TelegramTarget,
   TenantConfig,
   User,
   UserTopic,
@@ -32,14 +28,14 @@ import {
 
 export type ClientData = Readonly<{
   alerts: ReadonlyArray<Alert>;
-  connectedWallets: ReadonlyArray<ConnectedWallet>;
-  emailTargets: ReadonlyArray<EmailTarget>;
-  filters: ReadonlyArray<Types.Filter>;
-  smsTargets: ReadonlyArray<SmsTarget>;
-  sources: ReadonlyArray<Types.Source>;
-  targetGroups: ReadonlyArray<TargetGroup>;
-  telegramTargets: ReadonlyArray<TelegramTarget>;
-  discordTargets: ReadonlyArray<DiscordTarget>;
+  connectedWallets: ReadonlyArray<Types.ConnectedWalletFragmentFragment>;
+  emailTargets: ReadonlyArray<Types.EmailTargetFragmentFragment>;
+  filters: ReadonlyArray<Types.FilterFragmentFragment>;
+  smsTargets: ReadonlyArray<Types.SmsTargetFragmentFragment>;
+  sources: ReadonlyArray<Types.SourceFragmentFragment>;
+  targetGroups: ReadonlyArray<Types.TargetGroupFragmentFragment>;
+  telegramTargets: ReadonlyArray<Types.TelegramTargetFragmentFragment>;
+  discordTargets: ReadonlyArray<Types.DiscordTargetFragmentFragment>;
 }>;
 
 export type AlertFrequency =
@@ -407,14 +403,16 @@ export type NotifiClient = Readonly<{
   logOut: () => Promise<void>;
   connectWallet: (input: ConnectWalletParams) => Promise<ConnectedWallet>;
   createAlert: (input: ClientCreateAlertInput) => Promise<Alert>;
-  createSource: (input: Types.CreateSourceInput) => Promise<Types.Source>;
+  createSource: (
+    input: Types.CreateSourceInput,
+  ) => Promise<Types.SourceFragmentFragment>;
   createSupportConversation: () => Promise<SupportConversation>;
   createMetaplexAuctionSource: (
     input: ClientCreateMetaplexAuctionSourceInput,
-  ) => Promise<Types.Source>;
+  ) => Promise<Types.SourceFragmentFragment>;
   createBonfidaAuctionSource: (
     input: ClientCreateBonfidaAuctionSourceInput,
-  ) => Promise<Types.Source>;
+  ) => Promise<Types.SourceFragmentFragment>;
   deleteAlert: (input: ClientDeleteAlertInput) => Promise<string>;
   getConfiguration: () => Promise<ClientConfiguration>;
   getNotificationHistory: (

--- a/packages/notifi-core/lib/models/Alert.ts
+++ b/packages/notifi-core/lib/models/Alert.ts
@@ -17,8 +17,4 @@ import { Types } from '@notifi-network/notifi-graphql';
  */
 
 // Infer the fetched Alter type (Reason: the underlying type of target element ans sourceGroup not matching Gql types)
-export type Alert = NonNullable<Types.FetchDataQuery['alert']> extends Array<
-  infer U
->
-  ? NonNullable<U>
-  : never;
+export type Alert = Types.AlertFragmentFragment;

--- a/packages/notifi-core/lib/models/ConnectedWallet.ts
+++ b/packages/notifi-core/lib/models/ConnectedWallet.ts
@@ -10,9 +10,4 @@ import { Types } from '@notifi-network/notifi-graphql';
  * @property {string} walletBlockchain - the blockchain associated with the wallet
  *
  */
-export type ConnectedWallet =
-  Types.FetchDataQuery['connectedWallet'] extends infer R
-    ? R extends Array<infer V>
-      ? NonNullable<V>
-      : never
-    : never;
+export type ConnectedWallet = Types.ConnectedWalletFragmentFragment;

--- a/packages/notifi-core/lib/models/DiscordTarget.ts
+++ b/packages/notifi-core/lib/models/DiscordTarget.ts
@@ -19,7 +19,4 @@ export enum DiscordTargetStatus {
   COMPLETE = 'COMPLETE',
 }
 
-export type DiscordTarget = Omit<
-  Types.DiscordTarget,
-  'createdDate' | 'updatedDate'
->;
+export type DiscordTarget = Types.DiscordTargetFragmentFragment;

--- a/packages/notifi-core/lib/models/SmsTarget.ts
+++ b/packages/notifi-core/lib/models/SmsTarget.ts
@@ -12,8 +12,4 @@ import { Types } from '@notifi-network/notifi-graphql';
  * @property {boolean} isConfirmed - Is confirmed? After adding it will be auto-confirmed. Users can opt-out with STOP codes
  *
  */
-export type SmsTarget = Types.FetchDataQuery['smsTarget'] extends infer R
-  ? R extends Array<infer V>
-    ? NonNullable<V>
-    : never
-  : never;
+export type SmsTarget = Types.SmsTargetFragmentFragment;

--- a/packages/notifi-core/lib/models/SourceGroup.ts
+++ b/packages/notifi-core/lib/models/SourceGroup.ts
@@ -13,7 +13,4 @@ import { Types } from '@notifi-network/notifi-graphql';
  */
 
 // Infer the fetched Alter type (Reason: the underlying type of targetGroup element not matching Types.TargetGroup)
-export type SourceGroup = Omit<
-  Types.SourceGroup,
-  'createdDate' | 'updatedDate'
->;
+export type SourceGroup = Types.SourceGroupFragmentFragment;

--- a/packages/notifi-core/lib/models/TargetGroup.ts
+++ b/packages/notifi-core/lib/models/TargetGroup.ts
@@ -14,4 +14,4 @@ import { Types } from '@notifi-network/notifi-graphql';
  * @property {DiscordTarget[] | null} discordTargets - Array of discordTargets
  *
  */
-export type TargetGroup = Types.TargetGroup;
+export type TargetGroup = Types.TargetGroupFragmentFragment;

--- a/packages/notifi-core/lib/models/TelegramTarget.ts
+++ b/packages/notifi-core/lib/models/TelegramTarget.ts
@@ -13,9 +13,4 @@ import { Types } from '@notifi-network/notifi-graphql';
  * @property {string | null} confirmationUrl - If not confirmed, use this URL to allow the user to start the Telegram bot
  *
  */
-export type TelegramTarget =
-  Types.FetchDataQuery['telegramTarget'] extends infer R
-    ? R extends Array<infer V>
-      ? NonNullable<V>
-      : never
-    : never;
+export type TelegramTarget = Types.TelegramTargetFragmentFragment;

--- a/packages/notifi-core/lib/operations/CreateSource.ts
+++ b/packages/notifi-core/lib/operations/CreateSource.ts
@@ -19,7 +19,7 @@ import { Operation } from '../models';
 // TODO: Finally will be deprecated and replaced with automatically generated types
 export type CreateSourceInput = Types.CreateSourceInput;
 
-export type CreateSourceResult = Types.Source;
+export type CreateSourceResult = Types.SourceFragmentFragment;
 
 export type CreateSourceService = Readonly<{
   createSource: Operation<Types.CreateSourceInput, CreateSourceResult>;

--- a/packages/notifi-core/lib/operations/GetSources.ts
+++ b/packages/notifi-core/lib/operations/GetSources.ts
@@ -2,7 +2,7 @@ import { Types } from '@notifi-network/notifi-graphql';
 
 import { ParameterLessOperation } from '../models';
 
-export type GetSourcesResult = ReadonlyArray<Types.Source>;
+export type GetSourcesResult = ReadonlyArray<Types.SourceFragmentFragment>;
 
 export type GetSourcesService = Readonly<{
   getSources: ParameterLessOperation<GetSourcesResult>;

--- a/packages/notifi-react-card/lib/components/WalletList/WalletList.tsx
+++ b/packages/notifi-react-card/lib/components/WalletList/WalletList.tsx
@@ -9,7 +9,7 @@ import {
 import { ConnectWalletRow } from './ConnectWalletRow';
 
 export type WalletListInternalProps = Readonly<{
-  connectedWallets: ReadonlyArray<Types.ConnectedWallet>;
+  connectedWallets: ReadonlyArray<Types.ConnectedWalletFragmentFragment>;
   ownedWallets: ReadonlyArray<WalletWithSignParams>;
   disabled: boolean;
 }>;
@@ -48,7 +48,7 @@ export const WalletList: React.FC = () => {
     <WalletListInternal
       ownedWallets={owned}
       connectedWallets={connectedWallets.filter(
-        (wallet): wallet is Types.ConnectedWallet => !!wallet,
+        (wallet): wallet is Types.ConnectedWalletFragmentFragment => !!wallet,
       )}
       disabled={loading}
     />

--- a/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
@@ -252,7 +252,7 @@ export const NotifiSubscriptionContextProvider: React.FC<
 
       setConnectedWallets(
         newData.connectedWallet?.filter(
-          (wallet): wallet is Types.ConnectedWallet => !!wallet,
+          (wallet): wallet is Types.ConnectedWalletFragmentFragment => !!wallet,
         ) ?? [],
       );
       const emailTarget = targetGroup?.emailTargets?.[0] ?? null;

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -390,7 +390,7 @@ export const useNotifiSubscribe: ({
 
       const ensureSource = async (
         params: Types.CreateSourceInput,
-      ): Promise<Types.Source> => {
+      ): Promise<Types.SourceFragmentFragment> => {
         const existing = data.sources.find(
           (s) =>
             s.type === params.type &&
@@ -457,7 +457,7 @@ export const useNotifiSubscribe: ({
           sourceGroupName,
         } = alertConfiguration;
 
-        let source: Types.Maybe<Types.Source>;
+        let source: Types.Maybe<Types.SourceFragmentFragment>;
 
         if (createSourceParam !== undefined) {
           source = await ensureSource({

--- a/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
+++ b/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
@@ -238,14 +238,16 @@ export const tradingPairConfiguration = ({
 export const walletBalanceConfiguration = ({
   connectedWallets,
 }: Readonly<{
-  connectedWallets: ReadonlyArray<Types.ConnectedWallet>;
+  connectedWallets: ReadonlyArray<Types.ConnectedWalletFragmentFragment>;
 }>): AlertConfiguration => {
   return {
     type: 'multiple',
     filterType: 'BALANCE',
     filterOptions: null,
     sources: connectedWallets
-      .filter((wallet): wallet is Types.ConnectedWallet => !!wallet)
+      .filter(
+        (wallet): wallet is Types.ConnectedWalletFragmentFragment => !!wallet,
+      )
       .map(walletToSource),
     sourceGroupName: 'User Wallets',
   };
@@ -344,7 +346,8 @@ export const createConfigurations = (
       case 'walletBalance': {
         configs[eventType.name] = walletBalanceConfiguration({
           connectedWallets: connectedWallets.filter(
-            (wallet): wallet is Types.ConnectedWallet => !!wallet,
+            (wallet): wallet is Types.ConnectedWalletFragmentFragment =>
+              !!wallet,
           ),
         });
         break;

--- a/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
+++ b/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
@@ -937,7 +937,7 @@ const useNotifiClient = (
         }
 
         let sourceIds: ReadonlyArray<string> = [];
-        let sourceToUse: Types.Maybe<Types.Source>;
+        let sourceToUse: Types.Maybe<Types.SourceFragmentFragment>;
         if (sourceId === '' && sourceIdsInput !== undefined) {
           sourceToUse = newData.sources.find((s) => s.id === sourceIdsInput[0]);
           sourceIds = sourceIdsInput;
@@ -1122,7 +1122,9 @@ const useNotifiClient = (
    * See [Alert Creation Guide]{@link https://docs.notifi.network} for more information on creating Alerts
    */
   const createSource = useCallback(
-    async (input: Types.CreateSourceInput): Promise<Types.Source> => {
+    async (
+      input: Types.CreateSourceInput,
+    ): Promise<Types.SourceFragmentFragment> => {
       setLoading(true);
       try {
         const newData = await fetchDataImpl(
@@ -1172,7 +1174,7 @@ const useNotifiClient = (
   const createBonfidaAuctionSource = useCallback(
     async (
       input: ClientCreateBonfidaAuctionSourceInput,
-    ): Promise<Types.Source> => {
+    ): Promise<Types.SourceFragmentFragment> => {
       setLoading(true);
       try {
         const newData = await fetchDataImpl(
@@ -1216,7 +1218,7 @@ const useNotifiClient = (
   const createMetaplexAuctionSource = useCallback(
     async (
       input: ClientCreateMetaplexAuctionSourceInput,
-    ): Promise<Types.Source> => {
+    ): Promise<Types.SourceFragmentFragment> => {
       setLoading(true);
       try {
         const newData = await fetchDataImpl(

--- a/packages/notifi-react-hooks/lib/utils/ensureSource.ts
+++ b/packages/notifi-react-hooks/lib/utils/ensureSource.ts
@@ -14,9 +14,9 @@ export type ValueTransformFunc = (value: string) => string;
 
 const ensureSource = async (
   service: CreateSourceService,
-  existing: Types.Source[],
+  existing: Types.SourceFragmentFragment[],
   input: Types.CreateSourceInput,
-): Promise<Types.Source> => {
+): Promise<Types.SourceFragmentFragment> => {
   const found = existing.find((it) => input.name === it.name);
   if (found !== undefined) {
     return found;
@@ -30,9 +30,9 @@ const ensureSource = async (
 
 const ensureBonfidaAuctionSource = async (
   service: CreateSourceService,
-  existing: Types.Source[],
+  existing: Types.SourceFragmentFragment[],
   input: ClientCreateBonfidaAuctionSourceInput,
-): Promise<Types.Source> => {
+): Promise<Types.SourceFragmentFragment> => {
   const { auctionAddressBase58, auctionName } = input;
   const underlyingAddress = `${auctionName}:;:${auctionAddressBase58}`;
 
@@ -45,9 +45,9 @@ const ensureBonfidaAuctionSource = async (
 
 const ensureMetaplexAuctionSource = async (
   service: CreateSourceService,
-  existing: Types.Source[],
+  existing: Types.SourceFragmentFragment[],
   input: ClientCreateMetaplexAuctionSourceInput,
-): Promise<Types.Source> => {
+): Promise<Types.SourceFragmentFragment> => {
   const { auctionAddressBase58, auctionWebUrl } = input;
   const underlyingAddress = `${auctionWebUrl}:;:${auctionAddressBase58}`;
 

--- a/packages/notifi-react-hooks/lib/utils/fetchDataImpl.ts
+++ b/packages/notifi-react-hooks/lib/utils/fetchDataImpl.ts
@@ -25,8 +25,8 @@ import { Types } from '@notifi-network/notifi-graphql';
 export type InternalData = {
   alerts: Alert[];
   connectedWallets: ConnectedWallet[];
-  filters: Types.Filter[];
-  sources: Types.Source[];
+  filters: Types.FilterFragmentFragment[];
+  sources: Types.SourceFragmentFragment[];
   sourceGroups: SourceGroup[];
   targetGroups: TargetGroup[];
   emailTargets: EmailTarget[];
@@ -84,7 +84,7 @@ const doFetchData = async (service: Service): Promise<InternalData> => {
   ]);
 
   const filterIds = new Set<string | null>();
-  const filters: Types.Filter[] = [];
+  const filters: Types.FilterFragmentFragment[] = [];
   sources.forEach((source) => {
     source.applicableFilters?.forEach((filter) => {
       if (!filterIds.has(filter?.id ?? '')) {


### PR DESCRIPTION
Optimization: Use the type with `Fragment` suffix instead of extracting the same types from `FetchQuery`