### PR TITLE
Use Figma original svg instead of creating by CSS

### DIFF
--- a/packages/notifi-react-card/lib/assets/CircleBellIcon.tsx
+++ b/packages/notifi-react-card/lib/assets/CircleBellIcon.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+export type Props = React.SVGProps<SVGSVGElement>;
+
+export const CircleBellIcon: React.FC<Props> = (props: Props) => {
+  return (
+    <svg
+      width="21"
+      height="21"
+      viewBox="0 0 21 21"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <circle
+        cx="10.5"
+        cy="10.5"
+        r="9.5"
+        fill="white"
+        stroke="url(#paint0_linear_1316_3580)"
+        stroke-width="2"
+      />
+      <path
+        d="M10.4901 16.1875C11.1212 16.1875 11.6376 15.6712 11.6376 15.0401H9.3427C9.3427 15.6712 9.85331 16.1875 10.4901 16.1875ZM13.9324 12.7452V9.8766C13.9324 8.11529 12.9915 6.64083 11.3507 6.25071V5.86058C11.3507 5.38439 10.9663 5 10.4901 5C10.0139 5 9.62956 5.38439 9.62956 5.86058V6.25071C7.98299 6.64083 7.04783 8.10955 7.04783 9.8766V12.7452L5.90039 13.8926V14.4663H15.0799V13.8926L13.9324 12.7452Z"
+        fill="#262949"
+      />
+      <defs>
+        <linearGradient
+          id="paint0_linear_1316_3580"
+          x1="15.6331"
+          y1="3.32468"
+          x2="7.46429"
+          y2="19"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stop-color="#FE7970" />
+          <stop offset="1" stop-color="#FEB776" />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+};

--- a/packages/notifi-react-card/lib/components/SignupBanner.tsx
+++ b/packages/notifi-react-card/lib/components/SignupBanner.tsx
@@ -5,9 +5,9 @@ import {
 import clsx from 'clsx';
 import React, { useMemo } from 'react';
 
+import { CircleBellIcon } from '../assets/CircleBellIcon';
 import { useNotifiSubscriptionContext } from '../context';
 import { DeepPartialReadonly } from '../utils';
-import { AlertIcon } from './AlertHistory/AlertIcon';
 
 export type SignupBannerProps = Readonly<{
   data: CardConfigItemV1;
@@ -59,7 +59,7 @@ export const SignupBanner: React.FC<SignupBannerProps> = ({
                 : 'SignupBanner__Image',
             )}
           >
-            <AlertIcon icon={'BELL'} />
+            <CircleBellIcon />
           </div>
           <div
             className={clsx(

--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -1722,14 +1722,9 @@ input::-webkit-inner-spin-button {
 }
 
 .SignupBanner__Image {
-  width: 24px;
-  height: 24px;
-  color: var(--notifi-banner-icon-color);
-  background-color: var(--notifi-settings-icon-color);
-  margin-right: 10px;
-  border-radius: 50px;
-  overflow: hidden;
-  border: 2px solid var(--notifi-checkmark-color);
+  margin: 0px 8px 0px 12px;
+  display: flex;
+  justify-content: center;
 }
 
 .SignupBanner__Button {


### PR DESCRIPTION
Optimize singupBanner style by replacing css made icon with figma original svg