### PR TITLE
MVP-2773#3: Acala example consuming useNotifiSubscriptionContext/NotifiClientContext 

### DIFF
--- a/packages/notifi-react-example/src/NotifiCard/NotifiCard.tsx
+++ b/packages/notifi-react-example/src/NotifiCard/NotifiCard.tsx
@@ -2,6 +2,7 @@ import '@notifi-network/notifi-react-card/dist/index.css';
 import React from 'react';
 
 import {
+  PolkadotNotifiContextWrapper,
   SolanaNotifiContextWrapper,
   WalletConnectNotifiContextWrapper,
 } from '../NotifiContextWrapper';
@@ -35,6 +36,12 @@ const supportedViews: Record<ESupportedViews, React.ReactNode> = {
     </WalletConnectNotifiContextWrapper>
   ),
   [ESupportedViews.Polkadot]: <PolkadotCard />,
+  [ESupportedViews.WalletConnect]: <WalletConnectCard />,
+  [ESupportedViews.Polkadot]: (
+    <PolkadotNotifiContextWrapper>
+      <PolkadotCard />
+    </PolkadotNotifiContextWrapper>
+  ),
   [ESupportedViews.Sui]: <SuiNotifiCard />,
   [ESupportedViews.Keplr]: <KeplrCard />,
 };

--- a/packages/notifi-react-example/src/NotifiCard/PolkadotCard.tsx
+++ b/packages/notifi-react-example/src/NotifiCard/PolkadotCard.tsx
@@ -1,10 +1,64 @@
-import { AcalaConnectButton } from '../walletProviders/AcalaWalletContextProvider';
+import {
+  NotifiSubscriptionCard,
+  useNotifiClientContext,
+  useNotifiSubscriptionContext,
+} from '@notifi-network/notifi-react-card';
+
+import {
+  AcalaConnectButton,
+  useAcalaWallet,
+} from '../walletProviders/AcalaWalletContextProvider';
 
 export const PolkadotCard = () => {
+  const { alerts } = useNotifiSubscriptionContext();
+  const { client } = useNotifiClientContext();
+  const { acalaAddress, connected } = useAcalaWallet();
+
+  if (!connected || !acalaAddress) {
+    return (
+      <div>
+        <AcalaConnectButton />
+      </div>
+    );
+  }
+
   return (
     <div className="container">
       <h1>Notifi Card: Polkadot</h1>
-      <AcalaConnectButton />
+      <h3>Subscribing Alert(s)</h3>
+      {client.isInitialized && client.isAuthenticated ? (
+        <div>
+          <ul>
+            {Object.keys(alerts).length > 0 &&
+              Object.keys(alerts).map((alert) => (
+                <li key={alerts[alert]?.id}>
+                  <div>{alerts[alert]?.name}</div>
+                </li>
+              ))}
+          </ul>
+        </div>
+      ) : (
+        <div>Not yet register Notification</div>
+      )}
+      <h3>Display NotifiSubscriptionCard</h3>
+      <NotifiSubscriptionCard
+        darkMode
+        cardId="d8859ea72ff4449fa8f7f293ebd333c9"
+        onClose={() => alert('nope you must stay')}
+        copy={{
+          FetchedStateCard: {
+            SubscriptionCardV1: {
+              signUpHeader: 'Please sign up',
+              EditCard: {
+                AlertListPreview: {
+                  description:
+                    'Get your alerts here!!! you can subscribe to any of the following:',
+                },
+              },
+            },
+          },
+        }}
+      />
     </div>
   );
 };

--- a/packages/notifi-react-example/src/NotifiContextWrapper/AcalaNotifiContextWrapper.tsx
+++ b/packages/notifi-react-example/src/NotifiContextWrapper/AcalaNotifiContextWrapper.tsx
@@ -1,0 +1,42 @@
+import { NotifiContext } from '@notifi-network/notifi-react-card';
+import { PropsWithChildren } from 'react';
+
+import {
+  AcalaConnectButton,
+  useAcalaWallet,
+} from '../walletProviders/AcalaWalletContextProvider';
+
+export const PolkadotNotifiContextWrapper: React.FC<PropsWithChildren> = ({
+  children,
+}) => {
+  const { requestSignature, acalaAddress, connected, polkadotPublicKey } =
+    useAcalaWallet();
+
+  if (!connected || !acalaAddress) {
+    return (
+      <div>
+        <AcalaConnectButton />
+      </div>
+    );
+  }
+
+  return (
+    <div className="container">
+      <AcalaConnectButton />
+
+      <NotifiContext
+        dappAddress="junitest.xyz"
+        walletBlockchain="ACALA"
+        accountAddress={acalaAddress}
+        walletPublicKey={polkadotPublicKey!}
+        env="Development"
+        signMessage={(accountAddress, message) => {
+          console.log({ accountAddress, acalaAddress, message });
+          return requestSignature(acalaAddress, message);
+        }}
+      >
+        {children}
+      </NotifiContext>
+    </div>
+  );
+};

--- a/packages/notifi-react-example/src/NotifiContextWrapper/index.ts
+++ b/packages/notifi-react-example/src/NotifiContextWrapper/index.ts
@@ -1,2 +1,3 @@
 export * from './SolanaNotifiContextWrapper';
 export * from './WalletConnectNotifiContextWrapper';
+export * from './AcalaNotifiContextWrapper';


### PR DESCRIPTION
Add Acala (Polkadot) example of consuming `useNotifiSubscriptionContext`/ `useNotifiClientCotext` outside of `NotifiSubscriptionCard`

**NOTE**
> Originally missing Card section --> Add back