### PR TITLE
MVP-2804: Support EVMOS in SDK

### DIFF
--- a/packages/notifi-core/lib/NotifiClient.ts
+++ b/packages/notifi-core/lib/NotifiClient.ts
@@ -275,7 +275,8 @@ export type SignMessageParams =
         | 'AVALANCHE'
         | 'BINANCE'
         | 'INJECTIVE'
-        | 'OPTIMISM';
+        | 'OPTIMISM'
+        | 'EVMOS';
       signMessage: Uint8SignMessageFunction;
     }>
   | Readonly<{
@@ -307,7 +308,8 @@ export type WalletParams =
         | 'ARBITRUM'
         | 'AVALANCHE'
         | 'BINANCE'
-        | 'OPTIMISM';
+        | 'OPTIMISM'
+        | 'EVMOS';
 
       walletPublicKey: string;
     }>
@@ -350,7 +352,8 @@ export type WalletWithSignMessage =
         | 'ARBITRUM'
         | 'AVALANCHE'
         | 'BINANCE'
-        | 'OPTIMISM';
+        | 'OPTIMISM'
+        | 'EVMOS';
 
       walletPublicKey: string;
       signMessage: Uint8SignMessageFunction;

--- a/packages/notifi-core/lib/models/WalletBlockchain.ts
+++ b/packages/notifi-core/lib/models/WalletBlockchain.ts
@@ -10,4 +10,5 @@ export type WalletBlockchain =
   | 'NEAR'
   | 'OPTIMISM'
   | 'INJECTIVE'
-  | 'SUI';
+  | 'SUI'
+  | 'EVMOS';

--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -7,7 +7,6 @@ import type {
   NotifiFrontendConfiguration,
 } from '../configuration';
 import type {
-  AlertFrequency,
   CardConfigItemV1,
   EventTypeItem,
   WalletBalanceEventTypeItem,
@@ -43,6 +42,7 @@ export type SignMessageParams =
         | 'AVALANCHE'
         | 'BINANCE'
         | 'INJECTIVE'
+        | 'EVMOS'
         | 'OPTIMISM';
       signMessage: Uint8SignMessageFunction;
     }>
@@ -81,7 +81,8 @@ export type WalletWithSignMessage =
         | 'ARBITRUM'
         | 'AVALANCHE'
         | 'BINANCE'
-        | 'OPTIMISM';
+        | 'OPTIMISM'
+        | 'EVMOS';
 
       walletPublicKey: string;
       signMessage: Uint8SignMessageFunction;
@@ -265,6 +266,7 @@ export class NotifiFrontendClient {
       case 'AVALANCHE':
       case 'BINANCE':
       case 'OPTIMISM':
+      case 'EVMOS':
       case 'SOLANA': {
         const result = await this._service.logInFromDapp({
           walletBlockchain,
@@ -323,6 +325,7 @@ export class NotifiFrontendClient {
       case 'ARBITRUM':
       case 'AVALANCHE':
       case 'BINANCE':
+      case 'EVMOS':
       case 'OPTIMISM': {
         const { walletPublicKey, tenantId } = this
           ._configuration as NotifiConfigWithPublicKey;

--- a/packages/notifi-frontend-client/lib/client/ensureSource.ts
+++ b/packages/notifi-frontend-client/lib/client/ensureSource.ts
@@ -216,6 +216,8 @@ const ensureWalletBalanceSources = async (
           return 'OPTIMISM_WALLET';
         case 'SUI':
           return 'SUI_WALLET';
+        case 'EVMOS':
+          return 'EVMOS_WALLET';
         default:
           throw new Error('Unsupported walletType');
       }

--- a/packages/notifi-frontend-client/lib/configuration/NotifiFrontendConfiguration.ts
+++ b/packages/notifi-frontend-client/lib/configuration/NotifiFrontendConfiguration.ts
@@ -20,6 +20,7 @@ export type NotifiConfigWithPublicKey = Readonly<{
     | 'AVALANCHE'
     | 'BINANCE'
     | 'OPTIMISM'
+    | 'EVMOS'
     | 'SOLANA';
   walletPublicKey: string;
 }> &

--- a/packages/notifi-react-card/lib/context/NotifiContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiContext.tsx
@@ -87,6 +87,12 @@ export type SuiParams = Readonly<{
   signMessage: Uint8SignMessageFunction;
 }>;
 
+export type EvmosParams = Readonly<{
+  walletBlockchain: 'EVMOS';
+  walletPublicKey: string;
+  signMessage: Uint8SignMessageFunction;
+}>;
+
 export type MultiWalletParams = Readonly<{
   ownedWallets: ReadonlyArray<WalletWithSignParams>;
 }>;
@@ -104,7 +110,8 @@ type WalletParams =
   | AvalancheParams
   | OptimismParams
   | InjectiveParams
-  | SuiParams;
+  | SuiParams
+  | EvmosParams;
 
 export type NotifiParams = Readonly<{
   alertConfigurations?: Record<string, AlertConfiguration | null>;

--- a/packages/notifi-react-card/lib/utils/walletUtils.ts
+++ b/packages/notifi-react-card/lib/utils/walletUtils.ts
@@ -27,6 +27,8 @@ export const walletToSourceType = (
       return 'OPTIMISM_WALLET';
     case 'SUI':
       return 'SUI_WALLET';
+    case 'EVMOS':
+      return 'EVMOS_WALLET';
     default:
       throw new Error('Unsupported walletType');
   }

--- a/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
+++ b/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
@@ -144,6 +144,7 @@ const signMessage = async ({
     case 'BINANCE':
     case 'OPTIMISM':
     case 'AVALANCHE':
+    case 'EVMOS':
     case 'ETHEREUM': {
       if (signer.walletBlockchain !== params.walletBlockchain) {
         throw new Error('Signer and config have different walletBlockchain');


### PR DESCRIPTION

Add EVMOS chain support in SDK.

**NOTE**
Only can be merged after BE supports EVMOS chain (sourceType: EVMOS_WALLET)
