### PR TITLE
fix: logic in isTargetsExist

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
@@ -146,12 +146,7 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
   ]);
 
   const isTargetsExist = useMemo(() => {
-    return (
-      !!email ||
-      !!phoneNumber ||
-      !!telegramId ||
-      (!!discordTargetData?.id && !!discordTargetData?.discordAccountId)
-    );
+    return !!email || !!phoneNumber || !!telegramId || !!discordTargetData?.id;
   }, [
     email,
     phoneNumber,

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/PreviewCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/PreviewCard.tsx
@@ -39,9 +39,7 @@ export const PreviewCard: React.FC<PreviewCardProps> = ({
       !!email ||
       !!phoneNumber ||
       !!telegramId ||
-      (useDiscord &&
-        !!discordTargetData?.id &&
-        !!discordTargetData?.discordAccountId)
+      (useDiscord && !!discordTargetData?.id)
     );
   }, [
     email,


### PR DESCRIPTION
the react card showing the sign up banner instead of alert destinations list when sign up only with discord
Currently, we should have both id and discordAccountId available to show the destinations list, but the discordAccountId can't be available until after the account is verified

remove the condition !!discordTargetData?.discordAccountId in isTargetsExist logic
<img width="393" alt="Screenshot 2023-08-02 at 11 03 29 AM" src="https://github.com/notifi-network/notifi-sdk-ts/assets/26240001/ef648c18-7cf7-499e-a42f-97c681e19604">
<img width="365" alt="Screenshot 2023-08-02 at 11 10 19 AM" src="https://github.com/notifi-network/notifi-sdk-ts/assets/26240001/5e585b07-4eb3-4d17-a7e2-3739533c2ec1">