### PR TITLE
MVP-3163: Alert History line break issues

### DIFF
--- a/packages/notifi-react-card/lib/components/AlertHistory/AlertDetailsCard.tsx
+++ b/packages/notifi-react-card/lib/components/AlertHistory/AlertDetailsCard.tsx
@@ -36,11 +36,7 @@ export const AlertDetailsCard: React.FC<AlertDetailsProps> = ({
         </div>
       </div>
       <div className={clsx('NotifiAlertDetails__bottomContent')}>
-        <div>
-          {detailsContents.bottomContent.split('\n').map((content, index) => {
-            return <div key={index}>{content}</div>;
-          })}
-        </div>
+        <div>{detailsContents.bottomContent}</div>
         <div>{detailsContents.otherContent}</div>
       </div>
     </div>

--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -378,7 +378,7 @@ input::-webkit-inner-spin-button {
   line-height: 14px;
   color: var(--notifi-font-color);
   overflow: hidden;
-  white-space: pre-line;
+  white-space: pre-wrap;
   word-wrap: break-word;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -985,13 +985,20 @@ input::-webkit-inner-spin-button {
   text-align: start;
   font-weight: 700;
   font-size: 16px;
-  overflow-wrap: break-word;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .NotifiAlertDetails__bottomContent {
   text-align: start;
   font-size: 14px;
   overflow-wrap: break-word;
+  white-space: pre-wrap;
+  word-wrap: break-word;
 }
 
 .NotifiAlertDetails__timestamp {


### PR DESCRIPTION
Use more general CSS approach to preserve white space and break line sign (`\n`) in History List View and History Detail View.

See demo video attached herewith.





https://github.com/notifi-network/notifi-sdk-ts/assets/127958634/1301b00c-a7ae-48b5-9751-30503fa5bbd5


