### PR TITLE
MVP-3202: adopt new fusionNotificationHistory (default)

### DIFF
--- a/packages/notifi-react-card/lib/components/AlertHistory/AlertDetailsCard.tsx
+++ b/packages/notifi-react-card/lib/components/AlertHistory/AlertDetailsCard.tsx
@@ -1,12 +1,12 @@
-import { Types } from '@notifi-network/notifi-graphql';
 import clsx from 'clsx';
 import { getAlertDetailsContents } from 'notifi-react-card/lib/utils';
 import React, { useMemo } from 'react';
 
 import { formatAlertDetailsTimestamp } from '../../utils/AlertHistoryUtils';
+import { NotificationHistoryEntry } from '../subscription';
 
 export type AlertDetailsProps = Readonly<{
-  notificationEntry: Types.NotificationHistoryEntryFragmentFragment;
+  notificationEntry: NotificationHistoryEntry;
   classNames?: Readonly<{
     detailsContainer?: string;
     BackArrowIcon?: string;

--- a/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
@@ -1,5 +1,4 @@
 import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
-import { Types } from '@notifi-network/notifi-graphql';
 import clsx from 'clsx';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -36,6 +35,7 @@ import {
 import {
   AlertHistoryView,
   AlertHistoryViewProps,
+  NotificationHistoryEntry,
 } from './subscription-card-views/HistoryCardView';
 import {
   PreviewCard,
@@ -153,7 +153,7 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
     discordTargetData?.discordAccountId,
   ]);
   const [selectedAlertEntry, setAlertEntry] = useState<
-    Types.NotificationHistoryEntryFragmentFragment | undefined
+    NotificationHistoryEntry | undefined
   >(undefined);
 
   let view = null;

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
@@ -93,6 +93,7 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
         ? await frontendClient.getFusionNotificationHistory({
             first,
             after,
+            includeHidden: false,
           })
         : await client.getNotificationHistory({
             first,

--- a/packages/notifi-react-card/lib/utils/NotificationHistoryUtils.tsx
+++ b/packages/notifi-react-card/lib/utils/NotificationHistoryUtils.tsx
@@ -234,12 +234,12 @@ const concatHistoryNodes = (
   switch (nodes[0]?.__typename) {
     case 'FusionNotificationHistoryEntry':
       if (nodesToConcat[0]?.__typename !== 'FusionNotificationHistoryEntry') {
-        throw new Error('Type mismatch: FusionNotificationHistoryEntry');
+        return nodes;
       }
       return [...nodes, ...nodesToConcat];
     case 'NotificationHistoryEntry':
       if (nodesToConcat[0]?.__typename !== 'NotificationHistoryEntry') {
-        throw new Error('Type mismatch: NotificationHistoryEntry');
+        return nodes;
       }
       return [...nodes, ...nodesToConcat];
     default:


### PR DESCRIPTION
- Adopt new `fusionNotificationHistoryEntry` (`includeHidden=false`) endpoint for frontendClient by default (`isUsingFrontendClient=true`)

- Legacy `notificationHistoryEntry` will be used while using `hooks` (`isUsingFrontendClient=false`)
