### PR TITLE
fix can not toggle off discord target

### DIFF
--- a/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
@@ -345,7 +345,6 @@ export const NotifiSubscriptionContextProvider: React.FC<
         } else {
           setDiscordErrorMessage(undefined);
         }
-        setUseDiscord(true);
         setDiscordTargetData(discordTarget);
       } else {
         const targets = newData?.discordTarget;

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -249,7 +249,6 @@ export const useNotifiSubscribe: ({
         } else {
           setDiscordErrorMessage(undefined);
         }
-        setUseDiscord(true);
         setDiscordTargetData(discordTarget);
       } else {
         handleMissingDiscordTarget(newData?.discordTargets ?? []);


### PR DESCRIPTION
when there is a discord target exists(discord id is exists), we always reset the useDiscord to true, even if the user has been toggles off the discord from edit view. 
`contactInfo?.discord?.active && useDiscord` is the logic for showing discord target, useDiscord === true should only be set when user switches on from the toggle button