### PR TITLE
MVP-3387: show loading view while fetching history

### DIFF
--- a/packages/notifi-react-card/lib/components/common/LoadingStateCard.tsx
+++ b/packages/notifi-react-card/lib/components/common/LoadingStateCard.tsx
@@ -1,13 +1,11 @@
 import clsx from 'clsx';
 import React from 'react';
 
-import { LoadingState } from '../../hooks';
 import { DeepPartialReadonly } from '../../utils';
 import NotifiAlertBox, { NotifiAlertBoxProps } from '../NotifiAlertBox';
 import Spinner from './Spinner';
 
 export type LoadingStateCardProps = Readonly<{
-  card: LoadingState;
   spinnerSize?: string;
   ringColor?: string;
   copy?: DeepPartialReadonly<{

--- a/packages/notifi-react-card/lib/components/intercom/NotifiIntercomCardContainer.tsx
+++ b/packages/notifi-react-card/lib/components/intercom/NotifiIntercomCardContainer.tsx
@@ -22,12 +22,7 @@ export const NotifiIntercomCardContainer: React.FC<
 
   switch (card.state) {
     case 'loading':
-      contents = (
-        <LoadingStateCard
-          classNames={classNames?.LoadingStateCard}
-          card={card}
-        />
-      );
+      contents = <LoadingStateCard classNames={classNames?.LoadingStateCard} />;
       break;
     case 'error':
       contents = (

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscriptionCard.tsx
@@ -141,7 +141,6 @@ export const NotifiSubscriptionCard: React.FC<
           spinnerSize={loadingSpinnerSize}
           ringColor={loadingRingColor}
           classNames={classNames?.LoadingStateCard}
-          card={card}
           onClose={onClose}
         />
       );

--- a/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
@@ -48,6 +48,7 @@ import VerifyWalletView, {
 export type SubscriptionCardV1Props = Readonly<{
   copy?: DeepPartialReadonly<{
     EditCard: EditCardViewProps['copy'];
+    AlertHistory: AlertHistoryViewProps['copy'];
     expiredHeader: string;
     manageAlertsHeader: string;
     signUpHeader: string;
@@ -409,6 +410,7 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
             )}
             <AlertHistoryView
               classNames={classNames?.AlertHistoryView}
+              copy={copy?.AlertHistory}
               isHidden={selectedAlertEntry !== undefined}
               setAlertEntry={setAlertEntry}
               data={data}


### PR DESCRIPTION
## Issue

Opening the alert history moves the user through a loading screen, then it shows ‘no notification’, before showing the full history. User should see loading icon if payload has not been received.

## After fix (Video below)

https://github.com/notifi-network/notifi-sdk-ts/assets/127958634/60c4f2fd-4ce5-4171-8438-f8cb17b269c8

