### PR TITLE
MVP-2744: Add fusionHealthCheck eventType

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-**/node_modules
+**/node_modules*
+
 **/dist
 **/coverage
 **/.DS_Store

--- a/packages/notifi-frontend-client/lib/client/ensureSource.ts
+++ b/packages/notifi-frontend-client/lib/client/ensureSource.ts
@@ -675,14 +675,22 @@ const getFusionSourceFilter = (
   if (eventType.selectedUIType === 'HEALTH_CHECK') {
     // Use synthetic ref values to get from input (ratio)
     const healthRatioKey = `${eventType.name}__healthRatio`;
-    const healthRatio =
-      resolveNumberRef(
-        healthRatioKey,
-        { type: 'ref', ref: healthRatioKey },
-        inputs,
-      ) ?? eventType.checkRatios[0].ratio;
+    if (!inputs[healthRatioKey]) {
+      // Set default value if not provided
+      inputs[`${eventType.name}__healthRatio`] = eventType.checkRatios[1].ratio;
+    }
+    const healthRatio = resolveNumberRef(
+      healthRatioKey,
+      { type: 'ref', ref: healthRatioKey },
+      inputs,
+    );
     // Use synthetic ref values to get from input (direction)
     const thresholdDirectionKey = `${eventType.name}__healthThresholdDirection`;
+    if (!inputs[thresholdDirectionKey]) {
+      // Set default value if not provided
+      inputs[thresholdDirectionKey] =
+        eventType.checkRatios[0].type === 'above' ? 'above' : 'below';
+    }
     const thresholdDirection =
       resolveStringRef(
         thresholdDirectionKey,

--- a/packages/notifi-frontend-client/lib/client/ensureSource.ts
+++ b/packages/notifi-frontend-client/lib/client/ensureSource.ts
@@ -455,8 +455,7 @@ const ensureSources = async (
       const source = await ensureHealthCheckSources(service, eventType, inputs);
       return [source];
     }
-    case 'fusionHealthCheck':
-    case 'fusionToggle': {
+    case 'fusion': {
       const source = await ensureFusionSource(service, eventType, inputs);
       return [source];
     }
@@ -673,7 +672,7 @@ const getFusionSourceFilter = (
   }
 
   let filterOptions: FilterOptions = {}; // Default {} if eventType.type = fusionToggle
-  if (eventType.type === 'fusionHealthCheck') {
+  if (eventType.selectedUIType === 'HEALTH_CHECK') {
     // Use synthetic ref values to get from input (ratio)
     const healthRatioKey = `${eventType.name}__healthRatio`;
     const healthRatio =
@@ -1004,8 +1003,7 @@ export const ensureSourceAndFilters = async (
         filterOptions,
       };
     }
-    case 'fusionHealthCheck':
-    case 'fusionToggle': {
+    case 'fusion': {
       const { filter, filterOptions } = getFusionSourceFilter(
         sources[0],
         eventType,

--- a/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
+++ b/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
@@ -22,6 +22,7 @@ export type DirectPushEventTypeItem = Readonly<{
 
 export type FusionTypeBase = {
   name: string;
+  type: 'fusion';
   fusionEventId: ValueOrRef<string>;
   sourceAddress: ValueOrRef<string>;
   tooltipContent?: string;
@@ -30,12 +31,12 @@ export type FusionTypeBase = {
 
 export type FusionToggleEventTypeItem = FusionTypeBase &
   Readonly<{
-    type: 'fusionToggle';
+    selectedUIType: 'TOGGLE';
   }>;
 
 export type FusionHealthCheckEventTypeItem = FusionTypeBase &
   Readonly<{
-    type: 'fusionHealthCheck';
+    selectedUIType: 'HEALTH_CHECK';
     healthCheckSubtitle: string;
     numberType: NumberTypeSelect;
     alertFrequency: AlertFrequency;

--- a/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
+++ b/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
@@ -20,14 +20,31 @@ export type DirectPushEventTypeItem = Readonly<{
   tooltipContent?: string;
 }>;
 
-export type FusionToggleEventTypeItem = Readonly<{
-  type: 'fusionToggle';
+export type FusionTypeBase = {
   name: string;
   fusionEventId: ValueOrRef<string>;
   sourceAddress: ValueOrRef<string>;
   tooltipContent?: string;
   maintainSourceGroup?: boolean;
-}>;
+};
+
+export type FusionToggleEventTypeItem = FusionTypeBase &
+  Readonly<{
+    type: 'fusionToggle';
+  }>;
+
+export type FusionHealthCheckEventTypeItem = FusionTypeBase &
+  Readonly<{
+    type: 'fusionHealthCheck';
+    healthCheckSubtitle: string;
+    numberType: NumberTypeSelect;
+    alertFrequency: AlertFrequency;
+    checkRatios: CheckRatio[];
+  }>;
+
+export type FusionEventTypeItem =
+  | FusionToggleEventTypeItem
+  | FusionHealthCheckEventTypeItem;
 
 export type BroadcastEventTypeItem = Readonly<{
   type: 'broadcast';
@@ -137,7 +154,7 @@ export type EventTypeItem =
   | LabelEventTypeItem
   | PriceChangeEventTypeItem
   | CustomTopicTypeItem
-  | FusionToggleEventTypeItem
+  | FusionEventTypeItem
   | WalletBalanceEventTypeItem
   | XMTPTopicTypeItem
   | CreateSupportConversationEventTypeItem;

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeFusionHealthCheckRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeFusionHealthCheckRow.tsx
@@ -100,11 +100,6 @@ export const EventTypeFusionHealthCheckRow: React.FC<
   const INVALID_NUMBER = 'Please enter a valid number';
 
   useEffect(() => {
-    console.log('Filter', alerts[alertName]?.filterOptions);
-    console.log('Custom Value', customValue);
-  }, [alerts[alertName]?.filterOptions]);
-
-  useEffect(() => {
     if (loading || isNotificationLoading) {
       return;
     }
@@ -131,10 +126,8 @@ export const EventTypeFusionHealthCheckRow: React.FC<
           }
         });
         setInitialRatio(alertRatioValue);
-        console.log('Out', checkRatios, alertRatioValue, customValue);
         if (!checkRatios.includes(alertRatioValue) && customValue === '') {
           setSelectedIndex(3);
-          console.log('in', checkRatios, alertRatioValue);
           setCustomValue(
             config.numberType === 'percentage'
               ? alertRatioValue + '%'
@@ -226,7 +219,6 @@ export const EventTypeFusionHealthCheckRow: React.FC<
         ratioNumber <= 100 &&
         customValue
       ) {
-        console.log('handleCustomRatioButtonT', customInputRef.current);
         subscribeAlert({ eventType: config, inputs }, ratioNumber)
           .then(() => {
             setSelectedIndex(3);
@@ -237,7 +229,6 @@ export const EventTypeFusionHealthCheckRow: React.FC<
             setIsNotificationLoading(false);
           });
       } else {
-        console.log('handleCustomRatioButtonF', customInputRef.current);
         setErrorMessage(INVALID_NUMBER);
         setSelectedIndex(initialSelectedIndex);
         setIsNotificationLoading(false);
@@ -265,7 +256,6 @@ export const EventTypeFusionHealthCheckRow: React.FC<
         .then(() => {
           isCanaryActive && frontendClient.fetchData().then(render);
           setSelectedIndex(index);
-          console.log('new Subscription by default btn');
           setCustomValue('');
         })
         .catch(() => setErrorMessage(UNABLE_TO_SUBSCRIBE))
@@ -273,7 +263,6 @@ export const EventTypeFusionHealthCheckRow: React.FC<
           setIsNotificationLoading(false);
         });
     } else {
-      console.log('handleRatioButtonNew', value, index);
       setErrorMessage(INVALID_NUMBER);
       setIsNotificationLoading(false);
     }
@@ -307,7 +296,6 @@ export const EventTypeFusionHealthCheckRow: React.FC<
     } else {
       unSubscribeAlert({ eventType: config, inputs })
         .then((res) => {
-          console.log("start setCurrentValue('')in handleHealthCheckSub");
           setCustomValue('');
           if (res) {
             const responseHasAlert = res.alerts[alertName] !== undefined;
@@ -419,10 +407,7 @@ export const EventTypeFusionHealthCheckRow: React.FC<
                 setSelectedIndex(null);
               }}
               disabled={isNotificationLoading}
-              onBlur={() => {
-                console.log('onBlur');
-                handleCustomRatioButtonNewSubscription();
-              }}
+              onBlur={handleCustomRatioButtonNewSubscription}
               value={customValue}
               placeholder="Custom"
               className={clsx(
@@ -436,7 +421,6 @@ export const EventTypeFusionHealthCheckRow: React.FC<
                 classNames?.button,
               )}
               onChange={(e) => {
-                console.log('start setCurrentValue(e.target.value)in onChange');
                 setCustomValue(e.target.value ?? '');
               }}
             />

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeFusionHealthCheckRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeFusionHealthCheckRow.tsx
@@ -1,0 +1,456 @@
+import {
+  EventTypeItem,
+  FusionHealthCheckEventTypeItem,
+  ThresholdDirection,
+} from '@notifi-network/notifi-frontend-client';
+import clsx from 'clsx';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import {
+  useNotifiClientContext,
+  useNotifiSubscriptionContext,
+} from '../../context';
+import { SubscriptionData, useNotifiSubscribe } from '../../hooks';
+import {
+  DeepPartialReadonly,
+  fusionHealthCheckConfiguration,
+  subscribeAlertByFrontendClient,
+  unsubscribeAlertByFrontendClient,
+} from '../../utils';
+import type { NotifiToggleProps } from './NotifiToggle';
+import { NotifiToggle } from './NotifiToggle';
+import { NotifiTooltip, NotifiTooltipProps } from './NotifiTooltip';
+import { resolveStringRef } from './resolveRef';
+
+export type EventTypeFusionHealthCheckRowProps = Readonly<{
+  classNames?: DeepPartialReadonly<{
+    container: string;
+    label: string;
+    content: string;
+    button: string;
+    toggle: NotifiToggleProps['classNames'];
+    buttonContainer: string;
+    errorMessage: string;
+    tooltip: NotifiTooltipProps['classNames'];
+  }>;
+  disabled: boolean;
+  config: FusionHealthCheckEventTypeItem;
+  inputs: Record<string, unknown>;
+}>;
+
+const getParsedInputNumber = (input: string): number | null => {
+  if (input.indexOf('%') === input.length - 1) {
+    return parseFloat(input.slice(0, -1)) ?? null;
+  }
+  return null;
+};
+
+export const EventTypeFusionHealthCheckRow: React.FC<
+  EventTypeFusionHealthCheckRowProps
+> = ({ classNames, config, disabled, inputs }) => {
+  const { alerts, loading, render } = useNotifiSubscriptionContext();
+  const { instantSubscribe } = useNotifiSubscribe({
+    targetGroupName: 'Default',
+  });
+  const {
+    canary: { isActive: isCanaryActive, frontendClient },
+  } = useNotifiClientContext();
+
+  const [enabled, setEnabled] = useState(false);
+
+  // This indicates which box to select
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [initialSelectedIndex, setInitialSelectedIndex] = useState<
+    number | null
+  >(null);
+  const [initialRatio, setInitialRatio] = useState<number | null>(null);
+  const [isNotificationLoading, setIsNotificationLoading] =
+    useState<boolean>(false);
+  const [customValue, setCustomValue] = useState<string>('');
+  const customInputRef = useRef<HTMLInputElement>(null);
+  const thresholdDirection: ThresholdDirection = 'below';
+  const [errorMessage, setErrorMessage] = useState<string>('');
+  const fusionEventId = useMemo(
+    () => resolveStringRef(config.name, config.fusionEventId, inputs),
+    [config, inputs],
+  );
+
+  const fusionSourceAddress = useMemo(
+    () => resolveStringRef(config.name, config.sourceAddress, inputs),
+    [config, inputs],
+  );
+
+  const alertName = useMemo<string>(() => {
+    if (config.fusionEventId.type === 'value') {
+      return config.name;
+    }
+    return `${config.name}:${fusionEventId}`;
+  }, [config, fusionEventId]);
+
+  const tooltipContent = config.tooltipContent;
+
+  const UNABLE_TO_SUBSCRIBE = 'Unable to subscribe, please try again';
+  const UNABLE_TO_UNSUBSCRIBE = 'Unable to unsubscribe, please try again';
+  const INVALID_NUMBER = 'Please enter a valid number';
+
+  useEffect(() => {
+    console.log('Filter', alerts[alertName]?.filterOptions);
+    console.log('Custom Value', customValue);
+  }, [alerts[alertName]?.filterOptions]);
+
+  useEffect(() => {
+    if (loading || isNotificationLoading) {
+      return;
+    }
+
+    const ratios = config.checkRatios ?? [];
+    const checkRatios = ratios.map((ratio) => ratio.ratio);
+
+    const alert = alerts[alertName];
+
+    if (alert) {
+      let alertRatioValue: number | null = null;
+      if (alert.filterOptions) {
+        alertRatioValue =
+          config.numberType === 'percentage'
+            ? JSON.parse(alert.filterOptions).threshold * 100
+            : JSON.parse(alert.filterOptions).threshold;
+      }
+      setEnabled(true);
+      if (alertRatioValue) {
+        ratios.forEach((ratio, index) => {
+          if (ratio.ratio === alertRatioValue && customValue === '') {
+            setSelectedIndex(index);
+            setInitialSelectedIndex(index);
+          }
+        });
+        setInitialRatio(alertRatioValue);
+        console.log('Out', checkRatios, alertRatioValue, customValue);
+        if (!checkRatios.includes(alertRatioValue) && customValue === '') {
+          setSelectedIndex(3);
+          console.log('in', checkRatios, alertRatioValue);
+          setCustomValue(
+            config.numberType === 'percentage'
+              ? alertRatioValue + '%'
+              : alertRatioValue.toString(),
+          );
+        }
+      }
+    } else {
+      setEnabled(false);
+      setSelectedIndex(ratios.length - 1);
+      setInitialRatio(ratios[ratios.length - 1]?.ratio);
+    }
+  }, [alertName, alerts, loading, enabled, setEnabled]);
+
+  const subscribeAlert = useCallback(
+    async (
+      alertDetail: Readonly<{
+        eventType: EventTypeItem;
+        inputs: Record<string, unknown>;
+      }>,
+      ratioNumber: number,
+    ): Promise<SubscriptionData> => {
+      if (isCanaryActive) {
+        alertDetail.inputs[`${alertDetail.eventType.name}__healthRatio`] =
+          ratioNumber;
+        alertDetail.inputs[
+          `${alertDetail.eventType.name}__healthThresholdDirection`
+        ] = thresholdDirection;
+        return subscribeAlertByFrontendClient(frontendClient, alertDetail);
+      } else {
+        return instantSubscribe({
+          alertConfiguration: fusionHealthCheckConfiguration({
+            maintainSourceGroup: config?.maintainSourceGroup,
+            fusionId: fusionEventId,
+            fusionSourceAddress,
+            alertFrequency: config.alertFrequency,
+            thresholdDirection:
+              config.checkRatios[0].type ?? thresholdDirection,
+            threshold:
+              config.numberType === 'percentage'
+                ? ratioNumber / 100
+                : ratioNumber,
+          }),
+          alertName,
+        });
+      }
+    },
+    [isCanaryActive, frontendClient],
+  );
+
+  const unSubscribeAlert = useCallback(
+    async (
+      alertDetail: Readonly<{
+        eventType: EventTypeItem;
+        inputs: Record<string, unknown>;
+      }>,
+    ) => {
+      if (isCanaryActive) {
+        return unsubscribeAlertByFrontendClient(frontendClient, alertDetail);
+      } else {
+        return instantSubscribe({
+          alertName: alertDetail.eventType.name,
+          alertConfiguration: null,
+        });
+      }
+    },
+    [isCanaryActive, frontendClient],
+  );
+
+  const handleCustomRatioButtonNewSubscription = () => {
+    if (loading || isNotificationLoading) {
+      return;
+    }
+
+    setErrorMessage('');
+    setIsNotificationLoading(true);
+
+    if (customInputRef.current) {
+      customInputRef.current.placeholder = 'Custom';
+
+      const ratioNumber =
+        config.numberType === 'percentage'
+          ? getParsedInputNumber(customInputRef.current.value)
+          : parseFloat(customInputRef.current.value);
+
+      if (
+        ratioNumber &&
+        ratioNumber >= 0 &&
+        ratioNumber <= 100 &&
+        customValue
+      ) {
+        console.log('handleCustomRatioButtonT', customInputRef.current);
+        subscribeAlert({ eventType: config, inputs }, ratioNumber)
+          .then(() => {
+            setSelectedIndex(3);
+            isCanaryActive && frontendClient.fetchData().then(render);
+          })
+          .catch(() => setErrorMessage(UNABLE_TO_UNSUBSCRIBE))
+          .finally(() => {
+            setIsNotificationLoading(false);
+          });
+      } else {
+        console.log('handleCustomRatioButtonF', customInputRef.current);
+        setErrorMessage(INVALID_NUMBER);
+        setSelectedIndex(initialSelectedIndex);
+        setIsNotificationLoading(false);
+      }
+    }
+  };
+
+  const handleKeypressUp = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      if (customInputRef.current) {
+        customInputRef.current.blur();
+        event.preventDefault();
+      }
+    }
+  };
+  const handleRatioButtonNewSubscription = (value: number, index: number) => {
+    if (loading || isNotificationLoading) {
+      return;
+    }
+    setIsNotificationLoading(true);
+
+    setErrorMessage('');
+    if (value) {
+      subscribeAlert({ eventType: config, inputs }, value)
+        .then(() => {
+          isCanaryActive && frontendClient.fetchData().then(render);
+          setSelectedIndex(index);
+          console.log('new Subscription by default btn');
+          setCustomValue('');
+        })
+        .catch(() => setErrorMessage(UNABLE_TO_SUBSCRIBE))
+        .finally(() => {
+          setIsNotificationLoading(false);
+        });
+    } else {
+      console.log('handleRatioButtonNew', value, index);
+      setErrorMessage(INVALID_NUMBER);
+      setIsNotificationLoading(false);
+    }
+  };
+
+  const handleHealthCheckSubscription = useCallback(() => {
+    if (loading || isNotificationLoading) {
+      return;
+    }
+    setIsNotificationLoading(true);
+    setErrorMessage('');
+    if (!enabled && initialRatio !== null) {
+      subscribeAlert({ eventType: config, inputs }, initialRatio)
+        .then((res) => {
+          // We update optimistically so we need to check if the alert exists.
+          const responseHasAlert = res.alerts[alertName] !== undefined;
+          if (responseHasAlert !== true) {
+            setEnabled(false);
+          }
+          isCanaryActive && frontendClient.fetchData().then(render);
+          // setCustomValue('');
+        })
+        .catch((e) => {
+          setErrorMessage(UNABLE_TO_SUBSCRIBE);
+          setEnabled(false);
+          throw e;
+        })
+        .finally(() => {
+          setIsNotificationLoading(false);
+        });
+    } else {
+      unSubscribeAlert({ eventType: config, inputs })
+        .then((res) => {
+          console.log("start setCurrentValue('')in handleHealthCheckSub");
+          setCustomValue('');
+          if (res) {
+            const responseHasAlert = res.alerts[alertName] !== undefined;
+            if (responseHasAlert !== false) {
+              setEnabled(true);
+            }
+          }
+          // Else, ensured by frontendClient
+          isCanaryActive && frontendClient.fetchData().then(render);
+        })
+        .catch((e) => {
+          setErrorMessage(UNABLE_TO_SUBSCRIBE);
+          setEnabled(true);
+          throw e;
+        })
+        .finally(() => {
+          setIsNotificationLoading(false);
+        });
+    }
+  }, [initialRatio, enabled, isNotificationLoading, setIsNotificationLoading]);
+
+  return (
+    <div>
+      <div
+        className={clsx(
+          'EventTypeCustomHealthCheckRow__container',
+          classNames?.container,
+        )}
+      >
+        <div
+          className={clsx('EventTypeHealthCheckRow__label', classNames?.label)}
+        >
+          {config.name}
+          {tooltipContent !== undefined && tooltipContent.length > 0 ? (
+            <NotifiTooltip
+              classNames={classNames?.tooltip}
+              content={tooltipContent}
+            />
+          ) : null}
+        </div>
+        <NotifiToggle
+          checked={enabled}
+          classNames={classNames?.toggle}
+          disabled={disabled || isNotificationLoading}
+          setChecked={handleHealthCheckSubscription}
+        />
+      </div>
+      {enabled && config.checkRatios?.length ? (
+        <>
+          <div
+            className={clsx(
+              'EventTypeHealthCheckRow__content',
+              classNames?.content,
+            )}
+          >
+            {config.healthCheckSubtitle
+              ? config.healthCheckSubtitle
+              : `Alert me when my margin ratio is ${config.checkRatios[0]?.type}`}
+          </div>
+          <div
+            className={clsx(
+              'EventTypeHealthCheckRow__buttonContainer',
+              classNames?.buttonContainer,
+            )}
+          >
+            {config.checkRatios.map((value, index) => {
+              const numberType = config.numberType;
+
+              const percentage = value.ratio + '%';
+              const valueToShow =
+                numberType === 'percentage' ? percentage : value.ratio;
+              return (
+                <div
+                  key={index}
+                  className={clsx(
+                    'EventTypeHealthCheckRow__button',
+                    `${
+                      index === selectedIndex
+                        ? ' EventTypeHealthCheckRow__buttonSelected'
+                        : undefined
+                    }`,
+                    isNotificationLoading ? 'buttonDisabled' : undefined,
+                    classNames?.button,
+                  )}
+                  onClick={() => {
+                    if (
+                      isNotificationLoading === true ||
+                      selectedIndex === index
+                    ) {
+                      return;
+                    }
+
+                    handleRatioButtonNewSubscription(value.ratio, index);
+                  }}
+                >
+                  {valueToShow}
+                </div>
+              );
+            })}
+            <input
+              ref={customInputRef}
+              onKeyUp={(e) => handleKeypressUp(e)}
+              onFocus={(e) =>
+                (e.target.placeholder =
+                  config.numberType === 'percentage' ? '0.00%' : '0')
+              }
+              onClick={() => {
+                setErrorMessage('');
+                setSelectedIndex(null);
+              }}
+              disabled={isNotificationLoading}
+              onBlur={() => {
+                console.log('onBlur');
+                handleCustomRatioButtonNewSubscription();
+              }}
+              value={customValue}
+              placeholder="Custom"
+              className={clsx(
+                'EventTypeHealthCheckRow__button',
+                'EventTypeHealthCheckRow__customButton',
+                `${
+                  selectedIndex === 3
+                    ? ' EventTypeHealthCheckRow__buttonSelected'
+                    : undefined
+                }`,
+                classNames?.button,
+              )}
+              onChange={(e) => {
+                console.log('start setCurrentValue(e.target.value)in onChange');
+                setCustomValue(e.target.value ?? '');
+              }}
+            />
+          </div>
+          <label
+            className={clsx(
+              'NotifiEmailInput__errorMessage',
+              classNames?.errorMessage,
+            )}
+          >
+            {errorMessage}
+          </label>
+        </>
+      ) : null}
+    </div>
+  );
+};

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/AlertsPanel.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/AlertsPanel.tsx
@@ -1,4 +1,7 @@
-import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
+import {
+  CardConfigItemV1,
+  FusionHealthCheckEventTypeItem,
+} from '@notifi-network/notifi-frontend-client';
 import React from 'react';
 
 import {
@@ -167,23 +170,21 @@ export const AlertsPanel: React.FC<AlertsPanelProps> = ({
                 inputs={inputs}
               />
             );
-          case 'fusionToggle':
-            return (
-              <EventTypeFusionToggleRow
-                key={eventType.name}
-                classNames={classNames?.EventTypeFusionToggleRow}
-                disabled={inputDisabled}
-                config={eventType}
-                inputs={inputs}
-              />
-            );
-          case 'fusionHealthCheck':
-            return (
+          case 'fusion':
+            return eventType.selectedUIType === 'HEALTH_CHECK' ? (
               <EventTypeFusionHealthCheckRow
                 key={eventType.name}
                 disabled={inputDisabled}
                 config={eventType}
                 classNames={classNames?.EventTypeFusionHealthCheckRow}
+                inputs={inputs}
+              />
+            ) : (
+              <EventTypeFusionToggleRow
+                key={eventType.name}
+                classNames={classNames?.EventTypeFusionToggleRow}
+                disabled={inputDisabled}
+                config={eventType}
                 inputs={inputs}
               />
             );

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/AlertsPanel.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/AlertsPanel.tsx
@@ -15,6 +15,10 @@ import {
   EventTypeDirectPushRowProps,
 } from '../../EventTypeDirectPushRow';
 import {
+  EventTypeFusionHealthCheckRow,
+  EventTypeFusionHealthCheckRowProps,
+} from '../../EventTypeFusionHealthCheckRow';
+import {
   EventTypeFusionRowProps,
   EventTypeFusionToggleRow,
 } from '../../EventTypeFusionToggleRow';
@@ -63,6 +67,7 @@ export type AlertsPanelProps = Readonly<{
     EventTypeWalletBalanceRow?: EventTypeWalletBalanceRowProps['classNames'];
     EventTypeXMTPRow?: EventTypeXMPTRowProps['classNames'];
     EventTypeFusionToggleRow?: EventTypeFusionRowProps['classNames'];
+    EventTypeFusionHealthCheckRow?: EventTypeFusionHealthCheckRowProps['classNames'];
   }>;
   inputs: Record<string, unknown>;
 }>;
@@ -169,6 +174,16 @@ export const AlertsPanel: React.FC<AlertsPanelProps> = ({
                 classNames={classNames?.EventTypeFusionToggleRow}
                 disabled={inputDisabled}
                 config={eventType}
+                inputs={inputs}
+              />
+            );
+          case 'fusionHealthCheck':
+            return (
+              <EventTypeFusionHealthCheckRow
+                key={eventType.name}
+                disabled={inputDisabled}
+                config={eventType}
+                classNames={classNames?.EventTypeFusionHealthCheckRow}
                 inputs={inputs}
               />
             );

--- a/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
+++ b/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
@@ -28,14 +28,32 @@ export type BroadcastEventTypeItem = Readonly<{
   broadcastId: ValueOrRef<string>;
   tooltipContent?: string;
 }>;
-export type FusionToggleEventTypeItem = Readonly<{
-  type: 'fusionToggle';
+
+export type FusionTypeBase = {
   name: string;
   fusionEventId: ValueOrRef<string>;
   sourceAddress: ValueOrRef<string>;
   tooltipContent?: string;
   maintainSourceGroup?: boolean;
-}>;
+};
+
+export type FusionToggleEventTypeItem = FusionTypeBase &
+  Readonly<{
+    type: 'fusionToggle';
+  }>;
+
+export type FusionHealthCheckEventTypeItem = FusionTypeBase &
+  Readonly<{
+    type: 'fusionHealthCheck';
+    healthCheckSubtitle: string;
+    numberType: NumberTypeSelect;
+    alertFrequency: AlertFrequency;
+    checkRatios: CheckRatio[];
+  }>;
+
+export type FusionEventTypeItem =
+  | FusionToggleEventTypeItem
+  | FusionHealthCheckEventTypeItem;
 
 export type HealthCheckEventTypeItem = Readonly<{
   type: 'healthCheck';

--- a/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
+++ b/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
@@ -31,6 +31,7 @@ export type BroadcastEventTypeItem = Readonly<{
 
 export type FusionTypeBase = {
   name: string;
+  type: 'fusion';
   fusionEventId: ValueOrRef<string>;
   sourceAddress: ValueOrRef<string>;
   tooltipContent?: string;
@@ -39,12 +40,12 @@ export type FusionTypeBase = {
 
 export type FusionToggleEventTypeItem = FusionTypeBase &
   Readonly<{
-    type: 'fusionToggle';
+    selectedUIType: 'TOGGLE';
   }>;
 
 export type FusionHealthCheckEventTypeItem = FusionTypeBase &
   Readonly<{
-    type: 'fusionHealthCheck';
+    selectedUIType: 'HEALTH_CHECK';
     healthCheckSubtitle: string;
     numberType: NumberTypeSelect;
     alertFrequency: AlertFrequency;

--- a/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
+++ b/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
@@ -162,6 +162,34 @@ export const fusionToggleConfiguration = ({
   };
 };
 
+type FusionToggleConfiguration = {
+  fusionId: string;
+  fusionSourceAddress: string;
+  maintainSourceGroup?: boolean;
+  alertFrequency: FilterOptions['alertFrequency'];
+  threshold: number;
+  thresholdDirection: FilterOptions['thresholdDirection'];
+};
+export const fusionHealthCheckConfiguration = (
+  props: FusionToggleConfiguration,
+): AlertConfiguration => {
+  return {
+    type: 'single',
+    maintainSourceGroup: props.maintainSourceGroup,
+    filterType: 'FUSION_SOURCE',
+    filterOptions: {
+      alertFrequency: props.alertFrequency,
+      threshold: props.threshold,
+      thresholdDirection: props.thresholdDirection,
+    },
+    sourceType: 'FUSION_SOURCE',
+    createSource: {
+      address: props.fusionSourceAddress,
+      fusionEventTypeId: props.fusionId,
+    },
+  };
+};
+
 export const directMessageConfiguration = (
   params?: Readonly<{
     type?: string;

--- a/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
+++ b/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
@@ -393,20 +393,44 @@ export const createConfigurations = (
         break;
       }
 
-      case 'fusionToggle': {
-        configs[eventType.name] = fusionToggleConfiguration({
-          maintainSourceGroup: eventType.maintainSourceGroup,
-          fusionId: resolveStringRef(
-            eventType.name,
-            eventType.fusionEventId,
-            inputs,
-          ),
-          fusionSourceAddress: resolveStringRef(
-            eventType.name,
-            eventType.sourceAddress,
-            inputs,
-          ),
-        });
+      case 'fusion': {
+        switch (eventType.selectedUIType) {
+          case 'TOGGLE':
+            configs[eventType.name] = fusionToggleConfiguration({
+              maintainSourceGroup: eventType.maintainSourceGroup,
+              fusionId: resolveStringRef(
+                eventType.name,
+                eventType.fusionEventId,
+                inputs,
+              ),
+              fusionSourceAddress: resolveStringRef(
+                eventType.name,
+                eventType.sourceAddress,
+                inputs,
+              ),
+            });
+            break;
+          case 'HEALTH_CHECK':
+            configs[eventType.name] = fusionHealthCheckConfiguration({
+              maintainSourceGroup: eventType.maintainSourceGroup,
+              fusionId: resolveStringRef(
+                eventType.name,
+                eventType.fusionEventId,
+                inputs,
+              ),
+              fusionSourceAddress: resolveStringRef(
+                eventType.name,
+                eventType.sourceAddress,
+                inputs,
+              ),
+              alertFrequency: eventType.alertFrequency,
+              thresholdDirection: eventType.checkRatios[0].type ?? 'below',
+              threshold:
+                eventType.numberType === 'percentage'
+                  ? eventType.checkRatios[1].ratio / 100
+                  : eventType.checkRatios[1].ratio,
+            });
+        }
       }
     }
   });

--- a/packages/notifi-react-example/src/NotifiCard/DemoPreviewCard.tsx
+++ b/packages/notifi-react-example/src/NotifiCard/DemoPreviewCard.tsx
@@ -70,15 +70,7 @@ const data = `
   "id": "51fd3e3da1104f15abe4e1f8df46747e",
   "name": "DemoSolana",
   "eventTypes": [
-    {
-      "name": "Test msg",
-      "type": "broadcast",
-      "broadcastId": {
-        "type": "value",
-        "value": "colorfullife__test"
-      },
-      "tooltipContent": "This is a test"
-    },
+    
     {
       "name": "announce",
       "type": "broadcast",
@@ -107,13 +99,47 @@ const data = `
       }
     },
     {
-      "name": "test#2",
-      "type": "broadcast",
-      "broadcastId": {
+      "type": "fusion",
+      "name": "Fusion Toggle",
+      "tooltipContent": "This is Fusion Toggle alerts",
+      "selectedUIType": "TOGGLE",
+      "fusionEventId": {
         "type": "value",
-        "value": "colorfullife__test#2"
+        "value": "fusionEventId"
       },
-      "tooltipContent": "test#2"
+      "sourceAddress": {
+        "type": "value",
+        "value": "fusionSourceAddress"
+      },
+      "useCustomIcon": false
+    },
+    {
+      "name": "Fusion Health Alerts",
+      "selectedUIType": "HEALTH_CHECK",
+      "type": "fusion",
+      "tooltipContent": "This is Fusion Health alerts",
+      "fusionEventId": {
+        "type": "value",
+        "value": "fusionEventId"
+      },
+      "sourceAddress": {
+        "type": "value",
+        "value": "fusionSourceAddress"
+      },
+      "useCustomIcon": false,
+      "healthCheckSubtitle": "Fusion Health Alerts Subtitle",
+      "numberType": "percentage",
+      "alertFrequency": "SINGLE",
+      "checkRatios": [
+        {
+          "type": "below",
+          "ratio": 5
+        },
+        {
+          "type": "below",
+          "ratio": 10
+        }
+      ]
     },
     {
       "name": "customTest",


### PR DESCRIPTION
Add fusionHealthCheck event type

**NOTE**
Merge it after MVP-2745 since it changes the way how SDK resolve the config of fusion event type. The config generate by current AP is not able to work with this new approach.

https://github.com/notifi-network/notifi-sdk-ts/assets/127958634/86456317-99e7-42b0-89e6-e8fd27f162d4

