### PR TITLE
MVP-2842-rev: fix FrontendClient Discord verification fails 

### DIFF
--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -854,4 +854,12 @@ export class NotifiFrontendClient {
     const mutation = await this._service.createSupportConversation(input);
     return mutation;
   }
+
+  async createDiscordTarget(input: string) {
+    const mutation = await this._service.createDiscordTarget({
+      name: input,
+      value: input,
+    });
+    return mutation.createDiscordTarget;
+  }
 }

--- a/packages/notifi-frontend-client/lib/client/ensureTarget.ts
+++ b/packages/notifi-frontend-client/lib/client/ensureTarget.ts
@@ -114,8 +114,8 @@ export const ensureTelegram = ensureTarget(
 export const ensureDiscord = ensureTarget(
   async (service: Operations.CreateDiscordTargetService, value: string) => {
     const mutation = await service.createDiscordTarget({
-      name: value.toLowerCase(),
-      value: value.toLowerCase(),
+      name: value,
+      value,
     });
 
     const result = mutation.createDiscordTarget;
@@ -130,9 +130,8 @@ export const ensureDiscord = ensureTarget(
     const query = await service.getDiscordTargets({});
     return query.discordTarget;
   },
-  (arg: Types.DiscordTargetFragmentFragment | undefined) =>
-    arg?.discordAccountId?.toLowerCase(),
-  (value) => value.toLowerCase(),
+  (arg: Types.DiscordTargetFragmentFragment | undefined) => arg?.id,
+  (value) => value,
 );
 
 export type EnsureWebhookParams = Omit<

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
@@ -29,6 +29,14 @@ export type NotifiSubscribeButtonProps = Readonly<{
   inputs: Record<string, unknown>;
 }>;
 
+type TargetGroupData = {
+  name: string;
+  emailAddress?: string;
+  phoneNumber?: string;
+  telegramId?: string;
+  discordId?: string;
+};
+
 export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
   buttonText,
   classNames,
@@ -52,6 +60,7 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
     loading,
     setCardView,
     useDiscord,
+    discordTargetData,
     params,
     render,
     setLoading,
@@ -66,7 +75,7 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
 
   const isMultiWallet = (multiWallet?.ownedWallets?.length ?? 0) > 0;
 
-  const targetGroup = useMemo(
+  const targetGroup: TargetGroupData = useMemo(
     () => ({
       name: 'Default',
       emailAddress: email === '' ? undefined : email,
@@ -75,7 +84,7 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
         telegramId === ''
           ? undefined
           : formatTelegramForSubscription(telegramId),
-      discordId: useDiscord ? 'Default' : undefined,
+      discordId: useDiscord ? discordTargetData?.id : undefined,
     }),
     [email, phoneNumber, telegramId, useDiscord],
   );
@@ -83,7 +92,19 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
   const subscribeAlerts = useCallback(
     async (eventTypes: EventTypeConfig, inputs: Record<string, unknown>) => {
       if (isCanaryActive) {
-        await renewTargetGroups();
+        const data = await frontendClient.fetchData();
+        let discordTarget = data.targetGroup?.[0]?.discordTargets?.find(
+          (target) => target?.name === 'Default',
+        );
+        if (useDiscord && !discordTarget) {
+          discordTarget = await frontendClient.createDiscordTarget('Default');
+        }
+
+        await renewTargetGroups({
+          ...targetGroup,
+          discordId: discordTarget?.id,
+        });
+
         return subscribeAlertsByFrontendClient(
           frontendClient,
           eventTypes,
@@ -104,12 +125,15 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
     ],
   );
 
-  const renewTargetGroups = useCallback(async () => {
-    if (isCanaryActive) {
-      return frontendClient.ensureTargetGroup(targetGroup);
-    }
-    return updateTargetGroups();
-  }, [email, phoneNumber, useDiscord, telegramId, frontendClient]);
+  const renewTargetGroups = useCallback(
+    async (targetGroup: TargetGroupData) => {
+      if (isCanaryActive) {
+        return frontendClient.ensureTargetGroup(targetGroup);
+      }
+      return updateTargetGroups();
+    },
+    [email, phoneNumber, useDiscord, telegramId, frontendClient],
+  );
 
   const onClick = useCallback(async () => {
     let isFirstTimeUser = (client.data?.targetGroups?.length ?? 0) === 0;
@@ -132,7 +156,7 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
         const result = await subscribeAlerts(eventTypes, inputs);
         success = !!result;
       } else {
-        const result = await renewTargetGroups();
+        const result = await renewTargetGroups(targetGroup);
         success = !!result;
       }
 


### PR DESCRIPTION
## ISSUE
When using frontendClient,
1. it will create the different discordId name (`default`) than the one created by `react-hooks` (`Default`). We need to make them consistent.
2. same situation as #339 while `enableCanary={true}`.

**NOTE**
This is rev#2.
Take the suggestion of previous PR (#340) comment