### PR TITLE
MVP-3445: Fix Solana 'use hardwallet' not showing when destination is not required

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/EditCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/EditCardView.tsx
@@ -67,17 +67,14 @@ export const EditCardView: React.FC<EditCardViewProps> = ({
           <Spinner size="70px" />
         </div>
       ) : (
-        <>
-          {showPreview && !data.isContactInfoRequired ? null : (
-            <InputFields
-              data={data}
-              allowedCountryCodes={allowedCountryCodes}
-              inputDisabled={inputDisabled}
-              inputSeparators={inputSeparators}
-              inputTextFields={inputTextFields}
-            />
-          )}
-        </>
+        <InputFields
+          hideContactInputs={showPreview && !data.isContactInfoRequired}
+          data={data}
+          allowedCountryCodes={allowedCountryCodes}
+          inputDisabled={inputDisabled}
+          inputSeparators={inputSeparators}
+          inputTextFields={inputTextFields}
+        />
       )}
       <NotifiSubscribeButton
         buttonText={buttonText}

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/InputFields.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/InputFields.tsx
@@ -28,6 +28,7 @@ export type InputFieldsProps = {
   inputTextFields?: NotifiInputFieldsText;
   allowedCountryCodes: string[];
   inputDisabled: boolean;
+  hideContactInputs?: boolean;
   classNames?: Readonly<{
     NotifiEmailInput?: NotifiEmailInputProps['classNames'];
     NotifiSmsInput?: NotifiSmsInputProps['classNames'];
@@ -43,101 +44,105 @@ export const InputFields: React.FC<InputFieldsProps> = ({
   inputTextFields,
   allowedCountryCodes,
   inputDisabled,
+  hideContactInputs,
 }) => {
   const { params } = useNotifiClientContext();
 
   return (
     <>
-      {data.contactInfo.email.active ? (
-        <NotifiEmailInput
-          disabled={inputDisabled}
-          classNames={classNames?.NotifiEmailInput}
-          copy={{
-            label: inputTextFields?.label?.email,
-            placeholder: inputTextFields?.placeholderText?.email,
-          }}
-        />
-      ) : null}
-      {inputSeparators?.emailSeparator?.content ? (
-        <div
-          className={clsx(
-            'NotifiInputSeparator__container',
-            inputSeparators?.emailSeparator?.classNames?.container,
-          )}
-        >
-          <div
-            className={clsx(
-              'NotifiInputSeparator__content',
-              inputSeparators.emailSeparator.classNames?.content,
-            )}
-          >
-            {inputSeparators?.emailSeparator?.content}
-          </div>
-        </div>
-      ) : null}
-      {data.contactInfo.sms.active ? (
-        <NotifiSmsInput
-          disabled={inputDisabled}
-          classNames={classNames?.NotifiSmsInput}
-          allowedCountryCodes={allowedCountryCodes}
-          copy={{
-            label: inputTextFields?.label?.sms,
-            placeholder: inputTextFields?.placeholderText?.sms,
-          }}
-        />
-      ) : null}
-      {inputSeparators?.smsSeparator?.content ? (
-        <div
-          className={clsx(
-            'NotifiInputSeparator__container',
-            inputSeparators?.smsSeparator?.classNames?.container,
-          )}
-        >
-          <div
-            className={clsx(
-              'NotifiInputSeparator__content',
-              inputSeparators.smsSeparator.classNames?.content,
-            )}
-          >
-            {inputSeparators?.smsSeparator?.content}
-          </div>
-        </div>
-      ) : null}
-      {data.contactInfo.telegram.active ? (
-        <NotifiTelegramInput
-          disabled={inputDisabled}
-          classNames={classNames?.NotifiTelegramInput}
-          copy={{
-            label: inputTextFields?.label?.telegram,
-            placeholder: inputTextFields?.placeholderText?.telegram,
-          }}
-        />
-      ) : null}
-      {inputSeparators?.telegramSeparator?.content ? (
-        <div
-          className={clsx(
-            'NotifiInputSeparator__container',
-            inputSeparators?.telegramSeparator?.classNames?.container,
-          )}
-        >
-          <div
-            className={clsx(
-              'NotifiInputSeparator__content',
-              inputSeparators.telegramSeparator.classNames?.content,
-            )}
-          >
-            {inputSeparators?.telegramSeparator?.content}
-          </div>
-        </div>
-      ) : null}
+      {!hideContactInputs ? (
+        <>
+          {data.contactInfo.email.active ? (
+            <NotifiEmailInput
+              disabled={inputDisabled}
+              classNames={classNames?.NotifiEmailInput}
+              copy={{
+                label: inputTextFields?.label?.email,
+                placeholder: inputTextFields?.placeholderText?.email,
+              }}
+            />
+          ) : null}
+          {inputSeparators?.emailSeparator?.content ? (
+            <div
+              className={clsx(
+                'NotifiInputSeparator__container',
+                inputSeparators?.emailSeparator?.classNames?.container,
+              )}
+            >
+              <div
+                className={clsx(
+                  'NotifiInputSeparator__content',
+                  inputSeparators.emailSeparator.classNames?.content,
+                )}
+              >
+                {inputSeparators?.emailSeparator?.content}
+              </div>
+            </div>
+          ) : null}
+          {data.contactInfo.sms.active ? (
+            <NotifiSmsInput
+              disabled={inputDisabled}
+              classNames={classNames?.NotifiSmsInput}
+              allowedCountryCodes={allowedCountryCodes}
+              copy={{
+                label: inputTextFields?.label?.sms,
+                placeholder: inputTextFields?.placeholderText?.sms,
+              }}
+            />
+          ) : null}
+          {inputSeparators?.smsSeparator?.content ? (
+            <div
+              className={clsx(
+                'NotifiInputSeparator__container',
+                inputSeparators?.smsSeparator?.classNames?.container,
+              )}
+            >
+              <div
+                className={clsx(
+                  'NotifiInputSeparator__content',
+                  inputSeparators.smsSeparator.classNames?.content,
+                )}
+              >
+                {inputSeparators?.smsSeparator?.content}
+              </div>
+            </div>
+          ) : null}
+          {data.contactInfo.telegram.active ? (
+            <NotifiTelegramInput
+              disabled={inputDisabled}
+              classNames={classNames?.NotifiTelegramInput}
+              copy={{
+                label: inputTextFields?.label?.telegram,
+                placeholder: inputTextFields?.placeholderText?.telegram,
+              }}
+            />
+          ) : null}
+          {inputSeparators?.telegramSeparator?.content ? (
+            <div
+              className={clsx(
+                'NotifiInputSeparator__container',
+                inputSeparators?.telegramSeparator?.classNames?.container,
+              )}
+            >
+              <div
+                className={clsx(
+                  'NotifiInputSeparator__content',
+                  inputSeparators.telegramSeparator.classNames?.content,
+                )}
+              >
+                {inputSeparators?.telegramSeparator?.content}
+              </div>
+            </div>
+          ) : null}
 
-      {data.contactInfo?.discord?.active ? (
-        <NotifiDiscordToggle
-          disabled={inputDisabled}
-          classNames={classNames?.NotifiDiscordToggle}
-        />
+          {data.contactInfo?.discord?.active ? (
+            <NotifiDiscordToggle
+              disabled={inputDisabled}
+              classNames={classNames?.NotifiDiscordToggle}
+            />
+          ) : null}
+        </>
       ) : null}
-
       {params.walletBlockchain === 'SOLANA' ? (
         <NotifiHwWalletToggle
           disabled={inputDisabled}

--- a/packages/notifi-react-card/lib/hooks/useUnreadState.ts
+++ b/packages/notifi-react-card/lib/hooks/useUnreadState.ts
@@ -29,11 +29,6 @@ export const useUnreadState = () => {
     };
   }, [frontendClient.userState?.status]);
 
-  useEffect(
-    () => console.log({ isClientAuthenticated }),
-    [isClientAuthenticated],
-  );
-
   useEffect(() => {
     if (!walletPublicKey || !isClientAuthenticated) return;
 


### PR DESCRIPTION
In the react-card, when “Require Destinations” is turned off the signup page does not render the input fields including the “use hardware wallet” toggle for Solana with the hw wallet package. However the user needs to sign a message to login so will end up in a locked state where they cannot register at all. This will prevent any Solana users using a hw wallet from signing up to any dapp notifications. We should render the “use hardware wallet” toggle even if require destination is turned off.