### PR TITLE
Support custom targetGroupName in ensureAlert

### DIFF
--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -632,9 +632,11 @@ export class NotifiFrontendClient {
   async ensureAlert({
     eventType,
     inputs,
+    targetGroupName = 'Default',
   }: Readonly<{
     eventType: EventTypeItem;
     inputs: Record<string, unknown>;
+    targetGroupName?: string;
   }>): Promise<Types.AlertFragmentFragment> {
     const [alertsQuery, targetGroupsQuery, sourceAndFilters] =
       await Promise.all([
@@ -644,10 +646,10 @@ export class NotifiFrontendClient {
       ]);
 
     const targetGroup = targetGroupsQuery.targetGroup?.find(
-      (it) => it?.name === 'Default',
+      (it) => it?.name === targetGroupName,
     );
     if (targetGroup === undefined) {
-      throw new Error('Default target group does not exist');
+      throw new Error('Target group does not exist');
     }
 
     const { sourceGroup, filter, filterOptions } = sourceAndFilters;


### PR DESCRIPTION
Allow passing in a custom TargetGroup name durint ensureAlert in NotifiFrontendClient codepath.