### PR TITLE
MVP-3466: fix error while switching to consuming hooks (react-example)

### DIFF
--- a/packages/notifi-react-example/src/NotifiCard/KeplrCard.tsx
+++ b/packages/notifi-react-example/src/NotifiCard/KeplrCard.tsx
@@ -22,7 +22,7 @@ export const KeplrConnectButton: React.FC = () => {
 export const KeplrCard: React.FC = () => {
   const [isCardOpen, setIsCardOpen] = useState(false);
   const { alerts } = useNotifiSubscriptionContext();
-  const { client } = useNotifiClientContext();
+  const { client, isUsingFrontendClient } = useNotifiClientContext();
   const { key } = useKeplrContext();
   const keyBase64 = useMemo(
     () =>
@@ -51,8 +51,10 @@ export const KeplrCard: React.FC = () => {
         <div>Not yet register Notification</div>
       )}
       <h3>Display NotifiSubscriptionCard</h3>
-      <BellButton setIsCardOpen={setIsCardOpen} />
-      {isCardOpen ? (
+      {isUsingFrontendClient ? (
+        <BellButton setIsCardOpen={setIsCardOpen} />
+      ) : null}
+      {isCardOpen || !isUsingFrontendClient ? (
         <NotifiSubscriptionCard
           darkMode
           inputs={{ userWallet: key?.bech32Address }}

--- a/packages/notifi-react-example/src/NotifiCard/MetamaskCard.tsx
+++ b/packages/notifi-react-example/src/NotifiCard/MetamaskCard.tsx
@@ -11,7 +11,7 @@ import { BellButton } from './BellButton';
 export const MetamaskCard = () => {
   const [isCardOpen, setIsCardOpen] = useState(false);
   const { alerts } = useNotifiSubscriptionContext();
-  const { client } = useNotifiClientContext();
+  const { client, isUsingFrontendClient } = useNotifiClientContext();
   const { address } = useAccount();
   return (
     <>
@@ -33,8 +33,10 @@ export const MetamaskCard = () => {
           ) : (
             <div>Not yet register Notification</div>
           )}
-          <BellButton setIsCardOpen={setIsCardOpen} />
-          {isCardOpen ? (
+          {isUsingFrontendClient ? (
+            <BellButton setIsCardOpen={setIsCardOpen} />
+          ) : null}
+          {isCardOpen || !isUsingFrontendClient ? (
             <NotifiSubscriptionCard
               darkMode
               inputs={{ userWallet: address }}

--- a/packages/notifi-react-example/src/NotifiCard/PolkadotCard.tsx
+++ b/packages/notifi-react-example/src/NotifiCard/PolkadotCard.tsx
@@ -14,7 +14,7 @@ import { BellButton } from './BellButton';
 export const PolkadotCard = () => {
   const [isCardOpen, setIsCardOpen] = useState(false);
   const { alerts } = useNotifiSubscriptionContext();
-  const { client } = useNotifiClientContext();
+  const { client, isUsingFrontendClient } = useNotifiClientContext();
   const { acalaAddress, connected } = useAcalaWallet();
 
   if (!connected || !acalaAddress) {
@@ -44,8 +44,10 @@ export const PolkadotCard = () => {
         <div>Not yet register Notification</div>
       )}
       <h3>Display NotifiSubscriptionCard</h3>
-      <BellButton setIsCardOpen={setIsCardOpen} />
-      {isCardOpen ? (
+      {isUsingFrontendClient ? (
+        <BellButton setIsCardOpen={setIsCardOpen} />
+      ) : null}
+      {isCardOpen || !isUsingFrontendClient ? (
         <NotifiSubscriptionCard
           darkMode
           cardId="d8859ea72ff4449fa8f7f293ebd333c9"

--- a/packages/notifi-react-example/src/NotifiCard/SolanaCard.tsx
+++ b/packages/notifi-react-example/src/NotifiCard/SolanaCard.tsx
@@ -15,7 +15,7 @@ import './NotifiCard.css';
 export const SolanaCard: React.FC = () => {
   const [isCardOpen, setIsCardOpen] = React.useState(false);
   const { alerts } = useNotifiSubscriptionContext();
-  const { client } = useNotifiClientContext();
+  const { client, isUsingFrontendClient } = useNotifiClientContext();
   const inputLabels: NotifiInputFieldsText = {
     label: {
       email: 'Email',
@@ -62,8 +62,10 @@ export const SolanaCard: React.FC = () => {
       )}
       <h3>Display NotifiSubscriptionCard</h3>
 
-      <BellButton setIsCardOpen={setIsCardOpen} />
-      {isCardOpen ? (
+      {isUsingFrontendClient ? (
+        <BellButton setIsCardOpen={setIsCardOpen} />
+      ) : null}
+      {isCardOpen || !isUsingFrontendClient ? (
         <NotifiSubscriptionCard
           darkMode
           inputLabels={inputLabels}

--- a/packages/notifi-react-example/src/NotifiCard/SuiNotifiCard.tsx
+++ b/packages/notifi-react-example/src/NotifiCard/SuiNotifiCard.tsx
@@ -10,7 +10,7 @@ import { BellButton } from './BellButton';
 export const SuiNotifiCard: React.FC = () => {
   const [isCardOpen, setIsCardOpen] = useState(false);
   const { alerts } = useNotifiSubscriptionContext();
-  const { client } = useNotifiClientContext();
+  const { client, isUsingFrontendClient } = useNotifiClientContext();
 
   return (
     <div className="container">
@@ -31,8 +31,10 @@ export const SuiNotifiCard: React.FC = () => {
         <div>Not yet register Notification</div>
       )}
       <h3>Display NotifiSubscriptionCard</h3>
-      <BellButton setIsCardOpen={setIsCardOpen} />
-      {isCardOpen ? (
+      {isUsingFrontendClient ? (
+        <BellButton setIsCardOpen={setIsCardOpen} />
+      ) : null}
+      {isCardOpen || !isUsingFrontendClient ? (
         <NotifiSubscriptionCard
           darkMode
           cardId="d8859ea72ff4449fa8f7f293ebd333c9"

--- a/packages/notifi-react-example/src/NotifiCard/WalletConnectCard.tsx
+++ b/packages/notifi-react-example/src/NotifiCard/WalletConnectCard.tsx
@@ -10,7 +10,7 @@ import { BellButton } from './BellButton';
 export const WalletConnectCard = () => {
   const [isCardOpen, setIsCardOpen] = useState(false);
   const { alerts } = useNotifiSubscriptionContext();
-  const { client } = useNotifiClientContext();
+  const { client, isUsingFrontendClient } = useNotifiClientContext();
   return (
     <div>
       <h1>Notifi Card: WalletConnect</h1>
@@ -29,8 +29,10 @@ export const WalletConnectCard = () => {
       ) : (
         <div>Not yet register Notification</div>
       )}
-      <BellButton setIsCardOpen={setIsCardOpen} />
-      {isCardOpen ? (
+      {isUsingFrontendClient ? (
+        <BellButton setIsCardOpen={setIsCardOpen} />
+      ) : null}
+      {isCardOpen || !isUsingFrontendClient ? (
         <NotifiSubscriptionCard
           darkMode
           cardId="7fa9505a96064ed6b91ba2d14a9732de"


### PR DESCRIPTION
As title, fixing the error when using `isUsingFrontendClient=false` for `notifi-react-example`