### PR TITLE
MVP-2766: Address regression -> Capability using CommonJS require in notifi packages

### DIFF
--- a/packages/notifi-frontend-client/package.json
+++ b/packages/notifi-frontend-client/package.json
@@ -3,7 +3,6 @@
   "version": "0.73.1",
   "description": "The frontend client for Notifi",
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/notifi-graphql/package.json
+++ b/packages/notifi-graphql/package.json
@@ -3,7 +3,6 @@
   "version": "0.73.1",
   "description": "The GraphQL API for Notifi",
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/notifi-react-card/package.json
+++ b/packages/notifi-react-card/package.json
@@ -6,7 +6,14 @@
   "homepage": "https://github.com/notifi-network/notifi-sdk-ts#readme",
   "license": "MIT",
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./dist/index.css": "./dist/index.css"
+  },
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/notifi-solana-hw-login/package.json
+++ b/packages/notifi-solana-hw-login/package.json
@@ -3,7 +3,6 @@
   "version": "0.73.1",
   "description": "Plugin for Solana Hardware Login support",
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION

1. The following error will be thrown if using `commonJS` require.

```bash
./node_modules/@notifi-network/notifi-react-card/dist/index.js Can't import the named export 'GqlError' from non EcmaScript module (only default export is available)
```

> The same issue also happens on graphql and forntend-client

2. The CSS is not exported from package.json. It could possibily cause the error below:

```bash

Module not found: Error: Package path ./dist/index.css is not exported from package /path-to-module/notifi-sdk-ts/node_modules/@notifi-network/notifi-react-card (see exports field in /path-to-module/notifi-sdk-ts/node_modules/@notifi-network/notifi-react-card/package.json)

```