### PR TITLE
MVP-3202-patch: empty array case issue

### DIFF
--- a/packages/notifi-react-card/lib/utils/NotificationHistoryUtils.tsx
+++ b/packages/notifi-react-card/lib/utils/NotificationHistoryUtils.tsx
@@ -243,7 +243,7 @@ const concatHistoryNodes = (
       }
       return [...nodes, ...nodesToConcat];
     default:
-      throw new Error('Invalid type: NotificationHistoryEntry');
+      return nodesToConcat;
   }
 };
 


### PR DESCRIPTION
Fix the following case:
When concatenating history nodes, it will throws error if nodes is an empty array. 
