### PR TITLE
MVP-2860: re-signup fails when discord target enabled

### DIFF
--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -608,7 +608,12 @@ export const useNotifiSubscribe: ({
       let finalDiscordId = undefined;
 
       if (useDiscord === true) {
-        finalDiscordId = await client.createDiscordTarget('Default');
+        try {
+          finalDiscordId = await client.createDiscordTarget('Default');
+        } catch (e) {
+          // catch the case that the 'Default' discord already created
+          finalDiscordId = data.discordTargets[0].id;
+        }
       }
 
       const newResults: Record<string, Alert> = {};

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -605,14 +605,17 @@ export const useNotifiSubscribe: ({
       // "refresh" or "fetchData" to obtain existing settings first
       //
 
-      let finalDiscordId = undefined;
+      const existingDiscordTarget = data.discordTargets.find(
+        (target) => target.name === 'Default',
+      );
+
+      let finalDiscordId: string | undefined = undefined;
 
       if (useDiscord === true) {
-        try {
+        if (existingDiscordTarget !== undefined) {
+          finalDiscordId = existingDiscordTarget.id;
+        } else {
           finalDiscordId = await client.createDiscordTarget('Default');
-        } catch (e) {
-          // catch the case that the 'Default' discord already created
-          finalDiscordId = data.discordTargets[0].id;
         }
       }
 


### PR DESCRIPTION
## Replicate method

1. Signup a new wallet

2. Clean the browser cache

3. get in card and signup view will prompt up (expected because browser cache is cleaned)

4. toggle on the discord and signup.

5. Gql error 505See the error video demo attached herewith


See error video demo attched


https://github.com/notifi-network/notifi-sdk-ts/assets/127958634/e56f788a-5f12-49f1-80f0-7341af1450ad

