### PR TITLE
MVP-3315: Fix history not show if users re-signup

### DIFF
--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -433,15 +433,14 @@ export class NotifiFrontendClient {
         ? this._storage.setRoles(roles.filter(notNullOrEmpty))
         : Promise.resolve();
 
-    if (!authorization || !roles)
-      throw new Error('Failed to retrieve auth info');
-
-    const userState: UserState = {
-      status: 'authenticated',
-      authorization,
-      roles: roles.filter((role): role is string => !!role),
-    };
-    this._userState = userState;
+    if (authorization && roles) {
+      const userState: UserState = {
+        status: 'authenticated',
+        authorization,
+        roles: roles.filter((role): role is string => !!role),
+      };
+      this._userState = userState;
+    }
 
     await Promise.all([saveAuthorizationPromise, saveRolesPromise]);
   }

--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -433,6 +433,16 @@ export class NotifiFrontendClient {
         ? this._storage.setRoles(roles.filter(notNullOrEmpty))
         : Promise.resolve();
 
+    if (!authorization || !roles)
+      throw new Error('Failed to retrieve auth info');
+
+    const userState: UserState = {
+      status: 'authenticated',
+      authorization,
+      roles: roles.filter((role): role is string => !!role),
+    };
+    this._userState = userState;
+
     await Promise.all([saveAuthorizationPromise, saveRolesPromise]);
   }
 


### PR DESCRIPTION
The History will not show if users re-signup for some reason. Ex. losing jwt token (change browser/ pc ..etc) or token expiry.

This only happens when using frontend-client (which is default). Not happens in hooks (isUsingFrontendClient=false)

Visit Ticket page for more detail (issue video)

