### PR TITLE
Fix alertFrequency in fusionToggleConfiguration

### DIFF
--- a/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
+++ b/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
@@ -27,12 +27,12 @@ export type FusionTypeBase = {
   sourceAddress: ValueOrRef<string>;
   tooltipContent?: string;
   maintainSourceGroup?: boolean;
+  alertFrequency?: AlertFrequency;
 };
 
 export type FusionToggleEventTypeItem = FusionTypeBase &
   Readonly<{
     selectedUIType: 'TOGGLE';
-    alertFrequency?: AlertFrequency;
   }>;
 
 export type FusionHealthCheckEventTypeItem = FusionTypeBase &
@@ -40,7 +40,6 @@ export type FusionHealthCheckEventTypeItem = FusionTypeBase &
     selectedUIType: 'HEALTH_CHECK';
     healthCheckSubtitle: string;
     numberType: NumberTypeSelect;
-    alertFrequency: AlertFrequency;
     checkRatios: CheckRatio[];
   }>;
 

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeFusionToggleRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeFusionToggleRow.tsx
@@ -1,4 +1,7 @@
-import { EventTypeItem } from '@notifi-network/notifi-frontend-client';
+import {
+  EventTypeItem,
+  FusionToggleEventTypeItem,
+} from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import React, {
   useCallback,
@@ -12,11 +15,7 @@ import {
   useNotifiClientContext,
   useNotifiSubscriptionContext,
 } from '../../context';
-import {
-  FusionToggleEventTypeItem,
-  SubscriptionData,
-  useNotifiSubscribe,
-} from '../../hooks';
+import { SubscriptionData, useNotifiSubscribe } from '../../hooks';
 import {
   AlertConfiguration,
   DeepPartialReadonly,
@@ -81,6 +80,7 @@ export const EventTypeFusionToggleRow: React.FC<EventTypeFusionRowProps> = ({
       maintainSourceGroup: config?.maintainSourceGroup,
       fusionId: fusionEventId,
       fusionSourceAddress,
+      alertFrequency: config?.alertFrequency,
     });
   }, [alertName, config, inputs]);
 

--- a/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
+++ b/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
@@ -41,6 +41,7 @@ export type FusionTypeBase = {
 export type FusionToggleEventTypeItem = FusionTypeBase &
   Readonly<{
     selectedUIType: 'TOGGLE';
+    alertFrequency?: AlertFrequency;
   }>;
 
 export type FusionHealthCheckEventTypeItem = FusionTypeBase &

--- a/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
+++ b/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
@@ -36,12 +36,12 @@ export type FusionTypeBase = {
   sourceAddress: ValueOrRef<string>;
   tooltipContent?: string;
   maintainSourceGroup?: boolean;
+  alertFrequency?: AlertFrequency;
 };
 
 export type FusionToggleEventTypeItem = FusionTypeBase &
   Readonly<{
     selectedUIType: 'TOGGLE';
-    alertFrequency?: AlertFrequency;
   }>;
 
 export type FusionHealthCheckEventTypeItem = FusionTypeBase &
@@ -49,7 +49,6 @@ export type FusionHealthCheckEventTypeItem = FusionTypeBase &
     selectedUIType: 'HEALTH_CHECK';
     healthCheckSubtitle: string;
     numberType: NumberTypeSelect;
-    alertFrequency: AlertFrequency;
     checkRatios: CheckRatio[];
   }>;
 


### PR DESCRIPTION

1. Fix alertFrequency in fusionToggleConfiguration
2. Use frontend-client's cardConfig instead of hooks in card
3. Sync the cardConfig in hooks and frontend-client