### PR TITLE
MVP-2733:  login w/o targets refactor & style

### DIFF
--- a/packages/notifi-react-card/lib/components/NotifiDisclosureStatement.tsx
+++ b/packages/notifi-react-card/lib/components/NotifiDisclosureStatement.tsx
@@ -21,7 +21,7 @@ export const NotifiDisclosureStatement: React.FC<
       </label>
       <a
         className={clsx('NotifiDisclosure__hyperlink', classNames?.hyperlink)}
-        href="https://notifi.network/faqs"
+        href="https://notifi.network"
         target="_blank"
       >
         Learn more

--- a/packages/notifi-react-card/lib/components/NotifiFooter.tsx
+++ b/packages/notifi-react-card/lib/components/NotifiFooter.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import React from 'react';
 
-import { useNotifiSubscriptionContext } from '../context';
 import type { DeepPartialReadonly } from '../utils';
 import {
   NotifiDisclosureStatement,
@@ -29,11 +28,7 @@ export const NotifiFooter: React.FC<NotifiFooterProps> = ({
   classNames,
   copy,
 }: NotifiFooterProps) => {
-  const { cardView } = useNotifiSubscriptionContext();
-
-  const hideFooter = cardView.state === 'history';
-
-  return hideFooter ? null : (
+  return (
     <div className={clsx('NotifiFooter__container', classNames?.container)}>
       {copy?.disclosure ? (
         <NotifiDisclosureStatement
@@ -42,7 +37,7 @@ export const NotifiFooter: React.FC<NotifiFooterProps> = ({
         />
       ) : null}
       <a
-        href="https://notifi.network/faqs"
+        href="https://notifi.network"
         target="_blank"
         rel="noopener noreferrer"
         className={clsx(

--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -22,6 +22,7 @@
   --notifi-outgoing-message: #e5ebff;
   --notifi-settings-icon-color: #262949;
   --notifi-confirmation-color: #22af3c;
+  --notifi-divider-line: rgba(255, 255, 255, 0.2);
 }
 
 a {
@@ -58,6 +59,7 @@ a {
   --notifi-confirmation-color: #45c95e;
   --notifi-banner-background: #222222;
   --notifi-banner-icon-color: #262949;
+  --notifi-divider-line: rgba(255, 255, 255, 0.2);
 }
 
 input:autofill,
@@ -90,8 +92,7 @@ input::-webkit-inner-spin-button {
 }
 
 .NotifiPreviewCard__dividerLine {
-  border-top: 1px solid var(--notifi-font-color);
-  opacity: 0.2;
+  border-top: 1px solid var(--notifi-divider-line);
   margin: 20px 16px;
 }
 
@@ -107,7 +108,7 @@ input::-webkit-inner-spin-button {
   flex-grow: 1;
   display: flex;
   flex-direction: column;
-  margin: 0px 20px;
+  margin: 10px 20px;
 }
 
 .NotifiInputHeading {
@@ -128,6 +129,7 @@ input::-webkit-inner-spin-button {
   position: relative;
   flex-direction: column;
   flex-grow: 1;
+  margin-bottom: 0px !important;
 }
 
 .NotifiVerifyContainer {
@@ -199,8 +201,7 @@ input::-webkit-inner-spin-button {
   line-height: 14px;
   justify-content: center;
   align-items: center;
-  margin-bottom: 12px;
-  margin-top: 12px;
+  padding: 12px 0px;
 }
 
 .NotifiFooter__poweredByContainer {
@@ -300,10 +301,10 @@ input::-webkit-inner-spin-button {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  padding: 10px 0 0 10px;
+  padding: 10px 0 0 0px;
   flex-grow: 1;
   overflow: hidden;
-  margin: 10px 0;
+  border-bottom: 1px solid var(--notifi-divider-line);
 }
 
 .NotifiAlertHistory__content,
@@ -323,10 +324,9 @@ input::-webkit-inner-spin-button {
   border-radius: 16px;
 }
 
-.NotifiAlertHistory__dividerLine {
-  border-top: 1px solid var(--notifi-font-color);
+.DividerLine {
+  border-top: 1px solid var(--notifi-divider-line);
   border-radius: 5px;
-  opacity: 0.2;
   margin-bottom: 0 !important;
 }
 
@@ -966,6 +966,7 @@ input::-webkit-inner-spin-button {
   flex-direction: column;
   justify-content: flex-start;
   align-items: stretch;
+  margin: 0px 20px;
 }
 
 .NotifiAlertDetails__topContentContainer {
@@ -1600,6 +1601,7 @@ input::-webkit-inner-spin-button {
   flex-direction: column;
   flex-grow: 1;
   visibility: visible;
+  margin: 0px 20px;
 }
 
 .NotifiAlertHistory__container.NotifiAlertHistory__container--hidden {
@@ -1607,7 +1609,6 @@ input::-webkit-inner-spin-button {
 }
 
 .NotifiAlertHistory__virtuoso {
-  margin-bottom: 25px;
   overflow-x: hidden;
 }
 

--- a/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
@@ -25,6 +25,7 @@ import NotifiAlertBox, {
   NotifiAlertBoxButtonProps,
   NotifiAlertBoxProps,
 } from '../NotifiAlertBox';
+import { SignupBanner, SignupBannerProps } from '../SignupBanner';
 import { ErrorStateCard } from '../common';
 import {
   NotifiInputFieldsText,
@@ -72,6 +73,8 @@ export type SubscriptionCardV1Props = Readonly<{
     VerifyWalletView: VerifyWalletViewProps['classNames'];
     NotifiAlertBox: NotifiAlertBoxProps['classNames'];
     ErrorStateCard: string;
+    signupBanner: SignupBannerProps['classNames'];
+    dividerLine: string;
   }>;
   inputDisabled: boolean;
   data: CardConfigItemV1;
@@ -272,6 +275,7 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
           >
             <h2>{expiredHeader()}</h2>
           </NotifiAlertBox>
+          <div className={clsx('DividerLine', classNames?.dividerLine)} />
           <ExpiredTokenView classNames={classNames?.ExpiredTokenView} />
         </>
       );
@@ -289,6 +293,9 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
           >
             <h2>{previewHeader()}</h2>
           </NotifiAlertBox>
+          {!isTargetsExist ? (
+            <SignupBanner data={data} classNames={classNames?.signupBanner} />
+          ) : null}
           <PreviewCard
             data={data}
             inputs={inputs}
@@ -323,6 +330,7 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
               <h2>{editHeader()}</h2>
             )}
           </NotifiAlertBox>
+          <div className={clsx('DividerLine', classNames?.dividerLine)} />
           <EditCardView
             buttonText={cardView.state === 'signup' ? 'Next' : 'Update'}
             data={data}
@@ -358,6 +366,7 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
           >
             <h2>{verifyOnboardingHeader()}</h2>
           </NotifiAlertBox>
+          <div className={clsx('DividerLine', classNames?.dividerLine)} />
           <VerifyWalletView
             classNames={classNames?.VerifyWalletView}
             data={data}
@@ -395,6 +404,10 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
               classNames?.alertContainer,
             )}
           >
+            <div className={clsx('DividerLine', classNames?.dividerLine)} />
+            {!isTargetsExist ? (
+              <SignupBanner data={data} classNames={classNames?.signupBanner} />
+            ) : null}
             {selectedAlertEntry === undefined ? null : (
               <AlertDetailsCard
                 notificationEntry={selectedAlertEntry}

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
@@ -12,10 +12,7 @@ import React, {
 import { Virtuoso } from 'react-virtuoso';
 
 import { NotificationEmptyBellIcon } from '../../../assets/NotificationEmptyBellIcon';
-import {
-  useNotifiClientContext,
-  useNotifiSubscriptionContext,
-} from '../../../context';
+import { useNotifiClientContext } from '../../../context';
 import {
   DeepPartialReadonly,
   getAlertNotificationViewBaseProps,
@@ -26,7 +23,6 @@ import {
   AlertNotificationRow,
   AlertNotificationViewProps,
 } from '../../AlertHistory/AlertNotificationRow';
-import { SignupBanner, SignupBannerProps } from '../../SignupBanner';
 
 export type AlertHistoryViewProps = Readonly<{
   noAlertDescription?: string;
@@ -35,7 +31,6 @@ export type AlertHistoryViewProps = Readonly<{
   classNames?: DeepPartialReadonly<{
     title: string;
     header: string;
-    dividerLine: string;
     manageAlertLink: string;
     noAlertDescription: string;
     notificationDate: string;
@@ -47,7 +42,6 @@ export type AlertHistoryViewProps = Readonly<{
     historyContainer: string;
     virtuoso: string;
     AlertCard: AlertNotificationViewProps['classNames'];
-    signupBanner: SignupBannerProps['classNames']; // TODO: Move up one level (for MVP-2733), Blocker: MVP-2716
   }>;
   setAlertEntry: React.Dispatch<
     React.SetStateAction<
@@ -81,9 +75,6 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
     canary: { isActive: isCanaryActive, frontendClient },
   } = useNotifiClientContext();
 
-  const { email, phoneNumber, telegramId, discordTargetData, useDiscord } =
-    useNotifiSubscriptionContext();
-
   const { isClientInitialized, isClientAuthenticated } = useMemo(() => {
     return {
       isClientInitialized: isCanaryActive
@@ -94,23 +85,6 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
         : client.isAuthenticated,
     };
   }, [isCanaryActive, client, frontendClient]);
-
-  const isTargetsExist = useMemo(() => {
-    return (
-      !!email ||
-      !!phoneNumber ||
-      !!telegramId ||
-      (useDiscord &&
-        !!discordTargetData?.id &&
-        !!discordTargetData?.discordAccountId)
-    );
-  }, [
-    email,
-    phoneNumber,
-    telegramId,
-    discordTargetData?.id,
-    discordTargetData?.discordAccountId,
-  ]);
 
   const getNotificationHistory = useCallback(
     async ({ first, after }: GetNotificationHistoryInput) => {
@@ -165,16 +139,6 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
         { 'NotifiAlertHistory__container--hidden': isHidden },
       )}
     >
-      <div
-        className={clsx(
-          'NotifiAlertHistory__dividerLine',
-          classNames?.dividerLine,
-        )}
-      />
-      {!isTargetsExist && (
-        <SignupBanner data={data} classNames={classNames?.signupBanner} /> // TODO: Move up one level (for MVP-2733), Blocker: MVP-2716
-      )}
-
       {allNodes.length > 0 ? (
         <Virtuoso
           className={clsx('NotifiAlertHistory__virtuoso', classNames?.virtuoso)}

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/PreviewCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/PreviewCard.tsx
@@ -4,7 +4,6 @@ import { useNotifiSubscriptionContext } from 'notifi-react-card/lib/context';
 import React, { useMemo } from 'react';
 
 import { DeepPartialReadonly } from '../../../utils';
-import { SignupBanner, SignupBannerProps } from '../../SignupBanner';
 import { AlertsPanel, AlertsPanelProps } from './preview-panel/AlertsPanel';
 import {
   UserInfoPanel,
@@ -20,7 +19,6 @@ export type PreviewCardProps = Readonly<{
     UserInfoPanel?: DeepPartialReadonly<UserInfoPanelProps['classNames']>;
     NotifiPreviewCardTitle?: string;
     NotifiPreviewCardDividerLine?: string;
-    signupBanner?: SignupBannerProps['classNames']; // TODO: Move up one level (for MVP-2733), Blocker: MVP-2716
   };
   data: CardConfigItemV1;
   inputDisabled: boolean;
@@ -59,14 +57,12 @@ export const PreviewCard: React.FC<PreviewCardProps> = ({
         classNames?.NotifiPreviewCardContainer,
       )}
     >
-      {!isTargetsExist ? (
-        <SignupBanner data={data} classNames={classNames?.signupBanner} /> //TODO: Move up one level (for MVP-2733), Blocker: MVP-2716
-      ) : (
+      {isTargetsExist ? (
         <UserInfoPanel
           classNames={classNames?.UserInfoPanel}
           contactInfo={data.contactInfo}
         />
-      )}
+      ) : null}
 
       <div
         className={clsx(


### PR DESCRIPTION

## SDK3.0 login w/o targets refactor
- Consolidate `signup` banner
- Styling
- fix MVP-2822 (powered by Notifi)

Checkout demo below (Prod env):

https://github.com/notifi-network/notifi-sdk-ts/assets/127958634/b2f40036-8708-475f-8127-61717d863338

**TODO (POST ACTION)**
- Update SDK ver in AP Repo (MVP-2719)
