### PR TITLE
add EventTypeFusionMultiThreshhold

### DIFF
--- a/packages/notifi-frontend-client/lib/client/ensureSource.ts
+++ b/packages/notifi-frontend-client/lib/client/ensureSource.ts
@@ -474,6 +474,9 @@ const ensureSources = async (
     case 'label': {
       throw new Error('Unsupported event type');
     }
+    case 'fusionMultiThreshhold': {
+      throw new Error('Unsupported event type');
+    }
   }
 };
 
@@ -1007,6 +1010,9 @@ export const ensureSourceAndFilters = async (
       };
     }
     case 'label': {
+      throw new Error('Unsupported event type');
+    }
+    case 'fusionMultiThreshhold': {
       throw new Error('Unsupported event type');
     }
     case 'walletBalance': {

--- a/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
+++ b/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
@@ -75,6 +75,19 @@ export type TradingPairEventTypeItem = Readonly<{
   tradingPairs: ValueOrRef<ReadonlyArray<string>>;
 }>;
 
+export type FusionMultiThreshholdEventTypeItem = Readonly<{
+  type: 'fusionMultiThreshhold';
+  name: string;
+  tooltipContent?: string;
+  numberType: NumberTypeSelect;
+  subtitle?: string;
+  addThreshholdTitle?: string;
+  fusionEventId: ValueOrRef<string>;
+  sourceAddress: ValueOrRef<string>;
+  maintainSourceGroup?: boolean;
+  alertFrequency?: AlertFrequency;
+}>;
+
 export type PriceChangeDataSource = 'coingecko';
 
 export type PriceChangeEventTypeItem = Readonly<{
@@ -152,6 +165,7 @@ export type EventTypeItem =
   | BroadcastEventTypeItem
   | HealthCheckEventTypeItem
   | TradingPairEventTypeItem
+  | FusionMultiThreshholdEventTypeItem
   | LabelEventTypeItem
   | PriceChangeEventTypeItem
   | CustomTopicTypeItem

--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -572,6 +572,7 @@ input::-webkit-inner-spin-button {
 .EventTypeCustomToggleRow_label,
 .EventTypeHealthCheckRow__label,
 .EventTypeFusionToggleRow__label,
+.EventTypeFusionMultiThreshholdRow__label,
 .EventTypeCustomHealthCheckRow__label,
 .EventTypeCustomToggleRow__label,
 .EventTypeWalletBalanceRow__label,
@@ -587,11 +588,14 @@ input::-webkit-inner-spin-button {
   color: var(--notifi-font-color);
 }
 
+.EventTypeFusionMultiThreshholdRow__container,
+.EventTypeFusionMultiThreshholdRow__label,
 .EventTypeHealthCheckRow__container,
 .EventTypeHealthCheckRow__label {
   margin-bottom: 0 !important;
 }
 
+.EventTypeFusionMultiThreshholdRow__content,
 .EventTypeHealthCheckRow__content {
   font-size: 14px;
   color: var(--notifi-secondary-font-color);
@@ -1615,6 +1619,187 @@ input::-webkit-inner-spin-button {
 }
 
 .TradingPairSettingsRow__saveButton:disabled {
+  cursor: default;
+  color: var(--notifi-secondary-font-color);
+  background-color: var(--notifi-button-disabled-color);
+}
+
+.EventTypeFusionMultiThreshholdRow__container {
+  display: flex;
+  align-items: stretch;
+  flex-direction: column;
+}
+
+.EventTypeFusionMultiThreshholdRow__container > * {
+  margin-bottom: 0 !important;
+}
+
+.EventTypeFusionMultiThreshholdRow__container > *:not(:first-child) {
+  padding-top: 10px;
+}
+.EventTypeFusionMultiThreshholdRow__container > :last-child {
+  padding-bottom: 10px;
+}
+
+.EventTypeFusionMultiThreshholdRow__container > *:not(:last-child):not(:first-child) {
+  padding-bottom: 10px;
+  border-bottom: 1px var(--notifi-font-color) solid;
+}
+
+.EventTypeFusionMultiThreshholdRow__addThreshhold {
+  display: inline-block;
+  align-self: flex-start;
+  cursor: pointer;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--notifi-link-color);
+  font-size: 16px;
+  line-height: 20px;
+}
+
+.EventTypeFusionMultiThreshholdRow__addThreshhold:disabled {
+  cursor: default;
+  color: var(--notifi-secondary-font-color);
+}
+
+.EventTypeFusionMultiThreshholdRow__addThreshhold::before {
+  content: '+ ';
+}
+
+.FusionMultiThreshholdSettingsRow__container {
+  display: flex;
+  align-items: stretch;
+  flex-direction: column;
+  padding: 10px 0;
+}
+
+.FusionMultiThreshholdSettingsRow__dropdownContainer {
+  background-color: var(--notifi-input-background);
+  display: flex;
+  align-items: center;
+  border: 1px var(--notifi-input-border) solid;
+  border-radius: 5px;
+}
+
+.FusionMultiThreshholdSettingsRow__dropdownContainer::after {
+  content: '';
+  width: 1em;
+  height: 1em;
+  margin-right: 10px;
+  background-color: var(--notifi-font-color);
+  clip-path: polygon(90% 30%, 10% 30%, 50% 70%);
+}
+
+.FusionMultiThreshholdSettingsRow__dropdown {
+  box-sizing: border-box;
+  appearance: none;
+  background-color: transparent;
+  border: none;
+  padding: 10px 20px;
+  margin: 0;
+  width: 100%;
+  color: inherit;
+  cursor: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  outline: none;
+}
+
+.FusionMultiThreshholdSettingsRow__radioButton {
+  font-size: 16px;
+  line-height: 20px;
+  padding: 10px 30px;
+  margin-right: 10px;
+  margin-bottom: 0 !important;
+  border-radius: 5px;
+  border: none;
+  color: #000;
+  background-color: var(--notifi-tooltip-background);
+  cursor: pointer;
+}
+
+.FusionMultiThreshholdSettingsRow__radioSelected {
+  color: var(--notifi-button-text);
+  background-color: var(--notifi-button-color);
+}
+
+.FusionMultiThreshholdAlertRow__container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 10px 0;
+}
+
+.FusionMultiThreshholdAlertRow__textContainer {
+  display: flex;
+  flex-grow: 1;
+  flex-direction: column;
+  align-items: stretch;
+  margin-right: 10px;
+  margin-bottom: 0 !important;
+}
+
+.FusionMultiThreshholdAlertRow__name {
+  display: block;
+  font-size: 16px;
+  line-height: 20px;
+  color: var(--notifi-font-color);
+}
+
+.FusionMultiThreshholdAlertRow__description {
+  display: block;
+  font-size: 14px;
+  line-height: 18px;
+  color: var(--notifi-secondary-font-color);
+}
+
+.FusionMultiThreshholdAlertRow__deleteIcon {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  fill: var(--notifi-font-color);
+  cursor: pointer;
+}
+
+.FusionMultiThreshholdSettingsRow__threshholdInputContainer {
+  background-color: var(--notifi-input-background);
+  display: flex;
+  align-items: center;
+  border: 1px var(--notifi-input-border) solid;
+  border-radius: 5px;
+}
+
+.FusionMultiThreshholdSettingsRow__threshholdInput {
+  box-sizing: border-box;
+  appearance: none;
+  background-color: transparent;
+  border: none;
+  padding: 10px 20px;
+  margin: 0;
+  width: 100%;
+  color: inherit;
+  cursor: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  outline: none;
+}
+
+.FusionMultiThreshholdSettingsRow__saveButton {
+  font-size: 16px;
+  line-height: 20px;
+  padding: 5px 20px;
+  align-self: flex-start;
+  border-radius: 5px;
+  border: none;
+  color: var(--notifi-button-text);
+  background-color: var(--notifi-button-color);
+  cursor: pointer;
+}
+
+.FusionMultiThreshholdSettingsRow__saveButton:disabled {
   cursor: default;
   color: var(--notifi-secondary-font-color);
   background-color: var(--notifi-button-disabled-color);

--- a/packages/notifi-react-card/lib/components/subscription/EventTypeFusionMultiThreshholdRow.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/EventTypeFusionMultiThreshholdRow.tsx
@@ -1,0 +1,426 @@
+import {
+  EventTypeItem,
+  FusionEventTypeItem,
+} from '@notifi-network/notifi-frontend-client';
+import clsx from 'clsx';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { DeleteIcon } from '../../assets/DeleteIcon';
+import {
+  useNotifiClientContext,
+  useNotifiSubscriptionContext,
+} from '../../context';
+import {
+  FusionMultiThreshholdEventTypeItem,
+  SubscriptionData,
+  useNotifiSubscribe,
+} from '../../hooks';
+import {
+  DeepPartialReadonly,
+  fusionHealthCheckConfiguration,
+  subscribeAlertByFrontendClient,
+  unsubscribeAlertByFrontendClient,
+} from '../../utils';
+import { NotifiTooltip, NotifiTooltipProps } from './NotifiTooltip';
+import { resolveStringRef } from './resolveRef';
+
+export type EventTypeFusionMultiThreshholdRowProps = Readonly<{
+  classNames?: DeepPartialReadonly<{
+    container: string;
+    content: string;
+    label: string;
+    addThreshhold: string;
+    tooltip: NotifiTooltipProps['classNames'];
+    fusionMultiThreshholdAlertRow: FusionMultiThreshholdAlertRowProps['classNames'];
+    fusionMultiThreshholdSettingsRow: FusionMultiThreshholdSettingsRowProps['classNames'];
+  }>;
+  config: FusionMultiThreshholdEventTypeItem;
+  inputs: Record<string, unknown>;
+}>;
+
+export const EventTypeFusionMultiThreshholdRow: React.FC<
+  EventTypeFusionMultiThreshholdRowProps
+> = ({
+  classNames,
+  config,
+  inputs,
+}: EventTypeFusionMultiThreshholdRowProps) => {
+  const { name, tooltipContent } = config;
+  const { alerts } = useNotifiSubscriptionContext();
+
+  const fusionMultiThreshholdAlertNames = useMemo(() => {
+    if (alerts === undefined) {
+      return [];
+    }
+
+    return Object.keys(alerts)
+      .filter((alertName) => alertName.indexOf(config.name) >= 0)
+      .sort((a, b) => {
+        const getTime = (alertName: string) => {
+          const [, time] = alertName.split(':;:');
+          const date = new Date(time);
+          return date.getTime();
+        };
+
+        return getTime(a) - getTime(b);
+      });
+  }, [alerts, config.name]);
+
+  const [showInput, setShowInput] = useState(false);
+  const hasSetInput = useRef(false);
+  useEffect(() => {
+    if (!hasSetInput.current && alerts !== undefined) {
+      hasSetInput.current = true;
+      setShowInput(fusionMultiThreshholdAlertNames.length === 0);
+    }
+  }, [alerts, fusionMultiThreshholdAlertNames]);
+
+  return (
+    <div
+      className={clsx(
+        'EventTypeFusionMultiThreshholdRow__container',
+        classNames?.container,
+      )}
+    >
+      <div
+        className={clsx(
+          'EventTypeFusionMultiThreshholdRow__label',
+          classNames?.label,
+        )}
+      >
+        {name}
+        {tooltipContent !== undefined && tooltipContent.length > 0 ? (
+          <NotifiTooltip
+            classNames={classNames?.tooltip}
+            content={tooltipContent}
+          />
+        ) : null}
+      </div>
+      <div
+        className={clsx(
+          'EventTypeFusionMultiThreshholdRow__content',
+          classNames?.content,
+        )}
+      >
+        {config.subtitle
+          ? config.subtitle
+          : `Alert me when my margin ratio is:`}
+      </div>
+      {fusionMultiThreshholdAlertNames.map((alertName) => {
+        return (
+          <FusionMultiThreshholdAlertRow
+            key={alertName}
+            classNames={classNames?.fusionMultiThreshholdAlertRow}
+            alertName={alertName}
+            inputs={inputs}
+          />
+        );
+      })}
+      {showInput ? (
+        <FusionMultiThreshholdSettingsRow
+          classNames={classNames?.fusionMultiThreshholdSettingsRow}
+          config={config}
+          inputs={inputs}
+          onSave={() => {
+            setShowInput(false);
+          }}
+        />
+      ) : null}
+      <button
+        className={clsx(
+          'EventTypeFusionMultiThreshholdRow__addThreshhold',
+          classNames?.addThreshhold,
+        )}
+        disabled={showInput}
+        onClick={() => {
+          setShowInput(true);
+        }}
+      >
+        {config.addThreshholdTitle ? config.addThreshholdTitle : 'Add alert'}
+      </button>
+    </div>
+  );
+};
+
+export type FusionMultiThreshholdAlertRowProps = Readonly<{
+  classNames?: DeepPartialReadonly<{
+    container: string;
+    textContainer: string;
+    name: string;
+    description: string;
+    deleteIcon: string;
+  }>;
+  alertName: string;
+  inputs: Record<string, unknown>;
+}>;
+
+export const FusionMultiThreshholdAlertRow: React.FC<
+  FusionMultiThreshholdAlertRowProps
+> = ({ classNames, alertName, inputs }: FusionMultiThreshholdAlertRowProps) => {
+  const { render } = useNotifiSubscriptionContext();
+
+  const { instantSubscribe } = useNotifiSubscribe({
+    targetGroupName: 'Default',
+  });
+
+  const { isUsingFrontendClient, frontendClient } = useNotifiClientContext();
+
+  const name = useMemo(() => {
+    const [, , above, threshhold] = alertName.split(':;:');
+    return above + ' ' + threshhold;
+  }, [alertName]);
+
+  const unSubscribeAlert = useCallback(
+    async (
+      alertDetail: Readonly<{
+        eventType: EventTypeItem;
+        inputs: Record<string, unknown>;
+      }>,
+    ) => {
+      if (isUsingFrontendClient) {
+        return unsubscribeAlertByFrontendClient(frontendClient, alertDetail);
+      } else {
+        return instantSubscribe({
+          alertName: alertDetail.eventType.name,
+          alertConfiguration: null,
+        });
+      }
+    },
+    [isUsingFrontendClient, frontendClient],
+  );
+
+  return (
+    <div
+      className={clsx(
+        'FusionMultiThreshholdAlertRow__container',
+        classNames?.container,
+      )}
+    >
+      <div
+        className={clsx(
+          'FusionMultiThreshholdAlertRow__textContainer',
+          classNames?.textContainer,
+        )}
+      >
+        <span
+          className={clsx(
+            'FusionMultiThreshholdAlertRow__name',
+            classNames?.name,
+          )}
+        >
+          {name}
+        </span>
+      </div>
+      <div
+        className={clsx(
+          'FusionMultiThreshholdAlertRow__deleteIcon',
+          classNames?.deleteIcon,
+        )}
+        onClick={() => {
+          unSubscribeAlert({
+            eventType: {
+              name: alertName,
+            } as EventTypeItem, // We only need alertName to unsubscribe
+            inputs,
+          }).then(() => {
+            isUsingFrontendClient && frontendClient.fetchData().then(render);
+          });
+        }}
+      >
+        <DeleteIcon />
+      </div>
+    </div>
+  );
+};
+export type FusionMultiThreshholdSettingsRowProps = Readonly<{
+  classNames?: DeepPartialReadonly<{
+    buttonContainer: string;
+    radioButton: string;
+    container: string;
+    label: string;
+    option: string;
+    threshholdInput: string;
+    threshholdInputContainer: string;
+    saveButton: string;
+  }>;
+  config: FusionMultiThreshholdEventTypeItem;
+  inputs: Record<string, unknown>;
+  onSave: () => void;
+}>;
+
+export const FusionMultiThreshholdSettingsRow: React.FC<
+  FusionMultiThreshholdSettingsRowProps
+> = ({
+  classNames,
+  config,
+  inputs,
+  onSave,
+}: FusionMultiThreshholdSettingsRowProps) => {
+  const [above, setAbove] = useState<boolean>(true);
+  const [threshhold, setThreshhold] = useState<number>(0.0);
+  const { instantSubscribe } = useNotifiSubscribe({
+    targetGroupName: 'Default',
+  });
+  const { render } = useNotifiSubscriptionContext();
+
+  const { isUsingFrontendClient, frontendClient } = useNotifiClientContext();
+
+  const fusionEventId = useMemo(
+    () => resolveStringRef(config.name, config.fusionEventId, inputs),
+    [config, inputs],
+  );
+
+  const fusionSourceAddress = useMemo(
+    () => resolveStringRef(config.name, config.sourceAddress, inputs),
+    [config, inputs],
+  );
+
+  const alertConfiguration = useMemo(() => {
+    return fusionHealthCheckConfiguration({
+      maintainSourceGroup: config?.maintainSourceGroup,
+      fusionId: fusionEventId,
+      fusionSourceAddress,
+      alertFrequency: config.alertFrequency,
+      thresholdDirection: above ? 'above' : 'below',
+      threshold:
+        config.numberType === 'percentage' ? threshhold / 100 : threshhold,
+    });
+  }, [above, threshhold]);
+
+  const alertName = useMemo(() => {
+    const now = new Date().toISOString();
+
+    return `${config.name}:;:${now}:;:${
+      above ? 'Above' : 'Below'
+    }:;:${threshhold.toFixed(2)}${
+      config.numberType === 'percentage' ? '%' : ''
+    }`;
+  }, [config, above, threshhold]);
+
+  const subscribeAlert = useCallback(
+    async (
+      alertDetail: Readonly<{
+        eventType: FusionMultiThreshholdEventTypeItem;
+        inputs: Record<string, unknown>;
+      }>,
+      threshhold: number,
+    ): Promise<SubscriptionData> => {
+      if (isUsingFrontendClient) {
+        const fusionEventType: FusionEventTypeItem = {
+          name: alertDetail.eventType.name,
+          type: 'fusion',
+          fusionEventId: alertDetail.eventType.fusionEventId,
+          sourceAddress: alertDetail.eventType.sourceAddress,
+          maintainSourceGroup: alertDetail.eventType.maintainSourceGroup,
+          alertFrequency: alertDetail.eventType.alertFrequency,
+          selectedUIType: 'HEALTH_CHECK',
+          numberType: alertDetail.eventType.numberType,
+          healthCheckSubtitle: '',
+          checkRatios: [{ type: above ? 'above' : 'below', ratio: threshhold }],
+        };
+        alertDetail.inputs[`${alertDetail.eventType.name}__healthRatio`] =
+          threshhold;
+        alertDetail.inputs[
+          `${alertDetail.eventType.name}__healthThresholdDirection`
+        ] = above ? 'above' : 'below';
+        return subscribeAlertByFrontendClient(frontendClient, {
+          eventType: fusionEventType,
+          inputs: alertDetail.inputs,
+        });
+      }
+      if (!alertConfiguration)
+        throw new Error('alertConfiguration is undefinded');
+
+      return instantSubscribe({
+        alertName,
+        alertConfiguration,
+      });
+    },
+    [isUsingFrontendClient, frontendClient],
+  );
+
+  return (
+    <div
+      className={clsx(
+        'FusionMultiThreshholdSettingsRow__container',
+        classNames?.container,
+      )}
+    >
+      <div
+        className={clsx(
+          'FusionMultiThreshholdSettingsRow__buttonContainer',
+          classNames?.buttonContainer,
+        )}
+      >
+        <button
+          className={clsx(
+            'FusionMultiThreshholdSettingsRow__radioButton',
+            classNames?.radioButton,
+            { FusionMultiThreshholdSettingsRow__radioSelected: above },
+          )}
+          onClick={() => setAbove(true)}
+        >
+          Above
+        </button>
+        <button
+          className={clsx(
+            'FusionMultiThreshholdSettingsRow__radioButton',
+            classNames?.radioButton,
+            { FusionMultiThreshholdSettingsRow__radioSelected: !above },
+          )}
+          onClick={() => setAbove(false)}
+        >
+          Below
+        </button>
+      </div>
+      <div
+        className={clsx(
+          'FusionMultiThreshholdSettingsRow__threshholdInputContainer',
+          classNames?.threshholdInputContainer,
+        )}
+      >
+        <input
+          className={clsx(
+            'FusionMultiThreshholdSettingsRow__threshholdInput',
+            classNames?.threshholdInput,
+          )}
+          name="notifi-fusionmultithreshhold-threshhold"
+          type="number"
+          inputMode="decimal"
+          value={threshhold}
+          onChange={(e) => {
+            setThreshhold(e.target.valueAsNumber);
+          }}
+        />
+      </div>
+      <button
+        className={clsx(
+          'FusionMultiThreshholdSettingsRow__saveButton',
+          classNames?.saveButton,
+        )}
+        disabled={threshhold === undefined}
+        onClick={async () => {
+          await subscribeAlert(
+            {
+              eventType: { ...config, name: alertName },
+              inputs: inputs,
+            },
+            threshhold,
+          );
+          frontendClient.fetchData().then(render);
+          setAbove(true);
+          setThreshhold(0.0);
+          onSave();
+        }}
+      >
+        Save
+      </button>
+    </div>
+  );
+};

--- a/packages/notifi-react-card/lib/components/subscription/index.ts
+++ b/packages/notifi-react-card/lib/components/subscription/index.ts
@@ -8,6 +8,7 @@ export * from './EventTypeHealthCheckRow';
 export * from './EventTypeLabelRow';
 export * from './EventTypePriceChangeRow';
 export * from './EventTypeTradingPairsRow';
+export * from './EventTypeFusionMultiThreshholdRow';
 export * from './EventTypeUnsupportedRow';
 export * from './EventTypeWalletBalanceRow';
 export * from './FetchedStateCard';

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/AlertsPanel.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/preview-panel/AlertsPanel.tsx
@@ -19,6 +19,10 @@ import {
   EventTypeFusionHealthCheckRowProps,
 } from '../../EventTypeFusionHealthCheckRow';
 import {
+  EventTypeFusionMultiThreshholdRow,
+  EventTypeFusionMultiThreshholdRowProps,
+} from '../../EventTypeFusionMultiThreshholdRow';
+import {
   EventTypeFusionRowProps,
   EventTypeFusionToggleRow,
 } from '../../EventTypeFusionToggleRow';
@@ -63,6 +67,7 @@ export type AlertsPanelProps = Readonly<{
     EventTypeLabelRow?: EventTypeLabelRowProps['classNames'];
     EventTypePriceChangeRow?: EventTypePriceChangeRowProps['classNames'];
     EventTypeTradingPairsRow?: EventTypeTradingPairsRowProps['classNames'];
+    EventTypeFusionMultiThreshholdRow?: EventTypeFusionMultiThreshholdRowProps['classNames'];
     EventTypeUnsupportedRow?: EventTypeUnsupportedRowProps['classNames'];
     EventTypeWalletBalanceRow?: EventTypeWalletBalanceRowProps['classNames'];
     EventTypeXMTPRow?: EventTypeXMPTRowProps['classNames'];
@@ -153,6 +158,15 @@ export const AlertsPanel: React.FC<AlertsPanelProps> = ({
               <EventTypeTradingPairsRow
                 key={eventType.name}
                 classNames={classNames?.EventTypeTradingPairsRow}
+                config={eventType}
+                inputs={inputs}
+              />
+            );
+          case 'fusionMultiThreshhold':
+            return (
+              <EventTypeFusionMultiThreshholdRow
+                key={eventType.name}
+                classNames={classNames?.EventTypeFusionMultiThreshholdRow}
                 config={eventType}
                 inputs={inputs}
               />

--- a/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
+++ b/packages/notifi-react-card/lib/hooks/SubscriptionCardConfig.ts
@@ -89,6 +89,19 @@ export type TradingPairEventTypeItem = Readonly<{
   tradingPairs: ValueOrRef<ReadonlyArray<string>>;
 }>;
 
+export type FusionMultiThreshholdEventTypeItem = Readonly<{
+  type: 'fusionMultiThreshhold';
+  name: string;
+  tooltipContent?: string;
+  numberType: NumberTypeSelect;
+  subtitle?: string;
+  addThreshholdTitle?: string;
+  fusionEventId: ValueOrRef<string>;
+  sourceAddress: ValueOrRef<string>;
+  maintainSourceGroup?: boolean;
+  alertFrequency?: AlertFrequency;
+}>;
+
 export type WalletBalanceEventTypeItem = Readonly<{
   type: 'walletBalance';
   name: string;
@@ -107,7 +120,7 @@ export type PriceChangeEventTypeItem = Readonly<{
 
 export type USER_INTERFACE_TYPE = 'TOGGLE' | 'HEALTH_CHECK';
 
-export type NumberTypeSelect = 'percentage' | 'integer';
+export type NumberTypeSelect = 'percentage' | 'integer' | 'price';
 
 export type CustomToggleTypeItem = Readonly<{
   filterOptions: FilterOptions;
@@ -151,6 +164,7 @@ export type EventTypeItem =
   | HealthCheckEventTypeItem
   | LabelEventTypeItem
   | TradingPairEventTypeItem
+  | FusionMultiThreshholdEventTypeItem
   | WalletBalanceEventTypeItem
   | PriceChangeEventTypeItem
   | CustomTopicTypeItem


### PR DESCRIPTION
This PR adds a new EventType to the react-card that allows users to set up multiple fusion health check alerts in one row 

<img width="381" alt="Screen Shot 2023-09-12 at 00 29 23" src="https://github.com/notifi-network/notifi-sdk-ts/assets/8414510/11aee9a7-5734-48ad-afc8-66e98930631b">
