### PR TITLE
MVP-2716: Allow FTU login w/o targets

### DIFF
--- a/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
+++ b/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
@@ -212,6 +212,7 @@ export type CardConfigItemV1 = Readonly<{
   eventTypes: EventTypeConfig;
   inputs: InputsConfig;
   contactInfo: ContactInfoConfig;
+  isContactInfoRequired?: boolean;
   titles?: TitleSubtitleConfig;
 }>;
 

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
@@ -1,6 +1,7 @@
 import { SignMessageParams } from '@notifi-network/notifi-core';
 import {
   CardConfigItemV1,
+  ContactInfoConfig,
   EventTypeConfig,
 } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
@@ -165,16 +166,16 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
   ]);
 
   const hasErrors = emailErrorMessage !== '' || smsErrorMessage !== '';
+  const isInputFieldsValid = useMemo(() => {
+    return data.isContactInfoRequired
+      ? email || phoneNumber || telegramId || useDiscord
+      : true;
+  }, [email, phoneNumber, telegramId, useDiscord, data.isContactInfoRequired]);
 
   return (
     <button
       className={clsx('NotifiSubscribeButton__button', classNames?.button)}
-      disabled={
-        !isInitialized ||
-        loading ||
-        hasErrors ||
-        (!email && !phoneNumber && !telegramId && useDiscord === false)
-      }
+      disabled={!isInitialized || loading || hasErrors || !isInputFieldsValid}
       onClick={onClick}
     >
       <span className={clsx('NotifiSubscribeButton__label', classNames?.label)}>

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/EditCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/EditCardView.tsx
@@ -67,13 +67,17 @@ export const EditCardView: React.FC<EditCardViewProps> = ({
           <Spinner size="70px" />
         </div>
       ) : (
-        <InputFields
-          data={data}
-          allowedCountryCodes={allowedCountryCodes}
-          inputDisabled={inputDisabled}
-          inputSeparators={inputSeparators}
-          inputTextFields={inputTextFields}
-        />
+        <>
+          {showPreview && !data.isContactInfoRequired ? null : (
+            <InputFields
+              data={data}
+              allowedCountryCodes={allowedCountryCodes}
+              inputDisabled={inputDisabled}
+              inputSeparators={inputSeparators}
+              inputTextFields={inputTextFields}
+            />
+          )}
+        </>
       )}
       <NotifiSubscribeButton
         buttonText={buttonText}


### PR DESCRIPTION
Allow FTU to login w/o filling targets. See the detail flow below:

https://github.com/notifi-network/notifi-sdk-ts/assets/127958634/5bdee7b0-2fbb-49f8-9a11-73be9d44f532

**NOTE**
Not to merge until BE supports ~`isContactInfoRequired` in CardConfig (MVP-2714)~ MVP-2715. Otherwise, those users will not be able to get notification history