### PR TITLE
fix line break issue in destination section

### DIFF
--- a/packages/notifi-react-card/lib/assets/CircleBellIcon.tsx
+++ b/packages/notifi-react-card/lib/assets/CircleBellIcon.tsx
@@ -18,7 +18,7 @@ export const CircleBellIcon: React.FC<Props> = (props: Props) => {
         r="9.5"
         fill="white"
         stroke="url(#paint0_linear_1316_3580)"
-        stroke-width="2"
+        strokeWidth="2"
       />
       <path
         d="M10.4901 16.1875C11.1212 16.1875 11.6376 15.6712 11.6376 15.0401H9.3427C9.3427 15.6712 9.85331 16.1875 10.4901 16.1875ZM13.9324 12.7452V9.8766C13.9324 8.11529 12.9915 6.64083 11.3507 6.25071V5.86058C11.3507 5.38439 10.9663 5 10.4901 5C10.0139 5 9.62956 5.38439 9.62956 5.86058V6.25071C7.98299 6.64083 7.04783 8.10955 7.04783 9.8766V12.7452L5.90039 13.8926V14.4663H15.0799V13.8926L13.9324 12.7452Z"
@@ -33,8 +33,8 @@ export const CircleBellIcon: React.FC<Props> = (props: Props) => {
           y2="19"
           gradientUnits="userSpaceOnUse"
         >
-          <stop stop-color="#FE7970" />
-          <stop offset="1" stop-color="#FEB776" />
+          <stop stopColor="#FE7970" />
+          <stop offset="1" stopColor="#FEB776" />
         </linearGradient>
       </defs>
     </svg>

--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -883,7 +883,10 @@ input::-webkit-inner-spin-button {
   overflow-wrap: anywhere;
 }
 
-.NotifiUserInfoPanel__email {
+.NotifiUserInfoPanel__email,
+.NotifiUserInfoPanel__telegram,
+.NotifiUserInfoPanel__sms,
+.NotifiUserInfoPanel__discord {
   gap: 8px;
 }
 

--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -860,6 +860,10 @@ input::-webkit-inner-spin-button {
   outline: none;
 }
 
+.DestinationErrorMessage__confirmationLinkLabel {
+  white-space: nowrap;
+}
+
 .ConnectWalletRow__connectAnywayButton:disabled,
 .ConnectWalletRow__button:disabled {
   cursor: default;
@@ -877,6 +881,10 @@ input::-webkit-inner-spin-button {
   text-align: left;
   align-items: baseline;
   overflow-wrap: anywhere;
+}
+
+.NotifiUserInfoPanel__email {
+  gap: 8px;
 }
 
 .NotifiUserInfoPanel__myWalletLabel,


### PR DESCRIPTION
when the email address is too long, the 'resend link' is broken down into two line
also fixed the 'invalid DOM property' warning from CircleBellIcon
![image](https://github.com/notifi-network/notifi-sdk-ts/assets/26240001/386eda35-8692-4661-b3f0-170d72ede579)

before:
<img width="364" alt="Screenshot 2023-08-28 at 3 25 36 PM" src="https://github.com/notifi-network/notifi-sdk-ts/assets/26240001/94210a47-2e8a-42c7-9dd3-4ecc1d2d52cf">
after:
<img width="361" alt="Screenshot 2023-08-28 at 3 24 58 PM" src="https://github.com/notifi-network/notifi-sdk-ts/assets/26240001/c74650ea-f790-44a7-bb46-b3a0839c3d2d">
