### PR TITLE
Move un-runtime dependencies to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29613,6 +29613,7 @@
     },
     "node_modules/jsonc-parser": {
       "version": "3.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonfile": {
@@ -30558,6 +30559,7 @@
     },
     "node_modules/lunr": {
       "version": "2.3.9",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/magic-string": {
@@ -30679,6 +30681,7 @@
     },
     "node_modules/marked": {
       "version": "4.2.12",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -39265,6 +39268,7 @@
     },
     "node_modules/shiki": {
       "version": "0.10.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.0.0",
@@ -41457,6 +41461,7 @@
     },
     "node_modules/typedoc": {
       "version": "0.22.18",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "glob": "^8.0.3",
@@ -41477,6 +41482,7 @@
     },
     "node_modules/typedoc-plugin-missing-exports": {
       "version": "0.22.6",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "typedoc": "0.22.x"
@@ -41484,6 +41490,7 @@
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -41491,6 +41498,7 @@
     },
     "node_modules/typedoc/node_modules/glob": {
       "version": "8.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -41508,6 +41516,7 @@
     },
     "node_modules/typedoc/node_modules/minimatch": {
       "version": "5.1.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -42076,10 +42085,12 @@
     },
     "node_modules/vscode-oniguruma": {
       "version": "1.7.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-textmate": {
       "version": "5.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/w3c-hr-time": {
@@ -43992,12 +44003,12 @@
         "@notifi-network/notifi-core": "^0.76.0",
         "axios": "^0.26.0",
         "localforage": "^1.10.0",
-        "typedoc-plugin-missing-exports": "^0.22.6",
         "typescript": "^4.5.5"
       },
       "devDependencies": {
         "@types/node": "^17.0.21",
-        "@types/react": "^18.0"
+        "@types/react": "^18.0",
+        "typedoc-plugin-missing-exports": "^0.22.6"
       },
       "peerDependencies": {
         "react": "^17.0.2 || ^18.0",
@@ -63721,7 +63732,8 @@
       "version": "2.2.3"
     },
     "jsonc-parser": {
-      "version": "3.2.0"
+      "version": "3.2.0",
+      "dev": true
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -64358,7 +64370,8 @@
       }
     },
     "lunr": {
-      "version": "2.3.9"
+      "version": "2.3.9",
+      "dev": true
     },
     "magic-string": {
       "version": "0.25.9",
@@ -64439,7 +64452,8 @@
       }
     },
     "marked": {
-      "version": "4.2.12"
+      "version": "4.2.12",
+      "dev": true
     },
     "md5.js": {
       "version": "1.3.5",
@@ -69910,6 +69924,7 @@
     },
     "shiki": {
       "version": "0.10.1",
+      "dev": true,
       "requires": {
         "jsonc-parser": "^3.0.0",
         "vscode-oniguruma": "^1.6.1",
@@ -71372,6 +71387,7 @@
     },
     "typedoc": {
       "version": "0.22.18",
+      "dev": true,
       "requires": {
         "glob": "^8.0.3",
         "lunr": "^2.3.9",
@@ -71382,12 +71398,14 @@
       "dependencies": {
         "brace-expansion": {
           "version": "2.0.1",
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
           }
         },
         "glob": {
           "version": "8.1.0",
+          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -71398,6 +71416,7 @@
         },
         "minimatch": {
           "version": "5.1.6",
+          "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
@@ -71406,6 +71425,7 @@
     },
     "typedoc-plugin-missing-exports": {
       "version": "0.22.6",
+      "dev": true,
       "requires": {}
     },
     "typeforce": {
@@ -71750,10 +71770,12 @@
       "peer": true
     },
     "vscode-oniguruma": {
-      "version": "1.7.0"
+      "version": "1.7.0",
+      "dev": true
     },
     "vscode-textmate": {
-      "version": "5.2.0"
+      "version": "5.2.0",
+      "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/packages/notifi-react-hooks/package.json
+++ b/packages/notifi-react-hooks/package.json
@@ -27,7 +27,8 @@
   },
   "devDependencies": {
     "@types/node": "^17.0.21",
-    "@types/react": "^18.0"
+    "@types/react": "^18.0",
+    "typedoc-plugin-missing-exports": "^0.22.6"
   },
   "dependencies": {
     "@notifi-network/notifi-axios-adapter": "^0.76.0",
@@ -35,7 +36,6 @@
     "@notifi-network/notifi-core": "^0.76.0",
     "axios": "^0.26.0",
     "localforage": "^1.10.0",
-    "typedoc-plugin-missing-exports": "^0.22.6",
     "typescript": "^4.5.5"
   },
   "peerDependencies": {


### PR DESCRIPTION
As title.
After checking through all packages, we should move "typedoc-plugin-missing-exports" package to devDependencies.