### PR TITLE
Add publishFusionMessage to notifi-node

### DIFF
--- a/packages/notifi-graphql/lib/NotifiService.ts
+++ b/packages/notifi-graphql/lib/NotifiService.ts
@@ -50,6 +50,7 @@ export class NotifiService
     Operations.GetWebhookTargetsService,
     Operations.LogInFromDappService,
     Operations.LogInFromServiceService,
+    Operations.PublishFusionMessageService,
     Operations.RefreshAuthorizationService,
     Operations.RemoveSourceFromSourceGroupService,
     Operations.SendConversationMessageService,
@@ -436,6 +437,13 @@ export class NotifiService
       variables,
       headers,
     );
+  }
+
+  async publishFusionMessage(
+    variables: Generated.PublishFusionMessageMutationVariables,
+  ): Promise<Generated.PublishFusionMessageMutation> {
+    const headers = this._requestHeaders();
+    return this._typedClient.publishFusionMessage(variables, headers);
   }
 
   async refreshAuthorization(

--- a/packages/notifi-graphql/lib/gql/mutations/publishFusionMessage.gql.ts
+++ b/packages/notifi-graphql/lib/gql/mutations/publishFusionMessage.gql.ts
@@ -1,0 +1,19 @@
+import { gql } from 'graphql-request';
+
+export const PublishFusionMessage = gql`
+  mutation publishFusionMessage(
+    $eventTypeId: String!
+    $variablesJson: String!
+    $specificWallets: [KeyValuePairOfStringAndWalletBlockchainInput!]
+  ) {
+    publishFusionMessage(
+      publishFusionMessageInput: {
+        eventTypeId: $eventTypeId
+        variablesJson: $variablesJson
+        specificWallets: $specificWallets
+      }
+    ) {
+      eventUuid
+    }
+  }
+`;

--- a/packages/notifi-graphql/lib/operations/PublishFusionMessage.ts
+++ b/packages/notifi-graphql/lib/operations/PublishFusionMessage.ts
@@ -1,0 +1,10 @@
+import {
+  PublishFusionMessageMutation,
+  PublishFusionMessageMutationVariables,
+} from '../gql/generated';
+
+export type PublishFusionMessageService = Readonly<{
+  publishFusionMessage: (
+    variables: PublishFusionMessageMutationVariables,
+  ) => Promise<PublishFusionMessageMutation>;
+}>;

--- a/packages/notifi-graphql/lib/operations/index.ts
+++ b/packages/notifi-graphql/lib/operations/index.ts
@@ -37,6 +37,7 @@ export * from './GetTopics';
 export * from './GetWebhookTargets';
 export * from './LogInFromDappService';
 export * from './LogInFromServiceService';
+export * from './PublishFusionMessage';
 export * from './RefreshAuthorization';
 export * from './RemoveSourceFromSourceGroup';
 export * from './SendMessageService';

--- a/packages/notifi-node/lib/client/NotifiClient.ts
+++ b/packages/notifi-node/lib/client/NotifiClient.ts
@@ -75,6 +75,38 @@ class NotifiClient {
     }
   };
 
+  publishFusionMessage: (
+    jwt: string,
+    params: Readonly<{
+      eventTypeId: string;
+      variables: object;
+      specificWallets?: ReadonlyArray<
+        Readonly<{
+          walletPublicKey: string;
+          walletBlockchain: WalletBlockchain;
+        }>
+      >;
+    }>,
+  ) => Promise<void> = async (
+    jwt,
+    { eventTypeId, variables, specificWallets },
+  ) => {
+    this.service.setJwt(jwt);
+    await this.service.publishFusionMessage({
+      eventTypeId,
+      variablesJson: JSON.stringify(variables),
+      specificWallets:
+        specificWallets === undefined || specificWallets.length === 0
+          ? undefined
+          : specificWallets.map(({ walletPublicKey, walletBlockchain }) => {
+              return {
+                key: walletPublicKey,
+                value: walletBlockchain,
+              };
+            }),
+    });
+  };
+
   sendDirectPush: (
     jwt: string,
     params: Readonly<{


### PR DESCRIPTION
The publish message API is used by tenantMessenger to publish to arbitrary Event IDs with arbitrary variables.

It supports filtering via specificWallets, which is optional