### PR TITLE
MVP-2762: Regular users being not able to re-direct to historyView 

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
@@ -168,11 +168,6 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
     discordTargetData?.id,
     discordTargetData?.discordAccountId,
   ]);
-
-  const isTargetsValid = useMemo(() => {
-    return data.isContactInfoRequired ? isTargetsExist : isClientAuthenticated;
-  }, [isTargetsExist, data.isContactInfoRequired, isClientAuthenticated]);
-
   const [selectedAlertEntry, setAlertEntry] = useState<
     Types.NotificationHistoryEntryFragmentFragment | undefined
   >(undefined);
@@ -189,30 +184,30 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
   }, [email, phoneNumber, telegramId]);
 
   useEffect(() => {
-    if (demoPreview && demoPreview.view !== 'error') {
-      return setCardView({ state: demoPreview.view });
-    }
-    if (demoPreview && demoPreview.view === 'error') {
-      return setCardView({
-        state: demoPreview.view,
-        reason: 'test example reason',
-      });
-    }
+    setCardView((prev) => {
+      if (demoPreview) {
+        return {
+          state: demoPreview.view,
+          reason:
+            demoPreview.view === 'error' ? 'test example reason' : undefined,
+        };
+      }
 
-    if (!isClientInitialized || firstLoad.current) {
-      return;
-    }
+      if (!isClientAuthenticated) {
+        return { state: 'signup' };
+      }
 
-    firstLoad.current = true;
+      if (isClientTokenExpired) {
+        return { state: 'expired' };
+      }
 
-    if (isTargetsValid) {
-      setCardView({ state: 'history' });
-    } else if (isClientTokenExpired) {
-      setCardView({ state: 'expired' });
-    } else {
-      setCardView({ state: 'signup' });
-    }
-  }, [email, phoneNumber, telegramId, isClientInitialized, demoPreview]);
+      if (prev.state === 'signup') {
+        return { state: 'preview' };
+      }
+
+      return { state: 'history' };
+    });
+  }, []);
 
   const rightIcon: NotifiAlertBoxButtonProps | undefined = useMemo(() => {
     if (onClose === undefined) {

--- a/packages/notifi-react-card/lib/context/NotifiClientContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiClientContext.tsx
@@ -52,21 +52,15 @@ export const NotifiClientContextProvider: React.FC<NotifiParams> = ({
 
   const frontendClient = useMemo(() => {
     const configInput = getFrontendConfigInput(params);
-    return newFrontendClient(configInput);
+    const frontendClient = newFrontendClient(configInput);
+    frontendClient.initialize();
+    return frontendClient;
   }, [
     params.dappAddress,
     params.env,
     params.walletBlockchain,
     params.walletPublicKey,
   ]);
-
-  useEffect(() => {
-    // Init frontend client
-    if (!params.enableCanary) return;
-    if (!frontendClient.userState) {
-      frontendClient.initialize();
-    }
-  }, [frontendClient]);
 
   return (
     <NotifiClientContext.Provider


### PR DESCRIPTION
# 🛠️ Regular users being not able to re-direct to historyView

The regular users (Not FTU) should be able to routed to “HistoryView” when opening the card. 

However, the regular users will be routed to SingupView every time they open the card.

> ℹ️ This happens only with using frontendClient

https://github.com/notifi-network/notifi-sdk-ts/assets/127958634/a1a78eba-e669-4369-b63b-4717b7da7be9


