### PR TITLE
MVP-2773#2: WalletConnect example consuming  useNotifiSubscriptionContext/NotifiClientContext

### DIFF
--- a/packages/notifi-react-example/src/NotifiCard/NotifiCard.tsx
+++ b/packages/notifi-react-example/src/NotifiCard/NotifiCard.tsx
@@ -1,7 +1,10 @@
 import '@notifi-network/notifi-react-card/dist/index.css';
 import React from 'react';
 
-import { SolanaNotifiContextWrapper } from '../NotifiContextWrapper';
+import {
+  SolanaNotifiContextWrapper,
+  WalletConnectNotifiContextWrapper,
+} from '../NotifiContextWrapper';
 import { DemoPrviewCard } from './DemoPreviewCard';
 import { KeplrCard } from './KeplrCard';
 import './NotifiCard.css';
@@ -26,7 +29,11 @@ const supportedViews: Record<ESupportedViews, React.ReactNode> = {
       <SolanaCard />
     </SolanaNotifiContextWrapper>
   ),
-  [ESupportedViews.WalletConnect]: <WalletConnectCard />,
+  [ESupportedViews.WalletConnect]: (
+    <WalletConnectNotifiContextWrapper>
+      <WalletConnectCard />
+    </WalletConnectNotifiContextWrapper>
+  ),
   [ESupportedViews.Polkadot]: <PolkadotCard />,
   [ESupportedViews.Sui]: <SuiNotifiCard />,
   [ESupportedViews.Keplr]: <KeplrCard />,

--- a/packages/notifi-react-example/src/NotifiCard/WalletConnectCard.tsx
+++ b/packages/notifi-react-example/src/NotifiCard/WalletConnectCard.tsx
@@ -1,46 +1,36 @@
 import {
-  NotifiContext,
   NotifiSubscriptionCard,
+  useNotifiClientContext,
+  useNotifiSubscriptionContext,
 } from '@notifi-network/notifi-react-card';
-import { arrayify } from 'ethers/lib/utils.js';
-import { useAccount, useConnect, useDisconnect, useSignMessage } from 'wagmi';
-
-import { connector } from '../walletProviders/WalletConnectProvider';
 
 export const WalletConnectCard = () => {
-  const { address, isConnected } = useAccount();
-
-  const { connect } = useConnect({
-    connector: connector,
-  });
-  const { disconnect } = useDisconnect();
-
-  const { signMessageAsync } = useSignMessage();
+  const { alerts } = useNotifiSubscriptionContext();
+  const { client } = useNotifiClientContext();
   return (
     <div>
       <h1>Notifi Card: WalletConnect</h1>
-      <button onClick={() => (isConnected ? disconnect() : connect())}>
-        {isConnected ? `Disconnect: ${address}` : 'Connect Wallet'}
-      </button>
-      {isConnected ? (
-        <NotifiContext
-          dappAddress="testimpl"
-          env="Production"
-          signMessage={async (message: Uint8Array) => {
-            const result = await signMessageAsync({ message });
-            return arrayify(result);
-          }}
-          walletPublicKey={address ?? ''}
-          walletBlockchain="ETHEREUM"
-        >
-          <div style={{ width: '400px' }}>
-            <NotifiSubscriptionCard
-              cardId="7fa9505a96064ed6b91ba2d14a9732de"
-              darkMode //optional
-            />
-          </div>
-        </NotifiContext>
-      ) : null}
+      <h3>Subscribing Alert(s)</h3>
+      {client.isInitialized && client.isAuthenticated ? (
+        <div>
+          <ul>
+            {Object.keys(alerts).length > 0 &&
+              Object.keys(alerts).map((alert) => (
+                <li key={alerts[alert]?.id}>
+                  <div>{alerts[alert]?.name}</div>
+                </li>
+              ))}
+          </ul>
+        </div>
+      ) : (
+        <div>Not yet register Notification</div>
+      )}
+      <div style={{ width: '400px' }}>
+        <NotifiSubscriptionCard
+          cardId="7fa9505a96064ed6b91ba2d14a9732de"
+          darkMode //optional
+        />
+      </div>
     </div>
   );
 };

--- a/packages/notifi-react-example/src/NotifiContextWrapper/WalletConnectNotifiContextWrapper.tsx
+++ b/packages/notifi-react-example/src/NotifiContextWrapper/WalletConnectNotifiContextWrapper.tsx
@@ -1,0 +1,39 @@
+import { NotifiContext } from '@notifi-network/notifi-react-card';
+import { arrayify } from 'ethers/lib/utils.js';
+import { PropsWithChildren } from 'react';
+import { useAccount, useConnect, useDisconnect, useSignMessage } from 'wagmi';
+
+import { connector } from '../walletProviders/WalletConnectProvider';
+
+export const WalletConnectNotifiContextWrapper: React.FC<PropsWithChildren> = ({
+  children,
+}) => {
+  const { disconnect } = useDisconnect();
+  const { signMessageAsync } = useSignMessage();
+  const { address, isConnected } = useAccount();
+  const { connect } = useConnect({
+    connector: connector,
+  });
+
+  return (
+    <div>
+      <button onClick={() => (isConnected ? disconnect() : connect())}>
+        {isConnected ? `Disconnect: ${address}` : 'Connect Wallet'}
+      </button>
+      {isConnected ? (
+        <NotifiContext
+          dappAddress="testimpl"
+          env="Production"
+          signMessage={async (message: Uint8Array) => {
+            const result = await signMessageAsync({ message });
+            return arrayify(result);
+          }}
+          walletPublicKey={address ?? ''}
+          walletBlockchain="ETHEREUM"
+        >
+          {children}
+        </NotifiContext>
+      ) : null}
+    </div>
+  );
+};

--- a/packages/notifi-react-example/src/NotifiContextWrapper/index.ts
+++ b/packages/notifi-react-example/src/NotifiContextWrapper/index.ts
@@ -1,1 +1,2 @@
 export * from './SolanaNotifiContextWrapper';
+export * from './WalletConnectNotifiContextWrapper';


### PR DESCRIPTION
Add WalletConnect example of consuming `useNotifiSubscriptionContext`/ `useNotifiClientCotext` outside of `NotifiSubscriptionCard`