### PR TITLE
MVP-3529: Add 'X-Notifi-Client-Version' into gql request header

### DIFF
--- a/packages/notifi-graphql/lib/NotifiService.ts
+++ b/packages/notifi-graphql/lib/NotifiService.ts
@@ -1,6 +1,7 @@
 import { GraphQLClient } from 'graphql-request';
 import { v4 as uuid } from 'uuid';
 
+import { version } from '../package.json';
 import * as Generated from './gql/generated';
 import { getSdk } from './gql/generated';
 import type * as Operations from './operations';
@@ -508,7 +509,10 @@ export class NotifiService
 
   private _requestHeaders(): HeadersInit {
     const requestId = uuid();
-    const headers: HeadersInit = { 'X-Request-Id': requestId };
+    const headers: HeadersInit = {
+      'X-Request-Id': requestId,
+      'X-Notifi-Client-Version': version,
+    };
 
     if (this._jwt !== undefined) {
       headers['Authorization'] = `Bearer ${this._jwt}`;


### PR DESCRIPTION
Adding the ability to track the SDK version from each gql request to debug more efficiently.

See the demo video herewith:


https://github.com/notifi-network/notifi-sdk-ts/assets/127958634/6d156e23-a755-4dcf-a5a5-1b9defa5c78f

