### PR TITLE
MVP-2744-patch:  Backward compatibility for 'fusionToggle' Type

### DIFF
--- a/packages/notifi-frontend-client/lib/client/ensureSource.ts
+++ b/packages/notifi-frontend-client/lib/client/ensureSource.ts
@@ -455,6 +455,7 @@ const ensureSources = async (
       const source = await ensureHealthCheckSources(service, eventType, inputs);
       return [source];
     }
+    case 'fusionToggle':
     case 'fusion': {
       const source = await ensureFusionSource(service, eventType, inputs);
       return [source];
@@ -1011,6 +1012,7 @@ export const ensureSourceAndFilters = async (
         filterOptions,
       };
     }
+    case 'fusionToggle':
     case 'fusion': {
       const { filter, filterOptions } = getFusionSourceFilter(
         sources[0],

--- a/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
+++ b/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
@@ -22,7 +22,7 @@ export type DirectPushEventTypeItem = Readonly<{
 
 export type FusionTypeBase = {
   name: string;
-  type: 'fusion';
+  type: 'fusion' | 'fusionToggle'; // fusionToggle is deprecated (use fusion with selectedUIType: 'TOGGLE' instead)
   fusionEventId: ValueOrRef<string>;
   sourceAddress: ValueOrRef<string>;
   tooltipContent?: string;

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/AlertsPanel.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/AlertsPanel.tsx
@@ -1,7 +1,4 @@
-import {
-  CardConfigItemV1,
-  FusionHealthCheckEventTypeItem,
-} from '@notifi-network/notifi-frontend-client';
+import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
 import React from 'react';
 
 import {
@@ -170,6 +167,7 @@ export const AlertsPanel: React.FC<AlertsPanelProps> = ({
                 inputs={inputs}
               />
             );
+          case 'fusionToggle': // fusionToggle is deprecated (use fusion with selectedUIType===TOGGLE instead )
           case 'fusion':
             return eventType.selectedUIType === 'HEALTH_CHECK' ? (
               <EventTypeFusionHealthCheckRow

--- a/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
+++ b/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
@@ -31,7 +31,7 @@ export type BroadcastEventTypeItem = Readonly<{
 
 export type FusionTypeBase = {
   name: string;
-  type: 'fusion';
+  type: 'fusion' | 'fusionToggle';
   fusionEventId: ValueOrRef<string>;
   sourceAddress: ValueOrRef<string>;
   tooltipContent?: string;

--- a/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
+++ b/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
@@ -392,7 +392,21 @@ export const createConfigurations = (
         });
         break;
       }
-
+      case 'fusionToggle': // fusionToggle is deprecated (use 'fusion' type with 'selectedUIType = TOGGLE' instead )
+        configs[eventType.name] = fusionToggleConfiguration({
+          maintainSourceGroup: eventType.maintainSourceGroup,
+          fusionId: resolveStringRef(
+            eventType.name,
+            eventType.fusionEventId,
+            inputs,
+          ),
+          fusionSourceAddress: resolveStringRef(
+            eventType.name,
+            eventType.sourceAddress,
+            inputs,
+          ),
+        });
+        break;
       case 'fusion': {
         switch (eventType.selectedUIType) {
           case 'TOGGLE':


### PR DESCRIPTION
Make it backward compatible for those existing tenant configs using 'fusionToggle' type 