### PR TITLE
MVP-3105: Migrate type def from notifi-core to notifi-graphql

### DIFF
--- a/packages/notifi-react-card/lib/components/WalletList/ConnectWalletRow.tsx
+++ b/packages/notifi-react-card/lib/components/WalletList/ConnectWalletRow.tsx
@@ -1,7 +1,5 @@
-import {
-  ConnectedWallet,
-  WalletWithSignParams,
-} from '@notifi-network/notifi-core';
+import { WalletWithSignParams } from '@notifi-network/notifi-frontend-client';
+import { Types } from '@notifi-network/notifi-graphql';
 import { GqlError } from '@notifi-network/notifi-react-hooks';
 import { addressEllipsis } from 'notifi-react-card/lib/utils/stringUtils';
 import React, { useCallback, useMemo, useState } from 'react';
@@ -10,7 +8,7 @@ import { useNotifiSubscribe } from '../../hooks';
 
 export type ConnectWalletRowProps = WalletWithSignParams &
   Readonly<{
-    connectedWallets: ReadonlyArray<ConnectedWallet>;
+    connectedWallets: ReadonlyArray<Types.ConnectedWalletFragmentFragment>;
     disabled: boolean;
   }>;
 

--- a/packages/notifi-react-card/lib/components/WalletList/WalletList.tsx
+++ b/packages/notifi-react-card/lib/components/WalletList/WalletList.tsx
@@ -1,4 +1,4 @@
-import { WalletWithSignParams } from '@notifi-network/notifi-core';
+import { WalletWithSignParams } from '@notifi-network/notifi-frontend-client';
 import { Types } from '@notifi-network/notifi-graphql';
 import React from 'react';
 

--- a/packages/notifi-react-card/lib/components/intercom/MessageGroup.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/MessageGroup.tsx
@@ -1,7 +1,7 @@
+import { Types } from '@notifi-network/notifi-graphql';
 import clsx from 'clsx';
 import React from 'react';
 
-import { ChatMessage } from '../../hooks/useIntercomChat';
 import { formatHourTimestamp } from '../../utils/datetimeUtils';
 
 export type MessageGroupProps = Readonly<{
@@ -12,7 +12,7 @@ export type MessageGroupProps = Readonly<{
     timeStamp: string;
     sender: string;
   }>;
-  messages: ChatMessage[];
+  messages: Types.ConversationMessageFragment[];
   direction: string;
 }>;
 export const MessageGroup: React.FC<MessageGroupProps> = ({

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeCustomHealthCheckRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeCustomHealthCheckRow.tsx
@@ -1,4 +1,4 @@
-import { ThresholdDirection } from '@notifi-network/notifi-core';
+import { ThresholdDirection } from '@notifi-network/notifi-frontend-client';
 import {
   CustomTopicTypeItem,
   EventTypeItem,

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeHealthCheckRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeHealthCheckRow.tsx
@@ -1,4 +1,4 @@
-import { ThresholdDirection } from '@notifi-network/notifi-core';
+import { ThresholdDirection } from '@notifi-network/notifi-frontend-client';
 import {
   EventTypeItem,
   HealthCheckEventInputsWithCustomPercentage,

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeWalletBalanceRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeWalletBalanceRow.tsx
@@ -86,9 +86,7 @@ export const EventTypeWalletBalanceRow: React.FC<
         return subscribeAlertByFrontendClient(frontendClient, alertDetail);
       } else {
         return instantSubscribe({
-          alertConfiguration: walletBalanceConfiguration({
-            connectedWallets,
-          }),
+          alertConfiguration: walletBalanceConfiguration({ connectedWallets }),
           alertName: alertName,
         });
       }

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
@@ -1,4 +1,4 @@
-import { SignMessageParams } from '@notifi-network/notifi-core';
+import { SignMessageParams } from '@notifi-network/notifi-frontend-client';
 import {
   CardConfigItemV1,
   EventTypeConfig,

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/ExpiredTokenViewCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/ExpiredTokenViewCard.tsx
@@ -1,4 +1,4 @@
-import { SignMessageParams } from '@notifi-network/notifi-core';
+import { SignMessageParams } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import {
   useNotifiClientContext,

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
@@ -1,4 +1,3 @@
-import { GetNotificationHistoryInput } from '@notifi-network/notifi-core';
 import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
 import { Types } from '@notifi-network/notifi-graphql';
 import clsx from 'clsx';
@@ -86,7 +85,7 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
   }, [isCanaryActive, client, frontendClient]);
 
   const getNotificationHistory = useCallback(
-    async ({ first, after }: GetNotificationHistoryInput) => {
+    async ({ first, after }: Types.GetNotificationHistoryQueryVariables) => {
       if (isQuerying.current) {
         return;
       }

--- a/packages/notifi-react-card/lib/context/NotifiContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiContext.tsx
@@ -1,4 +1,4 @@
-import { WalletWithSignParams } from '@notifi-network/notifi-core';
+import { WalletWithSignParams } from '@notifi-network/notifi-frontend-client';
 import {
   AcalaSignMessageFunction,
   AptosSignMessageFunction,

--- a/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
@@ -1,9 +1,3 @@
-import {
-  Alert,
-  ConnectedWallet,
-  DiscordTarget,
-  DiscordTargetStatus,
-} from '@notifi-network/notifi-core';
 import { Types } from '@notifi-network/notifi-graphql';
 import { PropsWithChildren, useMemo } from 'react';
 import React, {
@@ -37,10 +31,10 @@ import {
 export type DestinationErrorMessages = DestinationErrors;
 
 export type NotifiSubscriptionData = Readonly<{
-  alerts: Readonly<Record<string, Alert | undefined>>;
-  connectedWallets: ReadonlyArray<ConnectedWallet>;
+  alerts: Readonly<Record<string, Types.AlertFragmentFragment | undefined>>;
+  connectedWallets: ReadonlyArray<Types.ConnectedWalletFragmentFragment>;
   setConnectedWallets: React.Dispatch<
-    React.SetStateAction<ReadonlyArray<ConnectedWallet>>
+    React.SetStateAction<ReadonlyArray<Types.ConnectedWalletFragmentFragment>>
   >;
   destinationErrorMessages: DestinationErrorMessages;
   email: string;
@@ -58,7 +52,9 @@ export type NotifiSubscriptionData = Readonly<{
   setCardView: React.Dispatch<React.SetStateAction<FetchedCardViewState>>;
   intercomCardView: IntercomCardView;
   setIntercomCardView: React.Dispatch<React.SetStateAction<IntercomCardView>>;
-  setAlerts: (alerts: Record<string, Alert | undefined>) => void;
+  setAlerts: (
+    alerts: Record<string, Types.AlertFragmentFragment | undefined>,
+  ) => void;
   setEmail: (email: string) => void;
   setPhoneNumber: (phoneNumber: string) => void;
   setTelegramId: (telegramId: string) => void;
@@ -81,9 +77,9 @@ export type NotifiSubscriptionData = Readonly<{
   setTelegramErrorMessage: (value: DestinationError) => void;
   resetErrorMessageState: () => void;
 
-  discordTargetData: DiscordTarget | undefined;
+  discordTargetData: Types.DiscordTargetFragmentFragment | undefined;
   setDiscordTargetData: React.Dispatch<
-    React.SetStateAction<DiscordTarget | undefined>
+    React.SetStateAction<Types.DiscordTargetFragmentFragment | undefined>
   >;
   render: (newData: Types.FetchDataQuery) => SubscriptionData;
 }>;
@@ -121,9 +117,11 @@ export const NotifiSubscriptionContextProvider: React.FC<
     string | undefined
   >(undefined);
 
-  const [alerts, setAlerts] = useState<Record<string, Alert | undefined>>({});
+  const [alerts, setAlerts] = useState<
+    Record<string, Types.AlertFragmentFragment | undefined>
+  >({});
   const [connectedWallets, setConnectedWallets] = useState<
-    ReadonlyArray<ConnectedWallet>
+    ReadonlyArray<Types.ConnectedWalletFragmentFragment>
   >([]);
   const [useHardwareWallet, setUseHardwareWallet] = useState<boolean>(false);
   const [useDiscord, setUseDiscord] = useState<boolean>(false);
@@ -134,7 +132,7 @@ export const NotifiSubscriptionContextProvider: React.FC<
   const [telegramId, setTelegramId] = useState<string>('');
 
   const [discordTargetData, setDiscordTargetData] = useState<
-    DiscordTarget | undefined
+    Types.DiscordTargetFragmentFragment | undefined
   >(undefined);
 
   const [destinationErrorMessages, setDestinationErrorMessages] =
@@ -245,7 +243,7 @@ export const NotifiSubscriptionContextProvider: React.FC<
       const targetGroup = newData.targetGroup?.find(
         (tg) => tg?.name === 'Default',
       );
-      const alerts: Record<string, Alert> = {};
+      const alerts: Record<string, Types.AlertFragmentFragment> = {};
       newData.alert?.forEach((alert) => {
         if (alert?.name) {
           alerts[alert.name] = alert;
@@ -334,9 +332,7 @@ export const NotifiSubscriptionContextProvider: React.FC<
             onClick: () => window.open(verificationLink, '_blank'),
             message: 'Enable Bot',
           });
-        } else if (
-          userStatus === DiscordTargetStatus.DISCORD_SERVER_NOT_JOINED
-        ) {
+        } else if (userStatus === 'DISCORD_SERVER_NOT_JOINED') {
           setDiscordErrorMessage({
             type: 'recoverableError',
             onClick: () => window.open(DISCORD_INVITE_URL, '_blank'),

--- a/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
+++ b/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
@@ -1,9 +1,9 @@
 // TODO: Import from library rather than copy / paste
 import {
   AlertFrequency,
-  CreateSourceInput,
   FilterOptions,
-} from '@notifi-network/notifi-core';
+} from '@notifi-network/notifi-frontend-client';
+import { Types } from '@notifi-network/notifi-graphql';
 
 export type ValueOrRef<ValueType> =
   | Readonly<{
@@ -131,7 +131,7 @@ export type CustomTypeBase = {
   type: 'custom';
   name: string;
   tooltipContent: string;
-  sourceType: CreateSourceInput['type'];
+  sourceType: Types.CreateSourceInput['type'];
   filterType: string;
   sourceAddress: ValueOrRef<string>;
 };
@@ -140,7 +140,7 @@ export type XMTPTopicTypeItem = {
   type: 'XMTP';
   name: string;
   tooltipContent: string;
-  sourceType?: CreateSourceInput['type'];
+  sourceType?: Types.CreateSourceInput['type'];
   filterType: string;
   XMTPTopics: ValueOrRef<ReadonlyArray<string>>;
 };

--- a/packages/notifi-react-card/lib/hooks/useIntercomChat.ts
+++ b/packages/notifi-react-card/lib/hooks/useIntercomChat.ts
@@ -1,4 +1,4 @@
-import { ConversationMessagesEntry } from '@notifi-network/notifi-core';
+import { Types } from '@notifi-network/notifi-graphql';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ListRange } from 'react-virtuoso';
 
@@ -8,14 +8,12 @@ import {
   sortByDate,
 } from '../utils/datetimeUtils';
 
-export type ChatMessage = ConversationMessagesEntry;
-
 type MessageDirection = 'INCOMING' | 'OUTGOING';
 
 type MessagesBlockFeedEntry = Readonly<{
   type: 'MESSAGES_BLOCK';
   direction: MessageDirection;
-  messages: ChatMessage[];
+  messages: Types.ConversationMessageFragment[];
 }>;
 
 export type FeedEntry = {
@@ -35,9 +33,9 @@ export const useIntercomChat = ({
   conversationId,
   userId,
 }: UseIntercomChatProps) => {
-  const [chatMessages, setChatMessages] = useState<ConversationMessagesEntry[]>(
-    [],
-  );
+  const [chatMessages, setChatMessages] = useState<
+    Types.ConversationMessageFragment[]
+  >([]);
   const [endCursor, setEndCursor] = useState<string | undefined>();
   const [hasNextPage, setHasNextPage] = useState<boolean | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -121,9 +119,9 @@ export const useIntercomChat = ({
 
   const conversation = useMemo(() => {
     //put the conversation into message group
-    const messageGroups: ChatMessage[][] = [];
+    const messageGroups: Types.ConversationMessageFragment[][] = [];
 
-    let messages: ChatMessage[] = [];
+    let messages: Types.ConversationMessageFragment[] = [];
 
     chatMessages?.forEach((message, index) => {
       const nextMessage = chatMessages[index + 1];

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -1,10 +1,4 @@
-import {
-  Alert,
-  ClientData,
-  ConnectWalletParams,
-  DiscordTarget,
-  DiscordTargetStatus,
-} from '@notifi-network/notifi-core';
+import { ConnectWalletParams } from '@notifi-network/notifi-frontend-client';
 import { Types } from '@notifi-network/notifi-graphql';
 import { isValidPhoneNumber } from 'libphonenumber-js';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -24,8 +18,21 @@ import { walletToSource } from '../utils/walletUtils';
 import { useNotifiForm } from './../context/NotifiFormContext';
 import { AlertConfiguration } from './../utils/AlertConfiguration';
 
+export type ClientData = Readonly<{
+  alerts: ReadonlyArray<Types.AlertFragmentFragment>;
+  connectedWallets: ReadonlyArray<Types.ConnectedWallet>;
+  emailTargets: ReadonlyArray<Types.EmailTargetFragmentFragment>;
+  filters: ReadonlyArray<Types.FilterFragmentFragment>;
+  smsTargets: ReadonlyArray<Types.SmsTargetFragmentFragment>;
+  sources: ReadonlyArray<Types.SourceFragmentFragment>;
+  targetGroups: ReadonlyArray<Types.TargetGroupFragmentFragment>;
+  telegramTargets: ReadonlyArray<Types.TelegramTargetFragmentFragment>;
+  sourceGroups: ReadonlyArray<Types.SourceGroupFragmentFragment>;
+  discordTargets: ReadonlyArray<Types.DiscordTargetFragmentFragment>;
+}>;
+
 export type SubscriptionData = Readonly<{
-  alerts: Readonly<Record<string, Alert>>;
+  alerts: Readonly<Record<string, Types.AlertFragmentFragment>>;
   email: string | null;
   phoneNumber: string | null;
   telegramId: string | null;
@@ -124,7 +131,7 @@ export const useNotifiSubscribe: ({
   );
 
   const handleMissingDiscordTarget = (
-    discordTargets: ReadonlyArray<DiscordTarget>,
+    discordTargets: ReadonlyArray<Types.DiscordTargetFragmentFragment>,
   ): void => {
     // Check for a confirmed discord target, and if none exists, use the first discord target.
     const target =
@@ -139,7 +146,7 @@ export const useNotifiSubscribe: ({
         (tg) => tg.name === targetGroupName,
       );
 
-      const alerts: Record<string, Alert> = {};
+      const alerts: Record<string, Types.AlertFragmentFragment> = {};
       newData?.alerts.forEach((alert) => {
         if (alert?.name) {
           alerts[alert.name] = alert;
@@ -226,9 +233,7 @@ export const useNotifiSubscribe: ({
             onClick: () => window.open(verificationLink, '_blank'),
             message: 'Enable Bot',
           });
-        } else if (
-          userStatus === DiscordTargetStatus.DISCORD_SERVER_NOT_JOINED
-        ) {
+        } else if (userStatus === 'DISCORD_SERVER_NOT_JOINED') {
           setDiscordErrorMessage({
             type: 'recoverableError',
             onClick: () => window.open(DISCORD_INVITE_URL, '_blank'),
@@ -382,7 +387,7 @@ export const useNotifiSubscribe: ({
         finalTelegramId: string | undefined;
         finalDiscordId: string | undefined;
       }>,
-    ): Promise<Alert | null> => {
+    ): Promise<Types.AlertFragmentFragment | null> => {
       if (demoPreview) throw Error('Preview card does not support method call');
       const { alertName, alertConfiguration } = alertParams;
       const { finalEmail, finalPhoneNumber, finalTelegramId, finalDiscordId } =
@@ -629,7 +634,7 @@ export const useNotifiSubscribe: ({
         }
       }
 
-      const newResults: Record<string, Alert> = {};
+      const newResults: Record<string, Types.AlertFragmentFragment> = {};
       for (let i = 0; i < names.length; ++i) {
         const name = names[i];
 

--- a/packages/notifi-react-card/lib/hooks/useSubscriptionCard.ts
+++ b/packages/notifi-react-card/lib/hooks/useSubscriptionCard.ts
@@ -1,5 +1,5 @@
-import { ClientFetchSubscriptionCardInput } from '@notifi-network/notifi-core';
 import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
+import { Types } from '@notifi-network/notifi-graphql';
 import { useEffect, useState } from 'react';
 
 import {
@@ -7,6 +7,11 @@ import {
   useNotifiDemoPreviewContext,
 } from '../context';
 import { ErrorViewState } from './useFetchedCardState';
+
+type ClientFetchSubscriptionCardInput = Omit<
+  Types.FindTenantConfigInput,
+  'tenant'
+>;
 
 export type LoadingState = Readonly<{
   state: 'loading';
@@ -47,8 +52,8 @@ export const useSubscriptionCard = (
             return Promise.reject(new Error('Failed to fetch data'));
           }
           card = JSON.parse(result.dataJson);
-        } else if ('version' in result) {
-          card = result as CardConfigItemV1; // TODO: Remove type casting after (MVP-2557)
+        } else if ('version' in result && result.version !== 'IntercomV1') {
+          card = result;
         }
 
         if (card?.version !== 'v1') {

--- a/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
+++ b/packages/notifi-react-card/lib/utils/AlertConfiguration.ts
@@ -1,5 +1,7 @@
-import type { FilterOptions } from '@notifi-network/notifi-core';
-import { EventTypeConfig } from '@notifi-network/notifi-frontend-client';
+import {
+  EventTypeConfig,
+  FilterOptions,
+} from '@notifi-network/notifi-frontend-client';
 import type { Types } from '@notifi-network/notifi-graphql';
 
 import { resolveStringRef } from '../components/subscription/resolveRef';

--- a/packages/notifi-react-card/lib/utils/NotificationHistoryUtils.tsx
+++ b/packages/notifi-react-card/lib/utils/NotificationHistoryUtils.tsx
@@ -1,10 +1,3 @@
-import {
-  AccountBalanceChangedEventDetails,
-  BroadcastMessageEventDetails,
-  ChatMessageReceivedEventDetails,
-  GenericEventDetails,
-  HealthValueOverThresholdEventDetails,
-} from '@notifi-network/notifi-core';
 import { Types } from '@notifi-network/notifi-graphql';
 import React from 'react';
 
@@ -15,6 +8,31 @@ import { SwapIcon } from '../assets/SwapIcon';
 import { AlertIcon } from '../components/AlertHistory/AlertIcon';
 import { AlertNotificationViewProps } from '../components/AlertHistory/AlertNotificationRow';
 import { formatAmount } from './AlertHistoryUtils';
+
+type AccountBalanceChangedEventDetails = Extract<
+  Types.NotificationHistoryEntryFragmentFragment['detail'],
+  { __typename: 'AccountBalanceChangedEventDetails' }
+>;
+
+type BroadcastMessageEventDetails = Extract<
+  Types.NotificationHistoryEntryFragmentFragment['detail'],
+  { __typename: 'BroadcastMessageEventDetails' }
+>;
+
+type ChatMessageReceivedEventDetails = Extract<
+  Types.NotificationHistoryEntryFragmentFragment['detail'],
+  { __typename: 'ChatMessageReceivedEventDetails' }
+>;
+
+type HealthValueOverThresholdEventDetails = Extract<
+  Types.NotificationHistoryEntryFragmentFragment['detail'],
+  { __typename: 'HealthValueOverThresholdEventDetails' }
+>;
+
+type GenericEventDetails = Extract<
+  Types.NotificationHistoryEntryFragmentFragment['detail'],
+  { __typename: 'GenericEventDetails' }
+>;
 
 type AlertDetailsContents = {
   topContent: string;

--- a/packages/notifi-react-card/lib/utils/frontendClient.ts
+++ b/packages/notifi-react-card/lib/utils/frontendClient.ts
@@ -1,9 +1,9 @@
-import { Alert } from '@notifi-network/notifi-core';
 import {
   EventTypeConfig,
   EventTypeItem,
   NotifiFrontendClient,
 } from '@notifi-network/notifi-frontend-client';
+import { Types } from '@notifi-network/notifi-graphql';
 
 import { SubscriptionData } from '../hooks';
 
@@ -26,7 +26,7 @@ export const subscribeAlertByFrontendClient = async (
     name: updatedTgs[0]?.name ?? '',
   };
 
-  const alerts: Record<string, Alert> = {};
+  const alerts: Record<string, Types.AlertFragmentFragment> = {};
 
   updatedData.alert?.forEach((alert) => {
     if (alert && alert.name) {
@@ -87,7 +87,7 @@ export const subscribeAlertsByFrontendClient = async (
     name: updatedTgs[0]?.name ?? '',
   };
 
-  const alerts: Record<string, Alert> = {};
+  const alerts: Record<string, Types.AlertFragmentFragment> = {};
 
   updatedData.alert?.forEach((alert) => {
     if (alert && alert.name) {

--- a/packages/notifi-react-card/lib/utils/walletUtils.ts
+++ b/packages/notifi-react-card/lib/utils/walletUtils.ts
@@ -1,12 +1,9 @@
-import {
-  ConnectedWallet,
-  CreateSourceInput,
-} from '@notifi-network/notifi-core';
+import { Types } from '@notifi-network/notifi-graphql';
 
 export const walletToSourceType = (
-  wallet: ConnectedWallet,
-): CreateSourceInput['type'] => {
-  switch (wallet.walletBlockchain) {
+  wallet: Types.ConnectedWallet,
+): Types.CreateSourceInput['type'] => {
+  switch (wallet?.walletBlockchain) {
     case 'ACALA':
       return 'ACALA_WALLET';
     case 'APTOS':
@@ -35,15 +32,17 @@ export const walletToSourceType = (
 };
 
 export const walletToSourceAddress = (
-  wallet: ConnectedWallet,
-): CreateSourceInput['blockchainAddress'] => {
-  if (wallet.address === null) {
+  wallet: Types.ConnectedWalletFragmentFragment,
+): Types.CreateSourceInput['blockchainAddress'] => {
+  if (wallet?.address === null) {
     throw new Error('Invalid connected wallet');
   }
-  return wallet.address;
+  return wallet?.address;
 };
 
-export const walletToSource = (wallet: ConnectedWallet): CreateSourceInput => {
+export const walletToSource = (
+  wallet: Types.ConnectedWalletFragmentFragment,
+): Types.CreateSourceInput => {
   const sourceAddress = walletToSourceAddress(wallet);
   const sourceType = walletToSourceType(wallet);
 


### PR DESCRIPTION
We do not need to use type defs in notifi-core anymore since notifi-graphql introduces 1:1 replacement. 
This PR replace all type defs `import xx from 'notifi-core'` with `import xx from notifi-graphql`