### PR TITLE
MVP-3104: Default behavior with frontendClient. Optional API to switch back to hooks if needed

### DIFF
--- a/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/IntercomCard.tsx
@@ -63,21 +63,19 @@ export const IntercomCard: React.FC<
       targetGroupName: 'Intercom',
     });
 
-  const {
-    client,
-    canary: { isActive: isCanaryActive, frontendClient },
-  } = useNotifiClientContext();
+  const { client, isUsingFrontendClient, frontendClient } =
+    useNotifiClientContext();
 
   const { isClientInitialized, isClientAuthenticated } = useMemo(() => {
     return {
-      isClientInitialized: isCanaryActive
+      isClientInitialized: isUsingFrontendClient
         ? !!frontendClient.userState
         : isInitialized,
-      isClientAuthenticated: isCanaryActive
+      isClientAuthenticated: isUsingFrontendClient
         ? frontendClient.userState?.status === 'authenticated'
         : isAuthenticated,
     };
-  }, [isCanaryActive, client, frontendClient]);
+  }, [isUsingFrontendClient, client, frontendClient]);
 
   const subscribeAlert = useCallback(
     async (
@@ -86,7 +84,7 @@ export const IntercomCard: React.FC<
         inputs: Record<string, unknown>;
       }>,
     ): Promise<SubscriptionData> => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         return subscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({
@@ -95,7 +93,7 @@ export const IntercomCard: React.FC<
         });
       }
     },
-    [isCanaryActive, frontendClient],
+    [isUsingFrontendClient, frontendClient],
   );
 
   useEffect(() => {
@@ -131,7 +129,7 @@ export const IntercomCard: React.FC<
   } = formErrorMessages;
 
   const createSupportConversation = useCallback(() => {
-    if (isCanaryActive) {
+    if (isUsingFrontendClient) {
       return frontendClient
         .createSupportConversation(
           inputs as Types.CreateSupportConversationMutationVariables,

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeBroadcastRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeBroadcastRow.tsx
@@ -51,9 +51,7 @@ export const EventTypeBroadcastRow: React.FC<EventTypeBroadcastRowProps> = ({
   const { instantSubscribe } = useNotifiSubscribe({
     targetGroupName: 'Default',
   });
-  const {
-    canary: { isActive: isCanaryActive, frontendClient },
-  } = useNotifiClientContext();
+  const { isUsingFrontendClient, frontendClient } = useNotifiClientContext();
 
   const [enabled, setEnabled] = useState(false);
   const [isNotificationLoading, setIsNotificationLoading] =
@@ -84,7 +82,7 @@ export const EventTypeBroadcastRow: React.FC<EventTypeBroadcastRowProps> = ({
         inputs: Record<string, unknown>;
       }>,
     ): Promise<SubscriptionData> => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         return subscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({
@@ -93,7 +91,7 @@ export const EventTypeBroadcastRow: React.FC<EventTypeBroadcastRowProps> = ({
         });
       }
     },
-    [isCanaryActive, frontendClient, alertConfiguration],
+    [isUsingFrontendClient, frontendClient, alertConfiguration],
   );
 
   const unSubscribeAlert = useCallback(
@@ -103,7 +101,7 @@ export const EventTypeBroadcastRow: React.FC<EventTypeBroadcastRowProps> = ({
         inputs: Record<string, unknown>;
       }>,
     ) => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         return unsubscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({
@@ -112,7 +110,7 @@ export const EventTypeBroadcastRow: React.FC<EventTypeBroadcastRowProps> = ({
         });
       }
     },
-    [isCanaryActive, frontendClient, alertConfiguration],
+    [isUsingFrontendClient, frontendClient, alertConfiguration],
   );
 
   const tooltipContent = config.tooltipContent;
@@ -147,7 +145,7 @@ export const EventTypeBroadcastRow: React.FC<EventTypeBroadcastRowProps> = ({
           if (responseHasAlert !== true) {
             setEnabled(false);
           }
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch(() => {
           setEnabled(false);
@@ -170,7 +168,7 @@ export const EventTypeBroadcastRow: React.FC<EventTypeBroadcastRowProps> = ({
             }
           }
           // Else, ensured by frontendClient
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch(() => {
           setEnabled(false);

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeCustomHealthCheckRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeCustomHealthCheckRow.tsx
@@ -81,9 +81,7 @@ export const EventTypeCustomHealthCheckRow: React.FC<
     setCustomValue('$' + value);
   };
 
-  const {
-    canary: { isActive: isCanaryActive, frontendClient },
-  } = useNotifiClientContext();
+  const { isUsingFrontendClient, frontendClient } = useNotifiClientContext();
 
   const [enabled, setEnabled] = useState(false);
   // This indicates which box to select
@@ -171,7 +169,7 @@ export const EventTypeCustomHealthCheckRow: React.FC<
       }>,
       ratioNumber: number,
     ): Promise<SubscriptionData> => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         alertDetail.inputs[`${alertDetail.eventType.name}__healthRatio`] =
           ratioNumber;
         alertDetail.inputs[
@@ -200,7 +198,7 @@ export const EventTypeCustomHealthCheckRow: React.FC<
         });
       }
     },
-    [isCanaryActive, frontendClient],
+    [isUsingFrontendClient, frontendClient],
   );
 
   const unSubscribeAlert = useCallback(
@@ -210,7 +208,7 @@ export const EventTypeCustomHealthCheckRow: React.FC<
         inputs: Record<string, unknown>;
       }>,
     ) => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         return unsubscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({
@@ -219,7 +217,7 @@ export const EventTypeCustomHealthCheckRow: React.FC<
         });
       }
     },
-    [isCanaryActive, frontendClient],
+    [isUsingFrontendClient, frontendClient],
   );
 
   const handleCustomRatioButtonNewSubscription = () => {
@@ -261,7 +259,7 @@ export const EventTypeCustomHealthCheckRow: React.FC<
       subscribeAlert({ eventType: config, inputs }, ratioNumber)
         .then(() => {
           setSelectedIndex(3);
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch(() => setErrorMessage(UNABLE_TO_UNSUBSCRIBE))
         .finally(() => {
@@ -292,7 +290,7 @@ export const EventTypeCustomHealthCheckRow: React.FC<
     if (value) {
       subscribeAlert({ eventType: config, inputs }, value)
         .then(() => {
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
           setSelectedIndex(index);
           setCustomValue('');
         })
@@ -324,7 +322,7 @@ export const EventTypeCustomHealthCheckRow: React.FC<
           if (responseHasAlert !== true) {
             setEnabled(false);
           }
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch((e) => {
           setErrorMessage(UNABLE_TO_SUBSCRIBE);
@@ -346,7 +344,7 @@ export const EventTypeCustomHealthCheckRow: React.FC<
             }
           }
           // Else, ensured by frontendClient
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch((e) => {
           setErrorMessage(UNABLE_TO_SUBSCRIBE);

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeCustomToggleRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeCustomToggleRow.tsx
@@ -53,9 +53,7 @@ export const EventTypeCustomToggleRow: React.FC<
     targetGroupName: 'Default',
   });
 
-  const {
-    canary: { isActive: isCanaryActive, frontendClient },
-  } = useNotifiClientContext();
+  const { isUsingFrontendClient, frontendClient } = useNotifiClientContext();
 
   const [enabled, setEnabled] = useState(false);
   const [isNotificationLoading, setIsNotificationLoading] =
@@ -87,7 +85,7 @@ export const EventTypeCustomToggleRow: React.FC<
         inputs: Record<string, unknown>;
       }>,
     ): Promise<SubscriptionData> => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         return subscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({
@@ -105,7 +103,7 @@ export const EventTypeCustomToggleRow: React.FC<
         });
       }
     },
-    [isCanaryActive, frontendClient, config],
+    [isUsingFrontendClient, frontendClient, config],
   );
 
   const unSubscribeAlert = useCallback(
@@ -115,7 +113,7 @@ export const EventTypeCustomToggleRow: React.FC<
         inputs: Record<string, unknown>;
       }>,
     ) => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         return unsubscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({
@@ -124,7 +122,7 @@ export const EventTypeCustomToggleRow: React.FC<
         });
       }
     },
-    [isCanaryActive, frontendClient],
+    [isUsingFrontendClient, frontendClient],
   );
 
   const handleNewSubscription = useCallback(() => {
@@ -146,7 +144,7 @@ export const EventTypeCustomToggleRow: React.FC<
           if (responseHasAlert !== true) {
             setEnabled(false);
           }
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch(() => {
           setEnabled(false);
@@ -170,7 +168,7 @@ export const EventTypeCustomToggleRow: React.FC<
             }
           }
           // Else, ensured by frontendClient
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch(() => {
           setEnabled(true);

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeDirectPushRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeDirectPushRow.tsx
@@ -47,9 +47,7 @@ export const EventTypeDirectPushRow: React.FC<EventTypeDirectPushRowProps> = ({
   const { instantSubscribe } = useNotifiSubscribe({
     targetGroupName: 'Default',
   });
-  const {
-    canary: { isActive: isCanaryActive, frontendClient },
-  } = useNotifiClientContext();
+  const { isUsingFrontendClient, frontendClient } = useNotifiClientContext();
   const [enabled, setEnabled] = useState(false);
 
   const pushId = useMemo(
@@ -77,7 +75,7 @@ export const EventTypeDirectPushRow: React.FC<EventTypeDirectPushRowProps> = ({
         inputs: Record<string, unknown>;
       }>,
     ): Promise<SubscriptionData> => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         return subscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({
@@ -86,7 +84,7 @@ export const EventTypeDirectPushRow: React.FC<EventTypeDirectPushRowProps> = ({
         });
       }
     },
-    [isCanaryActive, frontendClient, alertConfiguration],
+    [isUsingFrontendClient, frontendClient, alertConfiguration],
   );
 
   const unSubscribeAlert = useCallback(
@@ -96,7 +94,7 @@ export const EventTypeDirectPushRow: React.FC<EventTypeDirectPushRowProps> = ({
         inputs: Record<string, unknown>;
       }>,
     ) => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         return unsubscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({
@@ -105,7 +103,7 @@ export const EventTypeDirectPushRow: React.FC<EventTypeDirectPushRowProps> = ({
         });
       }
     },
-    [isCanaryActive, frontendClient, alertConfiguration],
+    [isUsingFrontendClient, frontendClient, alertConfiguration],
   );
 
   useEffect(() => {
@@ -128,7 +126,7 @@ export const EventTypeDirectPushRow: React.FC<EventTypeDirectPushRowProps> = ({
       })
         .then(() => {
           setEnabled(true);
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch(() => setEnabled(false))
         .finally(() => setLoading(false));
@@ -139,7 +137,7 @@ export const EventTypeDirectPushRow: React.FC<EventTypeDirectPushRowProps> = ({
       })
         .then(() => {
           setEnabled(false);
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch(() => setEnabled(true))
         .finally(() => setLoading(false));

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeFusionHealthCheckRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeFusionHealthCheckRow.tsx
@@ -65,9 +65,7 @@ export const EventTypeFusionHealthCheckRow: React.FC<
   const { instantSubscribe } = useNotifiSubscribe({
     targetGroupName: 'Default',
   });
-  const {
-    canary: { isActive: isCanaryActive, frontendClient },
-  } = useNotifiClientContext();
+  const { isUsingFrontendClient, frontendClient } = useNotifiClientContext();
 
   const [enabled, setEnabled] = useState(false);
 
@@ -173,7 +171,7 @@ export const EventTypeFusionHealthCheckRow: React.FC<
       }>,
       ratioNumber: number,
     ): Promise<SubscriptionData> => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         alertDetail.inputs[`${alertDetail.eventType.name}__healthRatio`] =
           ratioNumber;
         alertDetail.inputs[
@@ -198,7 +196,7 @@ export const EventTypeFusionHealthCheckRow: React.FC<
         });
       }
     },
-    [isCanaryActive, frontendClient],
+    [isUsingFrontendClient, frontendClient],
   );
 
   const unSubscribeAlert = useCallback(
@@ -208,7 +206,7 @@ export const EventTypeFusionHealthCheckRow: React.FC<
         inputs: Record<string, unknown>;
       }>,
     ) => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         return unsubscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({
@@ -217,7 +215,7 @@ export const EventTypeFusionHealthCheckRow: React.FC<
         });
       }
     },
-    [isCanaryActive, frontendClient],
+    [isUsingFrontendClient, frontendClient],
   );
 
   const handleCustomRatioButtonNewSubscription = () => {
@@ -259,7 +257,7 @@ export const EventTypeFusionHealthCheckRow: React.FC<
       subscribeAlert({ eventType: config, inputs }, ratioNumber)
         .then(() => {
           setSelectedIndex(3);
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch(() => setErrorMessage(UNABLE_TO_UNSUBSCRIBE))
         .finally(() => {
@@ -290,7 +288,7 @@ export const EventTypeFusionHealthCheckRow: React.FC<
     if (value) {
       subscribeAlert({ eventType: config, inputs }, value)
         .then(() => {
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
           setSelectedIndex(index);
           setCustomValue('');
         })
@@ -322,7 +320,7 @@ export const EventTypeFusionHealthCheckRow: React.FC<
           if (responseHasAlert !== true) {
             setEnabled(false);
           }
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch((e) => {
           setErrorMessage(UNABLE_TO_SUBSCRIBE);
@@ -344,7 +342,7 @@ export const EventTypeFusionHealthCheckRow: React.FC<
             }
           }
           // Else, ensured by frontendClient
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch((e) => {
           setErrorMessage(UNABLE_TO_SUBSCRIBE);

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeFusionToggleRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeFusionToggleRow.tsx
@@ -50,9 +50,7 @@ export const EventTypeFusionToggleRow: React.FC<EventTypeFusionRowProps> = ({
   const { instantSubscribe } = useNotifiSubscribe({
     targetGroupName: 'Default',
   });
-  const {
-    canary: { isActive: isCanaryActive, frontendClient },
-  } = useNotifiClientContext();
+  const { isUsingFrontendClient, frontendClient } = useNotifiClientContext();
 
   const [enabled, setEnabled] = useState(false);
   const [isNotificationLoading, setIsNotificationLoading] =
@@ -91,7 +89,7 @@ export const EventTypeFusionToggleRow: React.FC<EventTypeFusionRowProps> = ({
         inputs: Record<string, unknown>;
       }>,
     ): Promise<SubscriptionData> => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         return subscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({
@@ -100,7 +98,7 @@ export const EventTypeFusionToggleRow: React.FC<EventTypeFusionRowProps> = ({
         });
       }
     },
-    [isCanaryActive, frontendClient, alertConfiguration],
+    [isUsingFrontendClient, frontendClient, alertConfiguration],
   );
 
   const unSubscribeAlert = useCallback(
@@ -110,7 +108,7 @@ export const EventTypeFusionToggleRow: React.FC<EventTypeFusionRowProps> = ({
         inputs: Record<string, unknown>;
       }>,
     ) => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         return unsubscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({
@@ -119,7 +117,7 @@ export const EventTypeFusionToggleRow: React.FC<EventTypeFusionRowProps> = ({
         });
       }
     },
-    [isCanaryActive, frontendClient, alertConfiguration],
+    [isUsingFrontendClient, frontendClient, alertConfiguration],
   );
 
   const tooltipContent = config.tooltipContent;
@@ -154,7 +152,7 @@ export const EventTypeFusionToggleRow: React.FC<EventTypeFusionRowProps> = ({
           if (responseHasAlert !== true) {
             setEnabled(false);
           }
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch(() => {
           setEnabled(false);
@@ -177,7 +175,7 @@ export const EventTypeFusionToggleRow: React.FC<EventTypeFusionRowProps> = ({
             }
           }
           // Else, ensured by frontendClient
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch(() => {
           setEnabled(false);

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeHealthCheckRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeHealthCheckRow.tsx
@@ -80,9 +80,7 @@ export const EventTypeHealthCheckRow: React.FC<
     setCustomValue(value + '%');
   };
 
-  const {
-    canary: { isActive: isCanaryActive, frontendClient },
-  } = useNotifiClientContext();
+  const { isUsingFrontendClient, frontendClient } = useNotifiClientContext();
 
   const [enabled, setEnabled] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
@@ -149,7 +147,7 @@ export const EventTypeHealthCheckRow: React.FC<
           | HealthCheckEventInputsWithCustomPercentage;
       }>,
     ): Promise<SubscriptionData> => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         return subscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({
@@ -166,7 +164,7 @@ export const EventTypeHealthCheckRow: React.FC<
         });
       }
     },
-    [isCanaryActive, frontendClient, config],
+    [isUsingFrontendClient, frontendClient, config],
   );
 
   const unSubscribeAlert = useCallback(
@@ -176,7 +174,7 @@ export const EventTypeHealthCheckRow: React.FC<
         inputs: Record<string, unknown>;
       }>,
     ) => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         return unsubscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({
@@ -185,7 +183,7 @@ export const EventTypeHealthCheckRow: React.FC<
         });
       }
     },
-    [isCanaryActive, frontendClient],
+    [isUsingFrontendClient, frontendClient],
   );
 
   const handleToggleNewSubscription = useCallback(() => {
@@ -202,7 +200,7 @@ export const EventTypeHealthCheckRow: React.FC<
         },
       })
         .then(() => {
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch(() => setErrorMessage(UNABLE_TO_SUBSCRIBE))
         .finally(() => setLoading(false));
@@ -213,7 +211,7 @@ export const EventTypeHealthCheckRow: React.FC<
       })
         .then(() => {
           setCustomValue('');
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch(() => setErrorMessage(UNABLE_TO_SUBSCRIBE))
         .finally(() => setLoading(false));
@@ -235,7 +233,7 @@ export const EventTypeHealthCheckRow: React.FC<
         .then(() => {
           setSelectedIndex(index);
           setCustomValue('');
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch(() => setErrorMessage(UNABLE_TO_SUBSCRIBE));
     } else {
@@ -266,7 +264,7 @@ export const EventTypeHealthCheckRow: React.FC<
         })
           .then(() => {
             setSelectedIndex(3);
-            isCanaryActive && frontendClient.fetchData().then(render);
+            isUsingFrontendClient && frontendClient.fetchData().then(render);
           })
           .catch(() => setErrorMessage(UNABLE_TO_SUBSCRIBE));
       } else {

--- a/packages/notifi-react-card/lib/components/subscription/EventTypePriceChangeRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypePriceChangeRow.tsx
@@ -53,9 +53,7 @@ export const EventTypePriceChangeRow: React.FC<
     targetGroupName: 'Default',
   });
 
-  const {
-    canary: { isActive: isCanaryActive, frontendClient },
-  } = useNotifiClientContext();
+  const { isUsingFrontendClient, frontendClient } = useNotifiClientContext();
 
   const [enabled, setEnabled] = useState(false);
   const [isNotificationLoading, setIsNotificationLoading] =
@@ -88,7 +86,7 @@ export const EventTypePriceChangeRow: React.FC<
         inputs: Record<string, unknown>;
       }>,
     ): Promise<SubscriptionData> => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         return subscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({
@@ -97,7 +95,7 @@ export const EventTypePriceChangeRow: React.FC<
         });
       }
     },
-    [isCanaryActive, frontendClient, config],
+    [isUsingFrontendClient, frontendClient, config],
   );
   const unSubscribeAlert = useCallback(
     async (
@@ -106,7 +104,7 @@ export const EventTypePriceChangeRow: React.FC<
         inputs: Record<string, unknown>;
       }>,
     ) => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         return unsubscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({
@@ -115,7 +113,7 @@ export const EventTypePriceChangeRow: React.FC<
         });
       }
     },
-    [isCanaryActive, frontendClient],
+    [isUsingFrontendClient, frontendClient],
   );
 
   const handleNewSubscription = useCallback(() => {
@@ -136,7 +134,7 @@ export const EventTypePriceChangeRow: React.FC<
           if (responseHasAlert !== true) {
             setEnabled(false);
           }
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch(() => {
           setEnabled(false);
@@ -159,7 +157,7 @@ export const EventTypePriceChangeRow: React.FC<
             }
           }
           // Else, ensured by frontendClient
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch(() => {
           setEnabled(false);

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeTradingPairsRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeTradingPairsRow.tsx
@@ -153,9 +153,7 @@ export const TradingPairAlertRow: React.FC<TradingPairAlertRowProps> = ({
     targetGroupName: 'Default',
   });
 
-  const {
-    canary: { isActive: isCanaryActive, frontendClient },
-  } = useNotifiClientContext();
+  const { isUsingFrontendClient, frontendClient } = useNotifiClientContext();
 
   const { name, description } = useMemo(() => {
     // const alertName = `${config.name}:;:${now}:;:${selectedPair}:;:${
@@ -176,7 +174,7 @@ export const TradingPairAlertRow: React.FC<TradingPairAlertRowProps> = ({
         inputs: Record<string, unknown>;
       }>,
     ) => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         return unsubscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({
@@ -185,7 +183,7 @@ export const TradingPairAlertRow: React.FC<TradingPairAlertRowProps> = ({
         });
       }
     },
-    [isCanaryActive, frontendClient],
+    [isUsingFrontendClient, frontendClient],
   );
 
   return (
@@ -222,7 +220,7 @@ export const TradingPairAlertRow: React.FC<TradingPairAlertRowProps> = ({
             } as EventTypeItem, // We only need alertName to unsubscribe
             inputs,
           }).then(() => {
-            isCanaryActive && frontendClient.fetchData().then(render);
+            isUsingFrontendClient && frontendClient.fetchData().then(render);
           });
         }}
       >
@@ -271,9 +269,7 @@ export const TradingPairSettingsRow: React.FC<TradingPairSettingsRowProps> = ({
   });
   const { render } = useNotifiSubscriptionContext();
 
-  const {
-    canary: { isActive: isCanaryActive, frontendClient },
-  } = useNotifiClientContext();
+  const { isUsingFrontendClient, frontendClient } = useNotifiClientContext();
 
   const alertConfiguration = useMemo(() => {
     return selectedPair
@@ -299,7 +295,7 @@ export const TradingPairSettingsRow: React.FC<TradingPairSettingsRowProps> = ({
       inputs: TradingPairInputs;
     }>,
   ): Promise<SubscriptionData> => {
-    if (isCanaryActive) {
+    if (isUsingFrontendClient) {
       return subscribeAlertByFrontendClient(frontendClient, alertDetail);
     }
     if (!alertConfiguration)

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeWalletBalanceRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeWalletBalanceRow.tsx
@@ -55,9 +55,7 @@ export const EventTypeWalletBalanceRow: React.FC<
     targetGroupName: 'Default',
   });
 
-  const {
-    canary: { isActive: isCanaryActive, frontendClient },
-  } = useNotifiClientContext();
+  const { isUsingFrontendClient, frontendClient } = useNotifiClientContext();
 
   const [enabled, setEnabled] = useState(false);
 
@@ -82,7 +80,7 @@ export const EventTypeWalletBalanceRow: React.FC<
         inputs: Record<string, unknown>;
       }>,
     ): Promise<SubscriptionData> => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         return subscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({
@@ -91,7 +89,7 @@ export const EventTypeWalletBalanceRow: React.FC<
         });
       }
     },
-    [isCanaryActive, frontendClient, config],
+    [isUsingFrontendClient, frontendClient, config],
   );
   const unSubscribeAlert = useCallback(
     async (
@@ -100,7 +98,7 @@ export const EventTypeWalletBalanceRow: React.FC<
         inputs: Record<string, unknown>;
       }>,
     ) => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         return unsubscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({
@@ -109,7 +107,7 @@ export const EventTypeWalletBalanceRow: React.FC<
         });
       }
     },
-    [isCanaryActive, frontendClient],
+    [isUsingFrontendClient, frontendClient],
   );
 
   const handleNewSubscription = useCallback(() => {
@@ -124,7 +122,7 @@ export const EventTypeWalletBalanceRow: React.FC<
         inputs,
       })
         .then(() => {
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
           setEnabled(true);
         })
         .catch(() => {
@@ -147,7 +145,7 @@ export const EventTypeWalletBalanceRow: React.FC<
             }
           }
           // Else, ensured by frontendClient
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch(() => {
           setEnabled(true);

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeXMTPRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeXMTPRow.tsx
@@ -52,9 +52,7 @@ export const EventTypeXMTPRow: React.FC<EventTypeXMPTRowProps> = ({
     targetGroupName: 'Default',
   });
 
-  const {
-    canary: { isActive: isCanaryActive, frontendClient },
-  } = useNotifiClientContext();
+  const { isUsingFrontendClient, frontendClient } = useNotifiClientContext();
 
   const alertName = useMemo<string>(() => config.name, [config]);
 
@@ -88,7 +86,7 @@ export const EventTypeXMTPRow: React.FC<EventTypeXMPTRowProps> = ({
         inputs: Record<string, unknown>;
       }>,
     ): Promise<SubscriptionData> => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         return subscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({
@@ -97,7 +95,7 @@ export const EventTypeXMTPRow: React.FC<EventTypeXMPTRowProps> = ({
         });
       }
     },
-    [isCanaryActive, frontendClient],
+    [isUsingFrontendClient, frontendClient],
   );
 
   const unSubscribeAlert = useCallback(
@@ -107,7 +105,7 @@ export const EventTypeXMTPRow: React.FC<EventTypeXMPTRowProps> = ({
         inputs: Record<string, unknown>;
       }>,
     ) => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         return unsubscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({
@@ -116,7 +114,7 @@ export const EventTypeXMTPRow: React.FC<EventTypeXMPTRowProps> = ({
         });
       }
     },
-    [isCanaryActive, frontendClient],
+    [isUsingFrontendClient, frontendClient],
   );
 
   const handleNewSubscription = useCallback(() => {
@@ -139,7 +137,7 @@ export const EventTypeXMTPRow: React.FC<EventTypeXMPTRowProps> = ({
           if (responseHasAlert !== true) {
             setEnabled(false);
           }
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch((e) => {
           console.log('Failed to subscribeAlert', e);
@@ -164,7 +162,7 @@ export const EventTypeXMTPRow: React.FC<EventTypeXMPTRowProps> = ({
             }
           }
           // Else, ensured by frontendClient
-          isCanaryActive && frontendClient.fetchData().then(render);
+          isUsingFrontendClient && frontendClient.fetchData().then(render);
         })
         .catch(() => {
           setEnabled(true);

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
@@ -51,7 +51,8 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
   const {
     client,
     params: { multiWallet },
-    canary: { isActive: isCanaryActive, frontendClient },
+    isUsingFrontendClient,
+    frontendClient,
   } = useNotifiClientContext();
 
   const {
@@ -91,7 +92,7 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
 
   const subscribeAlerts = useCallback(
     async (eventTypes: EventTypeConfig, inputs: Record<string, unknown>) => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         const data = await frontendClient.fetchData();
         let discordTarget = data.targetGroup?.[0]?.discordTargets?.find(
           (target) => target?.name === 'Default',
@@ -116,7 +117,7 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
       );
     },
     [
-      isCanaryActive,
+      isUsingFrontendClient,
       frontendClient,
       email,
       phoneNumber,
@@ -127,7 +128,7 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
 
   const renewTargetGroups = useCallback(
     async (targetGroup: TargetGroupData) => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         return frontendClient.ensureTargetGroup(targetGroup);
       }
       return updateTargetGroups();
@@ -138,7 +139,7 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
   const onClick = useCallback(async () => {
     let isFirstTimeUser = (client.data?.targetGroups?.length ?? 0) === 0;
     if (
-      isCanaryActive &&
+      isUsingFrontendClient &&
       frontendClient.userState?.status !== 'authenticated'
     ) {
       await frontendClient.logIn({
@@ -160,7 +161,7 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
         success = !!result;
       }
 
-      if (isCanaryActive && success) {
+      if (isUsingFrontendClient && success) {
         const newData = await frontendClient.fetchData();
         render(newData);
       }

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCard.tsx
@@ -93,13 +93,11 @@ export const NotifiSubscriptionCard: React.FC<
   const { isInitialized, reload, isAuthenticated } = useNotifiSubscribe({
     targetGroupName: 'Default',
   });
-  const {
-    canary: { isActive: canaryIsActive, frontendClient },
-  } = useNotifiClientContext();
+  const { isUsingFrontendClient, frontendClient } = useNotifiClientContext();
 
   const isClientInitialized = useMemo(() => {
-    return canaryIsActive ? !!frontendClient.userState : isInitialized;
-  }, [frontendClient.userState?.status, isInitialized, canaryIsActive]);
+    return isUsingFrontendClient ? !!frontendClient.userState : isInitialized;
+  }, [frontendClient.userState?.status, isInitialized, isUsingFrontendClient]);
 
   const { loading, render } = useNotifiSubscriptionContext();
 
@@ -118,7 +116,7 @@ export const NotifiSubscriptionCard: React.FC<
       if (!isClientInitialized || !isAuthenticated) {
         return;
       }
-      if (canaryIsActive) {
+      if (isUsingFrontendClient) {
         return frontendClient.fetchData().then(render);
       }
       reload();
@@ -128,7 +126,12 @@ export const NotifiSubscriptionCard: React.FC<
     return () => {
       window.removeEventListener('focus', handler);
     };
-  }, [isClientInitialized, isAuthenticated, canaryIsActive, frontendClient]);
+  }, [
+    isClientInitialized,
+    isAuthenticated,
+    isUsingFrontendClient,
+    frontendClient,
+  ]);
 
   switch (card.state) {
     case 'loading':

--- a/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
@@ -114,15 +114,13 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
     },
   );
 
-  const {
-    canary: { isActive: canaryIsActive, frontendClient },
-  } = useNotifiClientContext();
+  const { isUsingFrontendClient, frontendClient } = useNotifiClientContext();
 
   const { isClientTokenExpired, isClientAuthenticated } = useMemo(() => {
     let isClientInitialized = false;
     let isClientTokenExpired = false;
     let isClientAuthenticated = false;
-    if (canaryIsActive) {
+    if (isUsingFrontendClient) {
       isClientInitialized = !!frontendClient.userState;
       isClientTokenExpired = frontendClient.userState?.status === 'expired';
       isClientAuthenticated =
@@ -142,7 +140,7 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
     isTokenExpired,
     isInitialized,
     isAuthenticated,
-    canaryIsActive,
+    isUsingFrontendClient,
   ]);
 
   const isTargetsExist = useMemo(() => {

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/ExpiredTokenViewCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/ExpiredTokenViewCard.tsx
@@ -21,16 +21,14 @@ export const ExpiredTokenView: React.FC<ExpiredTokenViewCardProps> = ({
   classNames,
 }) => {
   const { logIn } = useNotifiSubscribe({ targetGroupName: 'Default' });
-  const {
-    canary: { isActive: isCanaryActive, frontendClient },
-    params,
-  } = useNotifiClientContext();
+  const { frontendClient, isUsingFrontendClient, params } =
+    useNotifiClientContext();
 
   const { setCardView } = useNotifiSubscriptionContext();
 
   const handleClick = async () => {
     let success = false;
-    const result = isCanaryActive
+    const result = isUsingFrontendClient
       ? await frontendClient.logIn({
           walletBlockchain: params.walletBlockchain,
           signMessage: params.signMessage,

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
@@ -68,21 +68,19 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
     ReadonlyArray<Types.NotificationHistoryEntryFragmentFragment>
   >([]);
 
-  const {
-    client,
-    canary: { isActive: isCanaryActive, frontendClient },
-  } = useNotifiClientContext();
+  const { client, isUsingFrontendClient, frontendClient } =
+    useNotifiClientContext();
 
   const { isClientInitialized, isClientAuthenticated } = useMemo(() => {
     return {
-      isClientInitialized: isCanaryActive
+      isClientInitialized: isUsingFrontendClient
         ? !!frontendClient.userState
         : client.isInitialized,
-      isClientAuthenticated: isCanaryActive
+      isClientAuthenticated: isUsingFrontendClient
         ? frontendClient.userState?.status === 'authenticated'
         : client.isAuthenticated,
     };
-  }, [isCanaryActive, client, frontendClient]);
+  }, [isUsingFrontendClient, client, frontendClient]);
 
   const getNotificationHistory = useCallback(
     async ({ first, after }: Types.GetNotificationHistoryQueryVariables) => {
@@ -90,7 +88,7 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
         return;
       }
       isQuerying.current = true;
-      const result = await (isCanaryActive
+      const result = await (isUsingFrontendClient
         ? frontendClient
         : client
       ).getNotificationHistory({
@@ -110,7 +108,7 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
     [
       client,
       frontendClient,
-      isCanaryActive,
+      isUsingFrontendClient,
       setAllNodes,
       setEndCursor,
       setHasNextPage,
@@ -128,7 +126,7 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
         first: MESSAGES_PER_PAGE,
       });
     }
-  }, [client, frontendClient, isCanaryActive]);
+  }, [client, frontendClient, isUsingFrontendClient]);
   return (
     <div
       className={clsx(

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/VerifyWalletView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/VerifyWalletView.tsx
@@ -55,9 +55,7 @@ const VerifyWalletView: React.FC<VerifyWalletViewProps> = ({
   const { subscribe, updateWallets } = useNotifiSubscribe({
     targetGroupName: 'Default',
   });
-  const {
-    canary: { isActive: isCanaryActive, frontendClient },
-  } = useNotifiClientContext();
+  const { isUsingFrontendClient, frontendClient } = useNotifiClientContext();
 
   const targetGroup = useMemo(
     () => ({
@@ -75,7 +73,7 @@ const VerifyWalletView: React.FC<VerifyWalletViewProps> = ({
 
   const subscribeAlerts = useCallback(
     async (eventTypes: EventTypeConfig, inputs: Record<string, unknown>) => {
-      if (isCanaryActive) {
+      if (isUsingFrontendClient) {
         await frontendClient.ensureTargetGroup(targetGroup);
         return subscribeAlertsByFrontendClient(
           frontendClient,
@@ -88,7 +86,7 @@ const VerifyWalletView: React.FC<VerifyWalletViewProps> = ({
       );
     },
     [
-      isCanaryActive,
+      isUsingFrontendClient,
       frontendClient,
       email,
       phoneNumber,
@@ -98,11 +96,11 @@ const VerifyWalletView: React.FC<VerifyWalletViewProps> = ({
     ],
   );
   const renewWallets = useCallback(async () => {
-    if (isCanaryActive) {
+    if (isUsingFrontendClient) {
       return frontendClient.updateWallets();
     }
     return updateWallets();
-  }, [isCanaryActive, frontendClient, updateWallets]);
+  }, [isUsingFrontendClient, frontendClient, updateWallets]);
 
   const onClick = useCallback(async () => {
     if (cardView.state === 'verifyonboarding') {

--- a/packages/notifi-react-card/lib/context/NotifiClientContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiClientContext.tsx
@@ -10,10 +10,8 @@ import { NotifiParams } from './NotifiContext';
 
 export type NotifiClientContextData = Readonly<{
   client: ReturnType<typeof useNotifiClient>;
-  canary: {
-    isActive: boolean;
-    frontendClient: NotifiFrontendClient;
-  };
+  frontendClient: NotifiFrontendClient;
+  isUsingFrontendClient: boolean;
   params: NotifiParams;
 }>;
 
@@ -67,7 +65,8 @@ export const NotifiClientContextProvider: React.FC<NotifiParams> = ({
       value={{
         client,
         params,
-        canary: { isActive: params.enableCanary ?? false, frontendClient },
+        isUsingFrontendClient: params.isUsingFrontendClient ?? true,
+        frontendClient,
       }}
     >
       {children}

--- a/packages/notifi-react-card/lib/context/NotifiContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiContext.tsx
@@ -134,7 +134,7 @@ export type NotifiParams = Readonly<{
   env: NotifiEnvironment;
   keepSubscriptionData?: boolean;
   multiWallet?: MultiWalletParams;
-  enableCanary?: boolean;
+  isUsingFrontendClient?: boolean; // default is true
 }> &
   WalletParams;
 

--- a/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
@@ -98,9 +98,7 @@ const hasKey = <K extends string>(
 export const NotifiSubscriptionContextProvider: React.FC<
   PropsWithChildren<NotifiParams>
 > = ({ children, ...params }) => {
-  const {
-    canary: { isActive: isCanaryActive, frontendClient },
-  } = useNotifiClientContext();
+  const { frontendClient, isUsingFrontendClient } = useNotifiClientContext();
 
   const contextId = useMemo(() => {
     return new Date().toISOString();
@@ -190,7 +188,7 @@ export const NotifiSubscriptionContextProvider: React.FC<
     if (
       !didFetch.current &&
       frontendClient.userState?.status === 'authenticated' &&
-      isCanaryActive
+      isUsingFrontendClient
     ) {
       frontendClient
         .fetchData()

--- a/packages/notifi-react-card/lib/hooks/useIntercomCard.ts
+++ b/packages/notifi-react-card/lib/hooks/useIntercomCard.ts
@@ -26,15 +26,13 @@ export const useIntercomCard = (cardId: string): IntercomCardState => {
     state: 'loading',
   });
 
-  const {
-    client,
-    canary: { isActive: isCanaryEnabled, frontendClient },
-  } = useNotifiClientContext();
+  const { client, isUsingFrontendClient, frontendClient } =
+    useNotifiClientContext();
 
   useEffect(() => {
     setState({ state: 'loading' });
     let card: IntercomCardConfigItemV1 | undefined;
-    (isCanaryEnabled ? frontendClient : client)
+    (isUsingFrontendClient ? frontendClient : client)
       .fetchSubscriptionCard({
         type: 'INTERCOM_CARD',
         id: cardId,

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -305,7 +305,11 @@ export const useNotifiSubscribe: ({
       setUseDiscord(true);
     }
 
-    if (client.isAuthenticated && !didFetch.current && !params.enableCanary) {
+    if (
+      client.isAuthenticated &&
+      !didFetch.current &&
+      !params.isUsingFrontendClient
+    ) {
       didFetch.current = true;
       client
         .fetchData()

--- a/packages/notifi-react-card/lib/hooks/useSubscriptionCard.ts
+++ b/packages/notifi-react-card/lib/hooks/useSubscriptionCard.ts
@@ -36,15 +36,13 @@ export const useSubscriptionCard = (
     state: 'loading',
   });
   const { demoPreview } = useNotifiDemoPreviewContext();
-  const {
-    client,
-    canary: { isActive: isCanaryEnabled, frontendClient },
-  } = useNotifiClientContext();
+  const { client, isUsingFrontendClient, frontendClient } =
+    useNotifiClientContext();
 
   useEffect(() => {
     setState({ state: 'loading' });
     let card: CardConfigItemV1 | undefined;
-    (isCanaryEnabled ? frontendClient : client)
+    (isUsingFrontendClient ? frontendClient : client)
       .fetchSubscriptionCard(input)
       .then((result) => {
         if ('dataJson' in result) {
@@ -78,7 +76,7 @@ export const useSubscriptionCard = (
           });
         }
       });
-  }, [input.id, input.type, demoPreview, isCanaryEnabled]);
+  }, [input.id, input.type, demoPreview, isUsingFrontendClient]);
 
   return state;
 };


### PR DESCRIPTION
Change the card to use frontend-client as default.
It can be switched back to using hooks by passing in `isUsingFrontendClient=false` (default is true).