### PR TITLE
MVP-3051: EventTypeCustomHealthCheckRow not allows to input percentage

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/EventTypeCustomHealthCheckRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeCustomHealthCheckRow.tsx
@@ -108,7 +108,10 @@ export const EventTypeCustomHealthCheckRow: React.FC<
     if (alert) {
       let alertRatioValue: number | null = null;
       if (alert.filterOptions) {
-        alertRatioValue = JSON.parse(alert.filterOptions).threshold;
+        alertRatioValue =
+          config.numberType === 'percentage'
+            ? JSON.parse(alert.filterOptions).threshold * 100
+            : JSON.parse(alert.filterOptions).threshold;
       }
       setEnabled(true);
       if (alertRatioValue) {
@@ -199,28 +202,36 @@ export const EventTypeCustomHealthCheckRow: React.FC<
       return;
     }
 
+    const regex = new RegExp(
+      config.numberType === 'percentage' ? /^[0-9.%]+$/ : /^[0-9.]+$/,
+    );
+    if (!customInputRef.current || !regex.test(customInputRef.current.value)) {
+      return setErrorMessage(INVALID_NUMBER);
+    }
+
     setErrorMessage('');
     setIsNotificationLoading(true);
-    if (customInputRef.current) {
-      customInputRef.current.placeholder = 'Custom';
 
-      const ratioNumber =
-        config.numberType === 'percentage'
-          ? getParsedInputNumber(customInputRef.current.value)
-          : parseFloat(customInputRef.current.value);
+    customInputRef.current.placeholder = 'Custom';
+    const ratioNumber =
+      config.numberType === 'percentage'
+        ? getParsedInputNumber(customInputRef.current.value)
+        : parseFloat(customInputRef.current.value);
 
-      if (ratioNumber && customValue) {
-        subscribeAlert({ eventType: config, inputs }, ratioNumber)
-          .then(() => setSelectedIndex(3))
-          .catch(() => setErrorMessage(UNABLE_TO_UNSUBSCRIBE))
-          .finally(() => {
-            setIsNotificationLoading(false);
-          });
-      } else {
-        setErrorMessage(INVALID_NUMBER);
-        setSelectedIndex(initialSelectedIndex);
-        setIsNotificationLoading(false);
-      }
+    if (ratioNumber && customValue) {
+      subscribeAlert({ eventType: config, inputs }, ratioNumber)
+        .then(() => {
+          setSelectedIndex(3);
+          isCanaryActive && frontendClient.fetchData().then(render);
+        })
+        .catch(() => setErrorMessage(UNABLE_TO_UNSUBSCRIBE))
+        .finally(() => {
+          setIsNotificationLoading(false);
+        });
+    } else {
+      setErrorMessage(INVALID_NUMBER);
+      setSelectedIndex(initialSelectedIndex);
+      setIsNotificationLoading(false);
     }
   };
 
@@ -263,6 +274,7 @@ export const EventTypeCustomHealthCheckRow: React.FC<
     setIsNotificationLoading(true);
     setErrorMessage('');
     if (!enabled && initialRatio !== null) {
+      setEnabled(true);
       subscribeAlert({ eventType: config, inputs }, initialRatio)
         .then((res) => {
           // We update optimistically so we need to check if the alert exists.
@@ -272,14 +284,16 @@ export const EventTypeCustomHealthCheckRow: React.FC<
           }
           isCanaryActive && frontendClient.fetchData().then(render);
         })
-        .catch(() => {
+        .catch((e) => {
           setErrorMessage(UNABLE_TO_SUBSCRIBE);
           setEnabled(false);
+          throw e;
         })
         .finally(() => {
           setIsNotificationLoading(false);
         });
     } else {
+      setEnabled(false);
       unSubscribeAlert({ eventType: config, inputs })
         .then((res) => {
           setCustomValue('');
@@ -292,9 +306,10 @@ export const EventTypeCustomHealthCheckRow: React.FC<
           // Else, ensured by frontendClient
           isCanaryActive && frontendClient.fetchData().then(render);
         })
-        .catch(() => {
+        .catch((e) => {
           setErrorMessage(UNABLE_TO_SUBSCRIBE);
           setEnabled(true);
+          throw e;
         })
         .finally(() => {
           setIsNotificationLoading(false);
@@ -393,7 +408,6 @@ export const EventTypeCustomHealthCheckRow: React.FC<
                 setSelectedIndex(null);
               }}
               disabled={isNotificationLoading}
-              type="number"
               onBlur={handleCustomRatioButtonNewSubscription}
               value={customValue}
               placeholder="Custom"


### PR DESCRIPTION
1. If custom health value set as percentage in AP, card row always show invalid value

2. Percentage & integrate conversion not correct