### PR TITLE
MVP-2882: SDK card title not sync with AP setting

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
@@ -255,11 +255,13 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
   };
 
   const historyView = () => {
-    return selectedAlertEntry === undefined
-      ? useCustomTitles && data?.titles.alertDetailsView !== ''
-        ? data?.titles.alertDetailsView
-        : copy?.historyHeader ?? 'Alert History'
-      : copy?.detailHeader ?? 'Alert Details';
+    if (!useCustomTitles) {
+      return selectedAlertEntry ? 'Alert Details' : 'Alert History';
+    }
+
+    return selectedAlertEntry
+      ? data?.titles.alertDetailsView || 'Alert Details'
+      : data?.titles.historyView || 'Alert History';
   };
 
   switch (cardView.state) {


### PR DESCRIPTION
Set title of History & Alert Details View not correctly shown in sdk card. see image below
![Screenshot 2023-06-28 at 12 23 15](https://github.com/notifi-network/notifi-sdk-ts/assets/127958634/70b4446f-17ad-412f-add2-a36823da7719)

**ACTION LATER**
Need to update SDK in AP(Admin panel)