### PR TITLE
MVP-3388: fix 'notifi-react-hooks' creates mutliple targetGroups while signing up

### DIFF
--- a/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
+++ b/packages/notifi-react-hooks/lib/hooks/useNotifiClient.ts
@@ -807,7 +807,7 @@ const useNotifiClient = (
           service,
           newData.targetGroups,
           {
-            name: existingAlert.targetGroup.name ?? name,
+            name: existingAlert.targetGroup.name ?? 'Default',
             emailTargetIds: emailTargetIds.filter((id): id is string => !!id),
             smsTargetIds: smsTargetIds.filter((id): id is string => !!id),
             telegramTargetIds: telegramTargetIds.filter(
@@ -989,7 +989,7 @@ const useNotifiClient = (
           service,
           newData.targetGroups,
           {
-            name: targetGroupName ?? name,
+            name: targetGroupName ?? 'Default',
             emailTargetIds: emailTargetIds.filter((id): id is string => !!id),
             smsTargetIds: smsTargetIds.filter((id): id is string => !!id),
             telegramTargetIds: telegramTargetIds.filter(


### PR DESCRIPTION
## Issue
if using `notifi-react-hook` (`isUsingFrontendClient=false`) in Card, multiple targetGroups with alert topic name will be created while signing up.

For more detail checkout the video in MVP-3388 ticket

> This issue does not happen under frontendClient (`isUsingFrontendClient=true` --> default)  since the targetGroup name is  always `Default` while the `ensureAlert` is called: https://github.com/notifi-network/notifi-sdk-ts/blob/e8aa23fb395f1bd28106a33c17b8b90baee8e796/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts#L650

