### PR TITLE
MVP-3062: Throw error explicitly when failing subscribe alert

### DIFF
--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -435,7 +435,11 @@ export const useNotifiSubscribe: ({
           .find((f) => f?.filterType === filterType);
         if (filter === undefined || filter.id === null) {
           await deleteThisAlert();
-          return null;
+          throw new Error(
+            `No applicableFilters filter for sources: ${JSON.stringify(
+              sources,
+            )}`,
+          );
         } else {
           const sourceIds: string[] = [];
           const existingSourceGroup = data.sourceGroups.find(
@@ -629,19 +633,24 @@ export const useNotifiSubscribe: ({
 
         const config = configurations[name];
 
-        const alert = await updateAlertInternal(
-          {
-            alertName: name,
-            alertConfiguration: config,
-          },
-          data,
-          {
-            finalEmail,
-            finalPhoneNumber,
-            finalTelegramId,
-            finalDiscordId,
-          },
-        );
+        let alert = null;
+        try {
+          alert = await updateAlertInternal(
+            {
+              alertName: name,
+              alertConfiguration: config,
+            },
+            data,
+            {
+              finalEmail,
+              finalPhoneNumber,
+              finalTelegramId,
+              finalDiscordId,
+            },
+          );
+        } catch (e) {
+          console.log(`Error updating alert ${name}: ${e}`);
+        }
 
         if (alert !== null) {
           newResults[name] = alert;
@@ -775,7 +784,7 @@ export const useNotifiSubscribe: ({
           });
         }
       } catch (e) {
-        throw new Error('Something went wrong');
+        throw new Error(`Something went wrong: ${e}`);
       } finally {
         setLoading(false);
       }

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -520,7 +520,9 @@ export const useNotifiSubscribe: ({
           filter.id === null
         ) {
           await deleteThisAlert();
-          return null;
+          throw new Error(
+            `No applicableFilters filter for source: ${JSON.stringify(source)}`,
+          );
         } else if (
           existingAlert !== undefined &&
           existingAlert.id !== null &&


### PR DESCRIPTION
Sometimes, the alert subscription toggle pumps back to "unsubscribe" state after trying to subscribe w/o the reason. 
Throwing error in this case would help user (or dev) to get the hint.