### PR TITLE
Only support one Discord target per user

### DIFF
--- a/packages/notifi-core/lib/NotifiClient.ts
+++ b/packages/notifi-core/lib/NotifiClient.ts
@@ -112,7 +112,7 @@ export type ClientUpdateAlertInput = Readonly<{
   phoneNumber: string | undefined;
   telegramId: string | undefined;
   webhook?: ClientCreateWebhookParams;
-  discordId: string | undefined;
+  includeDiscord: boolean;
 }>;
 
 /**
@@ -145,7 +145,7 @@ export type ClientCreateAlertInput = Readonly<{
   webhook?: ClientCreateWebhookParams;
   sourceIds?: ReadonlyArray<string>;
   sourceGroupName?: string;
-  discordId: string | undefined;
+  includeDiscord: boolean;
 }>;
 
 export type ClientCreateWebhookParams = Omit<CreateWebhookTargetInput, 'name'>;
@@ -209,7 +209,7 @@ export type ClientEnsureTargetGroupInput = Readonly<{
   phoneNumber: string | undefined;
   telegramId: string | undefined;
   webhook?: ClientCreateWebhookParams;
-  discordId: string | undefined;
+  includeDiscord: boolean;
 }>;
 
 /**

--- a/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
@@ -321,7 +321,9 @@ export const NotifiSubscriptionContextProvider: React.FC<
         setTelegramErrorMessage(undefined);
       }
 
-      const discordTarget = targetGroup?.discordTargets?.[0];
+      const discordTarget = targetGroup?.discordTargets?.find(
+        (it) => it?.name === 'Default',
+      );
 
       const discordId = discordTarget?.id;
 

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -126,11 +126,12 @@ export const useNotifiSubscribe: ({
   const handleMissingDiscordTarget = (
     discordTargets: ReadonlyArray<DiscordTarget>,
   ): void => {
-    // Check for a confirmed discord target, and if none exists, use the first discord target.
+    // Check for the default, and if none exists, use the first discord target.
     const target =
-      discordTargets?.find((target) => target.isConfirmed) || discordTargets[0];
+      discordTargets?.find((target) => target.name === 'Default') ||
+      discordTargets?.[0];
 
-    setDiscordTargetData(target || undefined);
+    setDiscordTargetData(target);
   };
 
   const render = useCallback(
@@ -213,7 +214,9 @@ export const useNotifiSubscribe: ({
         setTelegramErrorMessage(undefined);
       }
 
-      const discordTarget = targetGroup?.discordTargets?.[0];
+      const discordTarget = targetGroup?.discordTargets?.find(
+        (it) => it?.name === 'Default',
+      );
 
       const discordId = discordTarget?.id;
 
@@ -385,8 +388,7 @@ export const useNotifiSubscribe: ({
     ): Promise<Alert | null> => {
       if (demoPreview) throw Error('Preview card does not support method call');
       const { alertName, alertConfiguration } = alertParams;
-      const { finalEmail, finalPhoneNumber, finalTelegramId, finalDiscordId } =
-        contacts;
+      const { finalEmail, finalPhoneNumber, finalTelegramId } = contacts;
       const existingAlert = data.alerts.find(
         (alert) => alert?.name === alertName,
       );
@@ -476,7 +478,7 @@ export const useNotifiSubscribe: ({
             targetGroupName,
             telegramId: finalTelegramId,
             sourceIds,
-            discordId: finalDiscordId,
+            includeDiscord: useDiscord,
             sourceGroupName,
           });
 
@@ -533,7 +535,7 @@ export const useNotifiSubscribe: ({
             emailAddress: finalEmail,
             phoneNumber: finalPhoneNumber,
             telegramId: finalTelegramId,
-            discordId: finalDiscordId,
+            includeDiscord: useDiscord,
           });
 
           return alert;
@@ -570,7 +572,7 @@ export const useNotifiSubscribe: ({
             targetGroupName,
             telegramId: finalTelegramId,
             sourceGroupName,
-            discordId: finalDiscordId,
+            includeDiscord: useDiscord,
           });
 
           return alert;
@@ -669,7 +671,7 @@ export const useNotifiSubscribe: ({
           name: targetGroupName,
           phoneNumber: finalPhoneNumber,
           telegramId: finalTelegramId,
-          discordId: finalDiscordId,
+          includeDiscord: useDiscord,
         });
       }
 
@@ -719,7 +721,7 @@ export const useNotifiSubscribe: ({
       name: targetGroupName,
       phoneNumber: finalPhoneNumber,
       telegramId: finalTelegramId,
-      discordId: finalDiscordId,
+      includeDiscord: useDiscord,
     });
 
     const newData = await client.fetchData();
@@ -782,7 +784,7 @@ export const useNotifiSubscribe: ({
             name: targetGroupName,
             phoneNumber: finalPhoneNumber,
             telegramId: finalTelegramId,
-            discordId: finalDiscordId,
+            includeDiscord: useDiscord,
           });
         }
       } catch (e) {

--- a/packages/notifi-react-hooks/lib/utils/ensureTargetIds.ts
+++ b/packages/notifi-react-hooks/lib/utils/ensureTargetIds.ts
@@ -40,10 +40,11 @@ const ensureTargetIds = async (
     phoneNumber: string | undefined;
     telegramId: string | undefined;
     webhook?: ClientCreateWebhookParams;
-    discordId: string | undefined;
+    includeDiscord: boolean;
   }>,
 ) => {
-  const { emailAddress, phoneNumber, telegramId, webhook, discordId } = input;
+  const { emailAddress, phoneNumber, telegramId, webhook, includeDiscord } =
+    input;
 
   const [
     emailTargetId,
@@ -56,7 +57,9 @@ const ensureTargetIds = async (
     ensureSms(service, existing.smsTargets, phoneNumber),
     ensureTelegram(service, existing.telegramTargets, telegramId),
     ensureWebhook(service, existing.webhookTargets, webhook),
-    ensureDiscord(service, existing.discordTargets, discordId),
+    includeDiscord
+      ? ensureDiscord(service, existing.discordTargets, 'Default')
+      : Promise.resolve(null),
   ]);
 
   const emailTargetIds = [];


### PR DESCRIPTION
We have various assumptions about this in the UI. Let's make it explicit in much of the API.

This also fixes an issue where we were conflating `id` and `name` in the Discord target due to a parameter name in the API.