### PR TITLE
MVP-2839: Fix confirm link (discord/ tg) not update after enabling bot

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCard.tsx
@@ -90,7 +90,9 @@ export const NotifiSubscriptionCard: React.FC<
   loadingSpinnerSize,
   onClose,
 }) => {
-  const { isInitialized } = useNotifiSubscribe({ targetGroupName: 'Default' });
+  const { isInitialized, reload, isAuthenticated } = useNotifiSubscribe({
+    targetGroupName: 'Default',
+  });
   const {
     canary: { isActive: canaryIsActive, frontendClient },
   } = useNotifiClientContext();
@@ -99,7 +101,7 @@ export const NotifiSubscriptionCard: React.FC<
     return canaryIsActive ? !!frontendClient.userState : isInitialized;
   }, [frontendClient.userState?.status, isInitialized, canaryIsActive]);
 
-  const { loading } = useNotifiSubscriptionContext();
+  const { loading, render } = useNotifiSubscriptionContext();
 
   const inputDisabled = loading || !isClientInitialized;
 
@@ -109,6 +111,16 @@ export const NotifiSubscriptionCard: React.FC<
   });
 
   let contents: React.ReactNode = null;
+
+  window.onfocus = () => {
+    // Ensure target is up-to-date after user returns to tab from 3rd party verification site
+    if (!isClientInitialized || !isAuthenticated) return;
+
+    if (canaryIsActive) {
+      return frontendClient.fetchData().then(render);
+    }
+    reload();
+  };
 
   switch (card.state) {
     case 'loading':

--- a/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
@@ -317,6 +317,8 @@ export const NotifiSubscriptionContextProvider: React.FC<
           },
           message: 'Verify ID',
         });
+      } else {
+        setTelegramErrorMessage(undefined);
       }
 
       const discordTarget = targetGroup?.discordTargets?.[0];

--- a/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
@@ -340,6 +340,8 @@ export const NotifiSubscriptionContextProvider: React.FC<
             onClick: () => window.open(DISCORD_INVITE_URL, '_blank'),
             message: 'Join Server',
           });
+        } else {
+          setDiscordErrorMessage(undefined);
         }
         setUseDiscord(true);
         setDiscordTargetData(discordTarget);

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -209,6 +209,8 @@ export const useNotifiSubscribe: ({
           },
           message: 'Verify ID',
         });
+      } else {
+        setTelegramErrorMessage(undefined);
       }
 
       const discordTarget = targetGroup?.discordTargets?.[0];

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -232,6 +232,8 @@ export const useNotifiSubscribe: ({
             onClick: () => window.open(DISCORD_INVITE_URL, '_blank'),
             message: 'Join Server',
           });
+        } else {
+          setDiscordErrorMessage(undefined);
         }
         setUseDiscord(true);
         setDiscordTargetData(discordTarget);


### PR DESCRIPTION
Now the discord confirmation link still remain the same even the users have already accepted the invitation. Like below.

![Screenshot 2023-06-16 at 23 17 59](https://github.com/notifi-network/notifi-sdk-ts/assets/127958634/a9e00104-6b0c-4b1b-9f8e-84925a9c348f)

This PR is to fix this issue.
