### PR TITLE
Fix: Worng healthCheck filterOption (threshold)

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/EventTypeHealthCheckRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeHealthCheckRow.tsx
@@ -151,10 +151,8 @@ export const EventTypeHealthCheckRow: React.FC<
           alertConfiguration: healthThresholdConfiguration({
             alertFrequency: config.alertFrequency,
             percentage: inputsValidator(alertDetail.inputs)
-              ? (alertDetail.inputs as HealthCheckEventInputsWithIndex).index
-              : (
-                  alertDetail.inputs as HealthCheckEventInputsWithCustomPercentage
-                ).customPercentage,
+              ? ratios[alertDetail.inputs.index].ratio
+              : alertDetail.inputs.customPercentage,
             thresholdDirection: inputsValidator(alertDetail.inputs)
               ? thresholdDirection
               : alertDetail.inputs.thresholdDirection,


### PR DESCRIPTION
As title, fix the issue that the `filterOption` -> `threshold` gets wrong data.  