### PR TITLE
Fix discord target in NotifiSubscribeButton

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
@@ -1,4 +1,3 @@
-import { SignMessageParams } from '@notifi-network/notifi-frontend-client';
 import {
   CardConfigItemV1,
   EventTypeConfig,
@@ -48,7 +47,6 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
   const { isInitialized, subscribe, updateTargetGroups } = useNotifiSubscribe({
     targetGroupName: 'Default',
   });
-  const { useHardwareWallet } = useNotifiSubscriptionContext();
   const frontendClientLogin = useFrontendClientLogin();
 
   const {
@@ -94,18 +92,7 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
   const subscribeAlerts = useCallback(
     async (eventTypes: EventTypeConfig, inputs: Record<string, unknown>) => {
       if (isUsingFrontendClient) {
-        const data = await frontendClient.fetchData();
-        let discordTarget = data.targetGroup?.[0]?.discordTargets?.find(
-          (target) => target?.name === 'Default',
-        );
-        if (useDiscord && !discordTarget) {
-          discordTarget = await frontendClient.createDiscordTarget('Default');
-        }
-
-        await renewTargetGroups({
-          ...targetGroup,
-          discordId: discordTarget?.id,
-        });
+        await renewTargetGroups(targetGroup);
 
         return subscribeAlertsByFrontendClient(
           frontendClient,
@@ -117,14 +104,7 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
         createConfigurations(eventTypes, inputs, connectedWallets),
       );
     },
-    [
-      isUsingFrontendClient,
-      frontendClient,
-      email,
-      phoneNumber,
-      telegramId,
-      useDiscord,
-    ],
+    [targetGroup, isUsingFrontendClient, frontendClient, connectedWallets],
   );
 
   const renewTargetGroups = useCallback(
@@ -134,7 +114,14 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
       }
       return updateTargetGroups();
     },
-    [email, phoneNumber, useDiscord, telegramId, frontendClient],
+    [
+      email,
+      phoneNumber,
+      useDiscord,
+      telegramId,
+      frontendClient,
+      isUsingFrontendClient,
+    ],
   );
 
   const onClick = useCallback(async () => {

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
@@ -89,6 +89,16 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
     [email, phoneNumber, telegramId, useDiscord],
   );
 
+  const renewTargetGroups = useCallback(
+    async (targetGroup: TargetGroupData) => {
+      if (isUsingFrontendClient) {
+        return frontendClient.ensureTargetGroup(targetGroup);
+      }
+      return updateTargetGroups();
+    },
+    [updateTargetGroups, frontendClient, isUsingFrontendClient],
+  );
+
   const subscribeAlerts = useCallback(
     async (eventTypes: EventTypeConfig, inputs: Record<string, unknown>) => {
       if (isUsingFrontendClient) {
@@ -104,23 +114,15 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
         createConfigurations(eventTypes, inputs, connectedWallets),
       );
     },
-    [targetGroup, isUsingFrontendClient, frontendClient, connectedWallets],
-  );
-
-  const renewTargetGroups = useCallback(
-    async (targetGroup: TargetGroupData) => {
-      if (isUsingFrontendClient) {
-        return frontendClient.ensureTargetGroup(targetGroup);
-      }
-      return updateTargetGroups();
-    },
     [
-      email,
-      phoneNumber,
-      useDiscord,
-      telegramId,
-      frontendClient,
+      targetGroup,
       isUsingFrontendClient,
+      frontendClient,
+      connectedWallets,
+      renewTargetGroups,
+      subscribeAlertsByFrontendClient,
+      subscribe,
+      createConfigurations,
     ],
   );
 

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -713,13 +713,6 @@ export const useNotifiSubscribe: ({
 
     let finalPhoneNumber = undefined;
 
-    let finalDiscordId = undefined;
-
-    if (useDiscord === true) {
-      finalDiscordId =
-        discordTargetDatafromSubscriptionContext?.id ?? 'Default';
-    }
-
     if (isValidPhoneNumber(formPhoneNumber)) {
       finalPhoneNumber = formPhoneNumber;
     }


### PR DESCRIPTION
The button had unnecessary logic for resolving the discord target.

This is probably stemming from the misnamed "discordId" param

Simply rely on ensureTargetGroup to do the right thing