### PR TITLE
MVP-2842: fix FrontendClient Discord verification fails

### DIFF
--- a/packages/notifi-frontend-client/lib/client/ensureTarget.ts
+++ b/packages/notifi-frontend-client/lib/client/ensureTarget.ts
@@ -114,8 +114,8 @@ export const ensureTelegram = ensureTarget(
 export const ensureDiscord = ensureTarget(
   async (service: Operations.CreateDiscordTargetService, value: string) => {
     const mutation = await service.createDiscordTarget({
-      name: value.toLowerCase(),
-      value: value.toLowerCase(),
+      name: value,
+      value,
     });
 
     const result = mutation.createDiscordTarget;
@@ -132,7 +132,6 @@ export const ensureDiscord = ensureTarget(
   },
   (arg: Types.DiscordTargetFragmentFragment | undefined) =>
     arg?.discordAccountId?.toLowerCase(),
-  (value) => value.toLowerCase(),
 );
 
 export type EnsureWebhookParams = Omit<


### PR DESCRIPTION
## ISSUE
When using frontendClient,
1. it will create the different discordId name (`default`) than the one created by `react-hooks` (`Default`). We need to make them consistent.
2. same situation as #339 while `enableCanary={true}`.
