### PR TITLE
MVP-3250: Update UreadHistory related client methods to support 'hide' feature

### DIFF
--- a/packages/notifi-axios-adapter/lib/mutations/markFusionNotificationHistoryAsRead.ts
+++ b/packages/notifi-axios-adapter/lib/mutations/markFusionNotificationHistoryAsRead.ts
@@ -13,9 +13,10 @@ const MUTATION = `
 mutation markFusionNotificationHistoryAsRead(
   $ids: [String!]!
   $beforeId: String
+  $readState: NotificationHistoryReadState
 ) {
   markFusionNotificationHistoryAsRead(
-    input: { ids: $ids, beforeId: $beforeId }
+    input: { ids: $ids, beforeId: $beforeId, readState: $readState }
   )
 }
 `.trim();

--- a/packages/notifi-axios-adapter/lib/queries/getFusionNotificationHistoryImpl.ts
+++ b/packages/notifi-axios-adapter/lib/queries/getFusionNotificationHistoryImpl.ts
@@ -11,8 +11,9 @@ import { fusionNotificationHistoryEntryFragment } from '../fragments/fusionNotif
 
 const DEPENDENCIES = [fusionNotificationHistoryEntryFragment];
 
-const QUERY = `query getFusionNotificationHistory($after: String, $first: Int) {
-  fusionNotificationHistory(after: $after, first: $first) {
+const QUERY =
+  `query getFusionNotificationHistory($after: String, $first: Int, $includeHidden: Boolean) {
+  fusionNotificationHistory(after: $after, first: $first, includeHidden: $includeHidden) {
     nodes {
       ...FusionNotificationHistoryEntry
     }

--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -905,10 +905,9 @@ export class NotifiFrontendClient {
     return mutation.createDiscordTarget;
   }
 
-  async markFusionNotificationHistoryAsRead(input: {
-    ids: string[];
-    beforeId?: string;
-  }): Promise<Types.MarkFusionNotificationHistoryAsReadMutation> {
+  async markFusionNotificationHistoryAsRead(
+    input: Types.MarkFusionNotificationHistoryAsReadMutationVariables,
+  ): Promise<Types.MarkFusionNotificationHistoryAsReadMutation> {
     const mutation = await this._service.markFusionNotificationHistoryAsRead(
       input,
     );

--- a/packages/notifi-graphql/lib/gql/mutations/markFusionNotificationHistoryAsRead.gql.ts
+++ b/packages/notifi-graphql/lib/gql/mutations/markFusionNotificationHistoryAsRead.gql.ts
@@ -4,9 +4,10 @@ export const MarkFusionNotificationHistoryAsRead = gql`
   mutation markFusionNotificationHistoryAsRead(
     $ids: [String!]!
     $beforeId: String
+    $readState: NotificationHistoryReadState
   ) {
     markFusionNotificationHistoryAsRead(
-      input: { ids: $ids, beforeId: $beforeId }
+      input: { ids: $ids, beforeId: $beforeId, readState: $readState }
     )
   }
 `;

--- a/packages/notifi-graphql/lib/gql/queries/getFusionNotificationHistory.gql.ts
+++ b/packages/notifi-graphql/lib/gql/queries/getFusionNotificationHistory.gql.ts
@@ -4,8 +4,16 @@ import { FusionNotificationHistoryEntryFragment } from '../fragments/FusionNotif
 import { PageInfoFragment } from '../fragments/PageInfoFragment.gql';
 
 export const GetFusionNotificationHistory = gql`
-  query getFusionNotificationHistory($after: String, $first: Int) {
-    fusionNotificationHistory(after: $after, first: $first) {
+  query getFusionNotificationHistory(
+    $after: String
+    $first: Int
+    $includeHidden: Boolean
+  ) {
+    fusionNotificationHistory(
+      after: $after
+      first: $first
+      includeHidden: $includeHidden
+    ) {
       nodes {
         ...FusionNotificationHistoryEntryFragment
       }

--- a/packages/notifi-react-example/src/FrontendClient/SolanaFrontendClient.tsx
+++ b/packages/notifi-react-example/src/FrontendClient/SolanaFrontendClient.tsx
@@ -146,6 +146,47 @@ export const SolanaFrontendClient: FC = () => {
               >
                 4. mark newest notification history as read
               </button>
+              <button
+                onClick={async () => {
+                  const newestHistory = (
+                    await client?.getFusionNotificationHistory({
+                      first: 1,
+                      includeHidden: false,
+                    })
+                  )?.nodes?.[0];
+                  if (!newestHistory) {
+                    return alert('no notification in the tray');
+                  }
+
+                  client
+                    ?.markFusionNotificationHistoryAsRead({
+                      ids: [newestHistory.id],
+                      readState: 'HIDDEN',
+                      /**
+                       * @description - If intend to hide all notification at the same time, use below instead
+                       * ids: [],
+                       * beforeId: newestHistory.id,
+                       * readState: 'HIDDEN',
+                       */
+                    })
+                    .then(async () => {
+                      const updatedNewest = (
+                        await client?.getFusionNotificationHistory({
+                          first: 1,
+                          includeHidden: false,
+                        })
+                      )?.nodes?.[0];
+                      alert(
+                        `notification history (ID:${newestHistory.id}) created at ${newestHistory.createdDate} is hidden, 
+                    now the newest unhidden notification history (ID: ${updatedNewest?.id}) is created at ${updatedNewest?.createdDate}}`,
+                      );
+                      console.log(updatedNewest);
+                    })
+                    .catch((err) => alert(err));
+                }}
+              >
+                5. Hide newest notification
+              </button>
               <h3>Auth</h3>
               <button onClick={logOut}>logout</button>
             </>

--- a/packages/notifi-react-example/src/NotifiCard/SolanaCard.tsx
+++ b/packages/notifi-react-example/src/NotifiCard/SolanaCard.tsx
@@ -120,6 +120,47 @@ export const SolanaCard: React.FC = () => {
           >
             4. mark newest notification history as read
           </button>
+          <button
+            onClick={async () => {
+              const newestHistory = (
+                await client?.getFusionNotificationHistory({
+                  first: 1,
+                  includeHidden: false,
+                })
+              )?.nodes?.[0];
+              if (!newestHistory) {
+                return alert('no notification in the tray');
+              }
+
+              client
+                ?.markFusionNotificationHistoryAsRead({
+                  ids: [newestHistory.id],
+                  readState: 'HIDDEN',
+                  /**
+                   * @description - If intend to hide all notification at the same time, use below instead
+                   * ids: [],
+                   * beforeId: newestHistory.id,
+                   * readState: 'HIDDEN',
+                   */
+                })
+                .then(async () => {
+                  const updatedNewest = (
+                    await client?.getFusionNotificationHistory({
+                      first: 1,
+                      includeHidden: false,
+                    })
+                  )?.nodes?.[0];
+                  alert(
+                    `notification history (ID:${newestHistory.id}) created at ${newestHistory.createdDate} is hidden, 
+                    now the newest unhidden notification history (ID: ${updatedNewest?.id}) is created at ${updatedNewest?.createdDate}}`,
+                  );
+                  console.log(updatedNewest);
+                })
+                .catch((err) => alert(err));
+            }}
+          >
+            5. Hide newest notification
+          </button>
         </div>
       ) : (
         <div>Not yet register Notification</div>


### PR DESCRIPTION
Since we need to support “Clear all” feature for Osmosis, new state “HIDDEN” is supported on BE.

SDK also need to have corresponding modification to support mutate and query “HIDDEN” state.

## NOTE
Do not merge until being tested in dev.