### PR TITLE
MVP-2718: Add new SignupBanner component

### DIFF
--- a/packages/notifi-react-card/lib/assets/BellIcon.tsx
+++ b/packages/notifi-react-card/lib/assets/BellIcon.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export type Props = React.SVGProps<SVGSVGElement>;
+
+export const BellIcon: React.FC<Props> = (props: Props) => {
+  return (
+    <svg
+      width="25"
+      height="25"
+      viewBox="-6 -6 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M5.49013 11.1875C6.12122 11.1875 6.63757 10.6712 6.63757 10.0401H4.3427C4.3427 10.6712 4.85331 11.1875 5.49013 11.1875ZM8.93244 7.74519V4.8766C8.93244 3.11529 7.99154 1.64083 6.35071 1.25071V0.860577C6.35071 0.384391 5.96632 0 5.49013 0C5.01395 0 4.62956 0.384391 4.62956 0.860577V1.25071C2.98299 1.64083 2.04783 3.10955 2.04783 4.8766V7.74519L0.900391 8.89263V9.46635H10.0799V8.89263L8.93244 7.74519Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+};

--- a/packages/notifi-react-card/lib/components/AlertHistory/AlertIcon.tsx
+++ b/packages/notifi-react-card/lib/components/AlertHistory/AlertIcon.tsx
@@ -1,3 +1,4 @@
+import { BellIcon } from 'notifi-react-card/lib/assets/BellIcon';
 import React from 'react';
 
 import { AnnouncementIcon } from '../../assets/AnnouncementIcon';
@@ -32,6 +33,7 @@ const icons: Record<string, React.FC<React.SVGProps<SVGSVGElement>>> = {
   SWAP: SwapIcon,
   URGENT: UrgentIcon,
   WATCH: WatchIcon,
+  BELL: BellIcon,
 };
 
 export type Props = React.SVGProps<SVGSVGElement> & Readonly<{ icon: string }>;

--- a/packages/notifi-react-card/lib/components/SignupBanner.tsx
+++ b/packages/notifi-react-card/lib/components/SignupBanner.tsx
@@ -1,0 +1,104 @@
+import {
+  CardConfigItemV1,
+  ContactInfoConfig,
+} from '@notifi-network/notifi-frontend-client';
+import clsx from 'clsx';
+import React, { useMemo } from 'react';
+
+import { useNotifiSubscriptionContext } from '../context';
+import { DeepPartialReadonly } from '../utils';
+import { AlertIcon } from './AlertHistory/AlertIcon';
+
+export type SignupBannerProps = Readonly<{
+  data: CardConfigItemV1;
+  classNames?: DeepPartialReadonly<{
+    banner: string;
+    bannerImage: string;
+    bannerLabel: string;
+    bannerContent: string;
+    bannerTitle: string;
+    bannerSubject: string;
+    bannerButton: string;
+  }>;
+}>;
+
+export const SignupBanner: React.FC<SignupBannerProps> = ({
+  classNames,
+  data,
+}) => {
+  const { cardView, setCardView } = useNotifiSubscriptionContext();
+
+  const targets = useMemo(() => {
+    const supportedTargets = Object.keys(data.contactInfo)
+      .filter((target) => {
+        return data.contactInfo[target as keyof ContactInfoConfig].active;
+      })
+      .map((target) => target.charAt(0).toLocaleUpperCase() + target.slice(1));
+    return supportedTargets.length > 1
+      ? supportedTargets.join(', ')
+      : supportedTargets[0];
+  }, []);
+  const onClick = () => {
+    setCardView({
+      state: 'edit',
+    });
+  };
+  return (
+    <>
+      <div
+        className={clsx(
+          classNames?.banner ? classNames.banner : 'SignupBanner',
+          cardView.state === 'preview' && 'SignupBanner__Column',
+        )}
+      >
+        <div className={clsx('SignupBanner__Label', classNames?.bannerLabel)}>
+          <div
+            className={clsx(
+              classNames?.bannerImage
+                ? classNames?.bannerImage
+                : 'SignupBanner__Image',
+            )}
+          >
+            <AlertIcon icon={'BELL'} />
+          </div>
+          <div
+            className={clsx(
+              classNames?.bannerContent
+                ? classNames.bannerContent
+                : 'SignupBanner__Content',
+            )}
+          >
+            <div
+              className={clsx(
+                classNames?.bannerTitle
+                  ? classNames.bannerTitle
+                  : 'SignupBanner__Title',
+              )}
+            >
+              Get alerts via
+            </div>
+            <div
+              className={clsx(
+                classNames?.bannerSubject
+                  ? classNames.bannerSubject
+                  : 'SignupBanner__Subject',
+              )}
+            >
+              {targets}
+            </div>
+          </div>
+        </div>
+        <button
+          className={clsx(
+            classNames?.bannerButton
+              ? classNames.bannerButton
+              : 'SignupBanner__Button',
+          )}
+          onClick={onClick}
+        >
+          Sign Up
+        </button>
+      </div>
+    </>
+  );
+};

--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -34,9 +34,11 @@ a {
   --notifi-focus-color: #fff;
   --notifi-toggle-handle: #fff;
   --notifi-toggle-inactive: #b6b8d5;
-  --notifi-toggle-active: linear-gradient(207.53deg,
-      #fe7970 11.91%,
-      #feb776 88.99%);
+  --notifi-toggle-active: linear-gradient(
+    207.53deg,
+    #fe7970 11.91%,
+    #feb776 88.99%
+  );
   --notifi-tooltip-background: rgba(60, 60, 60, 1);
   --notifi-alert-color: rgb(213, 25, 25);
   --notifi-link-color: hsl(240, 100%, 85%);
@@ -54,6 +56,8 @@ a {
   --notifi-outgoing-message: #678afc;
   --notifi-settings-icon-color: #fff;
   --notifi-confirmation-color: #45c95e;
+  --notifi-banner-background: #222222;
+  --notifi-banner-icon-color: #262949;
 }
 
 input:autofill,
@@ -287,7 +291,8 @@ input::-webkit-inner-spin-button {
   margin: 10px 0;
 }
 
-.NotifiAlertHistory__content {
+.NotifiAlertHistory__content,
+.SignupBanner__Content {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
@@ -316,7 +321,8 @@ input::-webkit-inner-spin-button {
   padding-right: 25px;
 }
 
-.NotifiAlertHistory__notificationTitle {
+.NotifiAlertHistory__notificationTitle,
+.SignupBanner__Title {
   font-size: 14px;
   line-height: 14px;
   overflow: hidden;
@@ -345,7 +351,8 @@ input::-webkit-inner-spin-button {
   text-align: center;
 }
 
-.NotifiAlertHistory__notificationSubject {
+.NotifiAlertHistory__notificationSubject,
+.SignupBanner__Subject {
   font-size: 12px;
   line-height: 14px;
   color: var(--notifi-font-color);
@@ -435,7 +442,9 @@ input::-webkit-inner-spin-button {
 .NotifiToggle__container {
   --notifi-toggle-size: 22px;
   --notifi-toggle-padding: 3px;
-  --notifi-toggle-container: calc(var(--notifi-toggle-size) + 2 * var(--notifi-toggle-padding));
+  --notifi-toggle-container: calc(
+    var(--notifi-toggle-size) + 2 * var(--notifi-toggle-padding)
+  );
   position: relative;
   display: inline-block;
   width: calc(var(--notifi-toggle-container) + var(--notifi-toggle-size));
@@ -483,11 +492,11 @@ input::-webkit-inner-spin-button {
   transition: 0.2s;
 }
 
-.NotifiToggle__input:checked+.NotifiToggle__slider {
+.NotifiToggle__input:checked + .NotifiToggle__slider {
   background: var(--notifi-toggle-active);
 }
 
-.NotifiToggle__input:checked+.NotifiToggle__slider:before {
+.NotifiToggle__input:checked + .NotifiToggle__slider:before {
   transform: translateX(var(--notifi-toggle-size));
 }
 
@@ -495,7 +504,7 @@ input::-webkit-inner-spin-button {
   cursor: progress;
 }
 
-.NotifiIntercomToggle__input:checked+.NotifiToggle__slider {
+.NotifiIntercomToggle__input:checked + .NotifiToggle__slider {
   background-color: #1448f3;
 }
 
@@ -884,7 +893,7 @@ input::-webkit-inner-spin-button {
   left: 50%;
 }
 
-.NotifiTooltip__container:hover>.NotifiTooltip__body {
+.NotifiTooltip__container:hover > .NotifiTooltip__body {
   visibility: visible;
 }
 
@@ -1392,15 +1401,15 @@ input::-webkit-inner-spin-button {
   flex-direction: column;
 }
 
-.EventTypeTradingPairsRow__container>* {
+.EventTypeTradingPairsRow__container > * {
   margin-bottom: 0 !important;
 }
 
-.EventTypeTradingPairsRow__container>*:not(:first-child) {
+.EventTypeTradingPairsRow__container > *:not(:first-child) {
   padding-top: 10px;
 }
 
-.EventTypeTradingPairsRow__container>*:not(:last-child) {
+.EventTypeTradingPairsRow__container > *:not(:last-child) {
   padding-bottom: 10px;
   border-bottom: 1px var(--notifi-font-color) solid;
 }
@@ -1662,10 +1671,46 @@ input::-webkit-inner-spin-button {
   padding: 0 20px;
 }
 
-
 .NotifiInputContainer__LoadingSpinner {
   display: flex;
   justify-content: center;
   align-items: center;
   flex-grow: 1;
+}
+
+.SignupBanner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: var(--notifi-banner-background);
+}
+
+.SignupBanner__Column {
+  flex-direction: column;
+  padding: 14px 0 20px 0;
+}
+
+.SignupBanner__Label {
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 0 0 10px;
+}
+
+.SignupBanner__Image {
+  width: 24px;
+  height: 24px;
+  color: var(--notifi-banner-icon-color);
+  background-color: var(--notifi-settings-icon-color);
+  margin-right: 10px;
+  border-radius: 50px;
+  overflow: hidden;
+  border: 2px solid var(--notifi-checkmark-color);
+}
+
+.SignupBanner__Button {
+  width: 72px;
+  height: 29px;
+  border-radius: 4.04px;
+  margin-right: 10px;
+  cursor: pointer;
 }

--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -81,7 +81,7 @@ input::-webkit-inner-spin-button {
   font-family: Helvetica, sans-serif;
   background-color: var(--notifi-card-background);
   border-radius: 5px;
-  padding: 20px 20px 5px 20px;
+  padding: 20px 0px 5px 0px;
   min-height: 510px;
 }
 
@@ -89,10 +89,25 @@ input::-webkit-inner-spin-button {
   flex-grow: 1;
 }
 
+.NotifiPreviewCard__dividerLine {
+  border-top: 1px solid var(--notifi-font-color);
+  opacity: 0.2;
+  margin: 20px 16px;
+}
+
+.NotifiPreviewCard__title {
+  line-height: 133.187%;
+  letter-spacing: 0.12px;
+  padding: 0 20px;
+  opacity: 0.6;
+  margin-bottom: 17.5px !important;
+}
+
 .NotifiInputContainer {
   flex-grow: 1;
   display: flex;
   flex-direction: column;
+  margin: 0px 20px;
 }
 
 .NotifiInputHeading {
@@ -228,7 +243,7 @@ input::-webkit-inner-spin-button {
 .NotifiAlertBox__container {
   display: flex;
   align-items: center;
-  padding: 0;
+  padding: 0px 20px;
 }
 
 .NotifiAlertBox__btn--left,
@@ -309,8 +324,10 @@ input::-webkit-inner-spin-button {
 }
 
 .NotifiAlertHistory__dividerLine {
-  border-top: 2px solid var(--notifi-font-color);
+  border-top: 1px solid var(--notifi-font-color);
   border-radius: 5px;
+  opacity: 0.2;
+  margin-bottom: 0 !important;
 }
 
 .NotifiAlertHistory__notificationDate {
@@ -524,6 +541,10 @@ input::-webkit-inner-spin-button {
   line-height: 20px;
   color: var(--notifi-font-color);
   margin-bottom: 0px !important;
+}
+
+.NotifiEventTypeContainer {
+  padding: 0 20px;
 }
 
 .EventTypeLabelRow__container,
@@ -788,6 +809,7 @@ input::-webkit-inner-spin-button {
   padding: 16px 16px 0px 16px;
   border-radius: 5px;
   background-color: var(--notifi-card-secondary-background);
+  margin: 0px 20px;
 }
 
 .NotifiPreviewCard__editButton {
@@ -1688,6 +1710,8 @@ input::-webkit-inner-spin-button {
 .SignupBanner__Column {
   flex-direction: column;
   padding: 14px 0 20px 0;
+  margin: 0px 20px;
+  border-radius: 4px;
 }
 
 .SignupBanner__Label {
@@ -1713,4 +1737,5 @@ input::-webkit-inner-spin-button {
   border-radius: 4.04px;
   margin-right: 10px;
   cursor: pointer;
+  border: none;
 }

--- a/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
@@ -370,6 +370,7 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
               classNames={classNames?.AlertHistoryView}
               isHidden={selectedAlertEntry !== undefined}
               setAlertEntry={setAlertEntry}
+              data={data}
             />
           </div>
         </>

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
@@ -165,15 +165,16 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
         { 'NotifiAlertHistory__container--hidden': isHidden },
       )}
     >
-      {!isTargetsExist && (
-        <SignupBanner data={data} classNames={classNames?.signupBanner} /> // TODO: Move up one level (for MVP-2733), Blocker: MVP-2716
-      )}
       <div
         className={clsx(
           'NotifiAlertHistory__dividerLine',
           classNames?.dividerLine,
         )}
       />
+      {!isTargetsExist && (
+        <SignupBanner data={data} classNames={classNames?.signupBanner} /> // TODO: Move up one level (for MVP-2733), Blocker: MVP-2716
+      )}
+
       {allNodes.length > 0 ? (
         <Virtuoso
           className={clsx('NotifiAlertHistory__virtuoso', classNames?.virtuoso)}

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
@@ -1,4 +1,5 @@
 import { GetNotificationHistoryInput } from '@notifi-network/notifi-core';
+import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
 import { Types } from '@notifi-network/notifi-graphql';
 import clsx from 'clsx';
 import React, {
@@ -11,7 +12,10 @@ import React, {
 import { Virtuoso } from 'react-virtuoso';
 
 import { NotificationEmptyBellIcon } from '../../../assets/NotificationEmptyBellIcon';
-import { useNotifiClientContext } from '../../../context';
+import {
+  useNotifiClientContext,
+  useNotifiSubscriptionContext,
+} from '../../../context';
 import {
   DeepPartialReadonly,
   getAlertNotificationViewBaseProps,
@@ -22,10 +26,12 @@ import {
   AlertNotificationRow,
   AlertNotificationViewProps,
 } from '../../AlertHistory/AlertNotificationRow';
+import { SignupBanner, SignupBannerProps } from '../../SignupBanner';
 
 export type AlertHistoryViewProps = Readonly<{
   noAlertDescription?: string;
   isHidden: boolean;
+  data: CardConfigItemV1;
   classNames?: DeepPartialReadonly<{
     title: string;
     header: string;
@@ -41,6 +47,7 @@ export type AlertHistoryViewProps = Readonly<{
     historyContainer: string;
     virtuoso: string;
     AlertCard: AlertNotificationViewProps['classNames'];
+    signupBanner: SignupBannerProps['classNames']; // TODO: Move up one level (for MVP-2733), Blocker: MVP-2716
   }>;
   setAlertEntry: React.Dispatch<
     React.SetStateAction<
@@ -51,6 +58,7 @@ export type AlertHistoryViewProps = Readonly<{
 
 export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
   classNames,
+  data,
   isHidden,
   noAlertDescription,
   setAlertEntry,
@@ -73,6 +81,9 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
     canary: { isActive: isCanaryActive, frontendClient },
   } = useNotifiClientContext();
 
+  const { email, phoneNumber, telegramId, discordTargetData, useDiscord } =
+    useNotifiSubscriptionContext();
+
   const { isClientInitialized, isClientAuthenticated } = useMemo(() => {
     return {
       isClientInitialized: isCanaryActive
@@ -83,6 +94,23 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
         : client.isAuthenticated,
     };
   }, [isCanaryActive, client, frontendClient]);
+
+  const isTargetsExist = useMemo(() => {
+    return (
+      !!email ||
+      !!phoneNumber ||
+      !!telegramId ||
+      (useDiscord &&
+        !!discordTargetData?.id &&
+        !!discordTargetData?.discordAccountId)
+    );
+  }, [
+    email,
+    phoneNumber,
+    telegramId,
+    discordTargetData?.id,
+    discordTargetData?.discordAccountId,
+  ]);
 
   const getNotificationHistory = useCallback(
     async ({ first, after }: GetNotificationHistoryInput) => {
@@ -137,6 +165,9 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
         { 'NotifiAlertHistory__container--hidden': isHidden },
       )}
     >
+      {!isTargetsExist && (
+        <SignupBanner data={data} classNames={classNames?.signupBanner} /> // TODO: Move up one level (for MVP-2733), Blocker: MVP-2716
+      )}
       <div
         className={clsx(
           'NotifiAlertHistory__dividerLine',

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/PreviewCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/PreviewCard.tsx
@@ -18,6 +18,8 @@ export type PreviewCardProps = Readonly<{
     AlertsPanel?: DeepPartialReadonly<AlertsPanelProps['classNames']>;
     backArrowContainer?: string;
     UserInfoPanel?: DeepPartialReadonly<UserInfoPanelProps['classNames']>;
+    NotifiPreviewCardTitle?: string;
+    NotifiPreviewCardDividerLine?: string;
     signupBanner?: SignupBannerProps['classNames']; // TODO: Move up one level (for MVP-2733), Blocker: MVP-2716
   };
   data: CardConfigItemV1;
@@ -65,6 +67,22 @@ export const PreviewCard: React.FC<PreviewCardProps> = ({
           contactInfo={data.contactInfo}
         />
       )}
+
+      <div
+        className={clsx(
+          'NotifiPreviewCard__dividerLine',
+          classNames?.NotifiPreviewCardDividerLine,
+        )}
+      />
+
+      <div
+        className={clsx(
+          'NotifiPreviewCard__title',
+          classNames?.NotifiPreviewCardTitle,
+        )}
+      >
+        Select the alerts you want to receive:
+      </div>
       <AlertsPanel
         classNames={classNames?.AlertsPanel}
         data={data}

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/PreviewCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/PreviewCard.tsx
@@ -1,8 +1,10 @@
 import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
-import React from 'react';
+import { useNotifiSubscriptionContext } from 'notifi-react-card/lib/context';
+import React, { useMemo } from 'react';
 
 import { DeepPartialReadonly } from '../../../utils';
+import { SignupBanner, SignupBannerProps } from '../../SignupBanner';
 import { AlertsPanel, AlertsPanelProps } from './preview-panel/AlertsPanel';
 import {
   UserInfoPanel,
@@ -16,6 +18,7 @@ export type PreviewCardProps = Readonly<{
     AlertsPanel?: DeepPartialReadonly<AlertsPanelProps['classNames']>;
     backArrowContainer?: string;
     UserInfoPanel?: DeepPartialReadonly<UserInfoPanelProps['classNames']>;
+    signupBanner?: SignupBannerProps['classNames']; // TODO: Move up one level (for MVP-2733), Blocker: MVP-2716
   };
   data: CardConfigItemV1;
   inputDisabled: boolean;
@@ -28,6 +31,25 @@ export const PreviewCard: React.FC<PreviewCardProps> = ({
   inputDisabled,
   inputs = {},
 }) => {
+  const { useDiscord, email, phoneNumber, telegramId, discordTargetData } =
+    useNotifiSubscriptionContext();
+
+  const isTargetsExist = useMemo(() => {
+    return (
+      !!email ||
+      !!phoneNumber ||
+      !!telegramId ||
+      (useDiscord &&
+        !!discordTargetData?.id &&
+        !!discordTargetData?.discordAccountId)
+    );
+  }, [
+    email,
+    phoneNumber,
+    telegramId,
+    discordTargetData?.id,
+    discordTargetData?.discordAccountId,
+  ]);
   return (
     <div
       className={clsx(
@@ -35,10 +57,14 @@ export const PreviewCard: React.FC<PreviewCardProps> = ({
         classNames?.NotifiPreviewCardContainer,
       )}
     >
-      <UserInfoPanel
-        classNames={classNames?.UserInfoPanel}
-        contactInfo={data.contactInfo}
-      />
+      {!isTargetsExist ? (
+        <SignupBanner data={data} classNames={classNames?.signupBanner} /> //TODO: Move up one level (for MVP-2733), Blocker: MVP-2716
+      ) : (
+        <UserInfoPanel
+          classNames={classNames?.UserInfoPanel}
+          contactInfo={data.contactInfo}
+        />
+      )}
       <AlertsPanel
         classNames={classNames?.AlertsPanel}
         data={data}


### PR DESCRIPTION
Add SignupBanner component for those users who want to sign up after logging in anonymously.

- Case#1: notification history page
<img width="406" alt="Screenshot 2023-06-27 at 11 58 41" src="https://github.com/notifi-network/notifi-sdk-ts/assets/127958634/84eecfca-5259-4a56-a5d1-0ff2ae8c6a1e">



- Case#2: Edit page
<img width="408" alt="Screenshot 2023-06-27 at 12 11 30" src="https://github.com/notifi-network/notifi-sdk-ts/assets/127958634/039fb2fd-c4a5-438e-97f1-42c1a57fdaf4">


## Blockers:
- [x]  The PR is in charge of rendering and styling the feature of #320. It can only work after merging #320. 


## TODO after merge

- [ ] Have an UAT with #320 ensuring it is working with whole flow.
- [ ] complete the ticket MVP-2733
