### PR TITLE
allow opting out from default signup at first time signup for single events 

### DIFF
--- a/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
+++ b/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
@@ -18,6 +18,7 @@ export type DirectPushEventTypeItem = Readonly<{
   name: string;
   directPushId: ValueOrRef<string>;
   tooltipContent?: string;
+  optOutAtSignup?: boolean;
 }>;
 
 export type FusionTypeBase = {
@@ -28,6 +29,7 @@ export type FusionTypeBase = {
   tooltipContent?: string;
   maintainSourceGroup?: boolean;
   alertFrequency?: AlertFrequency;
+  optOutAtSignup?: boolean;
 };
 
 export type FusionToggleEventTypeItem = FusionTypeBase &
@@ -61,6 +63,7 @@ export type BroadcastEventTypeItem = Readonly<{
   name: string;
   broadcastId: ValueOrRef<string>;
   tooltipContent?: string;
+  optOutAtSignup?: boolean;
 }>;
 
 export type HealthCheckEventTypeItem = Readonly<{
@@ -69,12 +72,14 @@ export type HealthCheckEventTypeItem = Readonly<{
   checkRatios: ValueOrRef<CheckRatio[]>;
   alertFrequency: AlertFrequency;
   tooltipContent?: string;
+  optOutAtSignup?: boolean;
 }>;
 
 export type LabelEventTypeItem = Readonly<{
   type: 'label';
   name: string;
   tooltipContent?: string;
+  optOutAtSignup?: boolean;
 }>;
 
 export type TradingPairEventTypeItem = Readonly<{
@@ -82,6 +87,7 @@ export type TradingPairEventTypeItem = Readonly<{
   name: string;
   tooltipContent?: string;
   tradingPairs: ValueOrRef<ReadonlyArray<string>>;
+  optOutAtSignup?: boolean;
 }>;
 
 export type PriceChangeDataSource = 'coingecko';
@@ -92,12 +98,14 @@ export type PriceChangeEventTypeItem = Readonly<{
   tokenIds: ReadonlyArray<string>;
   dataSource: PriceChangeDataSource;
   tooltipContent: string;
+  optOutAtSignup?: boolean;
 }>;
 
 export type WalletBalanceEventTypeItem = Readonly<{
   type: 'walletBalance';
   name: string;
   tooltipContent?: string;
+  optOutAtSignup?: boolean;
 }>;
 
 export type CustomTypeBase = {
@@ -107,11 +115,13 @@ export type CustomTypeBase = {
   sourceType: Gql.SourceType;
   filterType: string;
   sourceAddress: ValueOrRef<string>;
+  optOutAtSignup?: boolean;
 };
 
 export type CustomToggleTypeItem = Readonly<{
   filterOptions: FilterOptions;
   selectedUIType: 'TOGGLE';
+  optOutAtSignup?: boolean;
 }>;
 
 export type NumberTypeSelect = 'percentage' | 'integer' | 'price';
@@ -122,6 +132,7 @@ export type CustomHealthCheckItem = Readonly<{
   numberType: NumberTypeSelect;
   alertFrequency: AlertFrequency;
   checkRatios: CheckRatio[];
+  optOutAtSignup?: boolean;
 }>;
 
 type RatiosBelow = Readonly<{
@@ -146,6 +157,7 @@ export type XMTPTopicTypeItem = {
   sourceType?: Gql.SourceType;
   filterType: string;
   XMTPTopics: ValueOrRef<ReadonlyArray<string>>;
+  optOutAtSignup?: boolean;
 };
 
 export type CreateSupportConversationEventTypeItem = {
@@ -154,6 +166,7 @@ export type CreateSupportConversationEventTypeItem = {
   sourceType: Gql.SourceType;
   filterType: string;
   alertFrequency: AlertFrequency;
+  optOutAtSignup?: boolean;
 };
 
 export type EventTypeItem =

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
@@ -154,7 +154,10 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
     try {
       let success = false;
       if (isFirstTimeUser && !isMultiWallet) {
-        const result = await subscribeAlerts(eventTypes, inputs);
+        const subEvents = eventTypes.filter((event) => {
+          return event.optOutAtSignup ? true : false;
+        });
+        const result = await subscribeAlerts(subEvents, inputs);
         success = !!result;
       } else {
         const result = await renewTargetGroups(targetGroup);

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
@@ -155,7 +155,7 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
       let success = false;
       if (isFirstTimeUser && !isMultiWallet) {
         const subEvents = eventTypes.filter((event) => {
-          return event.optOutAtSignup ? true : false;
+          return event.optOutAtSignup ? false : true;
         });
         const result = await subscribeAlerts(subEvents, inputs);
         success = !!result;

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/VerifyWalletView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/VerifyWalletView.tsx
@@ -107,7 +107,10 @@ const VerifyWalletView: React.FC<VerifyWalletViewProps> = ({
       setLoading(true);
 
       try {
-        await subscribeAlerts(data.eventTypes, inputs);
+        const subEvents = data.eventTypes.filter((event) => {
+          return event.optOutAtSignup ? true : false;
+        });
+        await subscribeAlerts(subEvents, inputs);
       } finally {
         setLoading(false);
       }

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/VerifyWalletView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/VerifyWalletView.tsx
@@ -108,7 +108,7 @@ const VerifyWalletView: React.FC<VerifyWalletViewProps> = ({
 
       try {
         const subEvents = data.eventTypes.filter((event) => {
-          return event.optOutAtSignup ? true : false;
+          return event.optOutAtSignup ? false : true;
         });
         await subscribeAlerts(subEvents, inputs);
       } finally {


### PR DESCRIPTION
This change adds the ability to opt out single events from signing up at user signup. This can be enabled by passing `true` through the optional `optOutAtSignup` field through a custom JSON card config