### PR TITLE
MVP-3254: Make use of Nx-build to speed up build time

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,5 @@
 {
   "version": "0.85.0",
-  "useWorkspaces": true
+  "useWorkspaces": true,
+  "useNx": true
 }

--- a/nx.json
+++ b/nx.json
@@ -1,0 +1,11 @@
+{
+  "tasksRunnerOptions": {
+    "default": {
+      "runner": "nx/tasks-runners/default",
+      "options": {
+        "cacheableOperations": ["build"]
+      }
+    }
+  },
+  "targetDefaults": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "packages/notifi-solana-hw-login"
       ],
       "devDependencies": {
+        "@nrwl/nx-darwin-x64": "^15.9.3",
         "@trivago/prettier-plugin-sort-imports": "^3.3.0",
         "@types/jest": "^27.4.1",
         "@types/node-fetch": "^2.6.2",
@@ -9867,6 +9868,133 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-darwin-x64": {
+      "version": "15.9.3",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.3.tgz",
+      "integrity": "sha512-p+8UkfC6KTLOX4XRt7NSP8DoTzEgs73+SN0csoXT9VsNO35+F0Z5zMZxpEc7RVo5Wen/4PGh2OWA+8gtgntsJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-linux-arm-gnueabihf": {
+      "version": "15.8.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.8.7.tgz",
+      "integrity": "sha512-4F/8awwqPTt7zKQolvjBNrcR1wYicPjGchLOdaqnfMxn/iRRUdh0hD11mEP5zHNv9gZs/nOIvhdBUErNjFkplQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-linux-arm64-gnu": {
+      "version": "15.8.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.8.7.tgz",
+      "integrity": "sha512-3ZTSZx02Vv5emQOpaDROIcLtQucoXAe73zGKYDTXB95mxbOPSjjQJ8Rtx+BeqWq9JQoZZyRcD0qnBkTTy1aLRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-linux-arm64-musl": {
+      "version": "15.8.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.8.7.tgz",
+      "integrity": "sha512-SZxTomiHxAh8El+swbmGSGcaA0vGbHb/rmhFAixo19INu1wBJfD6hjkVJt17h6PyEO7BIYPOpRia6Poxnyv8hA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-linux-x64-gnu": {
+      "version": "15.8.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.8.7.tgz",
+      "integrity": "sha512-BlNC6Zz1/x6CFbBFTVrgRGMOPqb7zWh5cOjBVNpoBXYTEth1UXb2r1U+gpuQ4xdUqG+uXoWhy6BHJjqBIjzLJA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-linux-x64-musl": {
+      "version": "15.8.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-musl/-/nx-linux-x64-musl-15.8.7.tgz",
+      "integrity": "sha512-FNYX/IKy8SUbw6bJpvwZrup2YQBYmSJwP6Rw76Vf7c32XHk7uA6AjiPWMIrZCSndXcry8fnwXvR+J2Dnyo82nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-win32-arm64-msvc": {
+      "version": "15.8.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.8.7.tgz",
+      "integrity": "sha512-sZALEzazjPAeLlw6IbFWsMidCZ4ZM3GKWZZ6rsAqG2y7I9t4nlUPH/y/Isl9MuLBvrBCBXbVnD20wh6EhtuwTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-win32-x64-msvc": {
+      "version": "15.8.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.8.7.tgz",
+      "integrity": "sha512-VMdDptI2rqkLQRCvertF29QeA/V/MnFtHbsmVzMCEv5EUfrkHbA5LLxV66LLfngmkDT1FHktffztlsMpbxvhRw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -35148,6 +35276,22 @@
         }
       }
     },
+    "node_modules/nx/node_modules/@nrwl/nx-darwin-x64": {
+      "version": "15.8.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.8.7.tgz",
+      "integrity": "sha512-VqHJEP0wgFu1MU0Bo1vKZ5/s7ThRfYkX8SyGUxjVTzR02CrsjC4rNxFoKD8Cc4YkUn44U/F78toGf+i2gRcjSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/nx/node_modules/ansi-styles": {
       "version": "4.3.0",
       "dev": true,
@@ -52061,6 +52205,61 @@
       "dev": true,
       "optional": true
     },
+    "@nrwl/nx-darwin-x64": {
+      "version": "15.9.3",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.3.tgz",
+      "integrity": "sha512-p+8UkfC6KTLOX4XRt7NSP8DoTzEgs73+SN0csoXT9VsNO35+F0Z5zMZxpEc7RVo5Wen/4PGh2OWA+8gtgntsJQ==",
+      "dev": true
+    },
+    "@nrwl/nx-linux-arm-gnueabihf": {
+      "version": "15.8.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.8.7.tgz",
+      "integrity": "sha512-4F/8awwqPTt7zKQolvjBNrcR1wYicPjGchLOdaqnfMxn/iRRUdh0hD11mEP5zHNv9gZs/nOIvhdBUErNjFkplQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@nrwl/nx-linux-arm64-gnu": {
+      "version": "15.8.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.8.7.tgz",
+      "integrity": "sha512-3ZTSZx02Vv5emQOpaDROIcLtQucoXAe73zGKYDTXB95mxbOPSjjQJ8Rtx+BeqWq9JQoZZyRcD0qnBkTTy1aLRg==",
+      "dev": true,
+      "optional": true
+    },
+    "@nrwl/nx-linux-arm64-musl": {
+      "version": "15.8.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.8.7.tgz",
+      "integrity": "sha512-SZxTomiHxAh8El+swbmGSGcaA0vGbHb/rmhFAixo19INu1wBJfD6hjkVJt17h6PyEO7BIYPOpRia6Poxnyv8hA==",
+      "dev": true,
+      "optional": true
+    },
+    "@nrwl/nx-linux-x64-gnu": {
+      "version": "15.8.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.8.7.tgz",
+      "integrity": "sha512-BlNC6Zz1/x6CFbBFTVrgRGMOPqb7zWh5cOjBVNpoBXYTEth1UXb2r1U+gpuQ4xdUqG+uXoWhy6BHJjqBIjzLJA==",
+      "dev": true,
+      "optional": true
+    },
+    "@nrwl/nx-linux-x64-musl": {
+      "version": "15.8.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-musl/-/nx-linux-x64-musl-15.8.7.tgz",
+      "integrity": "sha512-FNYX/IKy8SUbw6bJpvwZrup2YQBYmSJwP6Rw76Vf7c32XHk7uA6AjiPWMIrZCSndXcry8fnwXvR+J2Dnyo82nQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@nrwl/nx-win32-arm64-msvc": {
+      "version": "15.8.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.8.7.tgz",
+      "integrity": "sha512-sZALEzazjPAeLlw6IbFWsMidCZ4ZM3GKWZZ6rsAqG2y7I9t4nlUPH/y/Isl9MuLBvrBCBXbVnD20wh6EhtuwTw==",
+      "dev": true,
+      "optional": true
+    },
+    "@nrwl/nx-win32-x64-msvc": {
+      "version": "15.8.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.8.7.tgz",
+      "integrity": "sha512-VMdDptI2rqkLQRCvertF29QeA/V/MnFtHbsmVzMCEv5EUfrkHbA5LLxV66LLfngmkDT1FHktffztlsMpbxvhRw==",
+      "dev": true,
+      "optional": true
+    },
     "@nrwl/tao": {
       "version": "15.8.7",
       "dev": true,
@@ -68775,6 +68974,13 @@
         "yargs-parser": "21.1.1"
       },
       "dependencies": {
+        "@nrwl/nx-darwin-x64": {
+          "version": "15.8.7",
+          "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.8.7.tgz",
+          "integrity": "sha512-VqHJEP0wgFu1MU0Bo1vKZ5/s7ThRfYkX8SyGUxjVTzR02CrsjC4rNxFoKD8Cc4YkUn44U/F78toGf+i2gRcjSQ==",
+          "dev": true,
+          "optional": true
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "dev": true,

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "jest"
   },
   "devDependencies": {
+    "@nrwl/nx-darwin-x64": "^15.9.3",
     "@trivago/prettier-plugin-sort-imports": "^3.3.0",
     "@types/jest": "^27.4.1",
     "@types/node-fetch": "^2.6.2",


### PR DESCRIPTION

We can use lerna's built-in nx support to cache and speed up local build time.

https://github.com/notifi-network/notifi-sdk-ts/assets/127958634/77437648-2fba-48da-b6d0-e119152753d2

