### PR TITLE
MVP-3641: Setup new cardConfig and scaffold SubscriptionCaardV2

### DIFF
--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -7,8 +7,10 @@ import type {
   NotifiFrontendConfiguration,
 } from '../configuration';
 import type {
+  CardConfigItem,
   CardConfigItemV1,
   EventTypeItem,
+  TopicTypeItem,
   WalletBalanceEventTypeItem,
 } from '../models';
 import { IntercomCardConfigItemV1 } from '../models/IntercomCardConfig';
@@ -153,7 +155,7 @@ type FindSubscriptionCardParams = Omit<Types.FindTenantConfigInput, 'tenant'>;
 // modify the string literal, which then causes authentication to fail due to different strings
 export const SIGNING_MESSAGE = `Sign in with Notifi \n\n    No password needed or gas is needed. \n\n    Clicking “Approve” only means you have proved this wallet is owned by you! \n\n    This request will not trigger any transaction or cost any gas fees. \n\n    Use of our website and service is subject to our terms of service and privacy policy. \n \n 'Nonce:' `;
 
-export type SupportedCardConfigType = CardConfigItemV1;
+export type SupportedCardConfigType = CardConfigItem;
 
 export type UserState = Readonly<
   | {
@@ -649,7 +651,7 @@ export class NotifiFrontendClient {
     inputs,
     targetGroupName = 'Default',
   }: Readonly<{
-    eventType: EventTypeItem;
+    eventType: EventTypeItem | TopicTypeItem;
     inputs: Record<string, unknown>;
     targetGroupName?: string;
   }>): Promise<Types.AlertFragmentFragment> {

--- a/packages/notifi-frontend-client/lib/client/ensureSource.ts
+++ b/packages/notifi-frontend-client/lib/client/ensureSource.ts
@@ -11,6 +11,7 @@ import {
   HealthCheckEventTypeItem,
   PriceChangeEventTypeItem,
   ThresholdDirection,
+  TopicTypeItem,
   TradingPairEventTypeItem,
   WalletBalanceEventTypeItem,
   XMTPTopicTypeItem,
@@ -43,7 +44,7 @@ const ensureDirectPushSource = async (
 
 const ensureFusionSource = async (
   service: Operations.GetSourcesService & Operations.CreateSourceService,
-  eventType: FusionEventTypeItem,
+  eventType: FusionEventTypeItem | TopicTypeItem,
   inputs: Record<string, unknown>,
 ): Promise<Types.SourceFragmentFragment> => {
   const address = resolveStringRef(
@@ -414,7 +415,7 @@ const ensureSources = async (
   service: Operations.GetSourcesService &
     Operations.CreateSourceService &
     Operations.GetConnectedWalletsService,
-  eventType: EventTypeItem,
+  eventType: EventTypeItem | TopicTypeItem,
   inputs: Record<string, unknown>,
 ): Promise<ReadonlyArray<Types.SourceFragmentFragment>> => {
   switch (eventType.type) {
@@ -665,7 +666,7 @@ const getWalletBalanceSourceFilter = (
 };
 const getFusionSourceFilter = (
   source: Types.SourceFragmentFragment,
-  eventType: FusionEventTypeItem,
+  eventType: FusionEventTypeItem | TopicTypeItem,
   inputs: Record<string, unknown>,
 ): GetFilterResults => {
   const filter = source.applicableFilters?.find(
@@ -676,7 +677,10 @@ const getFusionSourceFilter = (
   }
 
   let filterOptions: FilterOptions = {}; // Default {}
-  if (eventType.selectedUIType === 'TOGGLE'  || eventType.selectedUIType === 'MULTI_THRESHOLD') {
+  if (
+    eventType.selectedUIType === 'TOGGLE' ||
+    eventType.selectedUIType === 'MULTI_THRESHOLD'
+  ) {
     if (eventType.alertFrequency !== undefined) {
       filterOptions = {
         alertFrequency: eventType.alertFrequency,
@@ -901,7 +905,7 @@ export const ensureSourceAndFilters = async (
     Operations.CreateSourceGroupService &
     Operations.UpdateSourceGroupService &
     Operations.GetConnectedWalletsService,
-  eventType: EventTypeItem,
+  eventType: EventTypeItem | TopicTypeItem,
   inputs: Record<string, unknown>,
 ): Promise<
   Readonly<{

--- a/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
+++ b/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
@@ -228,11 +228,19 @@ export type ContactInfoConfig = Readonly<{
   discord: DiscordContactInfo;
 }>;
 
-export type CardConfigItemV1 = Readonly<{
-  version: 'v1';
+export type CardConfigItem = CardConfigItemV1 | CardConfigItemV2;
+
+export type CardConfigItemV2 = Readonly<
+  { version: 'v2'; topicTypes: TopicTypeItem[] } & CardConfigBase
+>;
+
+export type CardConfigItemV1 = Readonly<
+  { version: 'v1'; eventTypes: EventTypeConfig } & CardConfigBase
+>;
+
+export type CardConfigBase = Readonly<{
   id: string | null;
   name: string;
-  eventTypes: EventTypeConfig;
   inputs: InputsConfig;
   contactInfo: ContactInfoConfig;
   isContactInfoRequired?: boolean;
@@ -255,3 +263,40 @@ export type TitleSubtitleConfigActive = Readonly<{
 export type TitleSubtitleConfig =
   | TitleSubtitleConfigActive
   | TitleSubtitleConfigInactive;
+
+// SDK3.0 (SubscriptionCardV2)
+// Rename EventTypeItem to TopicTypeItem for the naming convention (AP V2)
+export type TopicTypeItem = TopicTypeItemBase & FrontendUIType;
+
+type TopicTypeItemBase = {
+  name: string;
+  type: 'fusion'; // This is for backward compatibility to differentiate from legacy type.
+  fusionEventId: ValueOrRef<string>;
+  sourceAddress: ValueOrRef<string>;
+  tooltipContent?: string;
+  maintainSourceGroup?: boolean;
+  alertFrequency?: AlertFrequency;
+  optOutAtSignup?: boolean;
+  displayNameOverride?: string;
+};
+
+// To differentiate fusion UI type, use `selectedUIType`.
+type FrontendUIType = Toggle | HealthCheck | MultiThreshold;
+
+type Toggle = Readonly<{
+  selectedUIType: 'TOGGLE';
+}>;
+
+type HealthCheck = Readonly<{
+  selectedUIType: 'HEALTH_CHECK';
+  healthCheckSubtitle: string;
+  numberType: NumberTypeSelect;
+  checkRatios: CheckRatio[];
+}>;
+
+type MultiThreshold = Readonly<{
+  selectedUIType: 'MULTI_THRESHOLD';
+  numberType: NumberTypeSelect;
+  subtitle?: string;
+  addThreshholdTitle?: string;
+}>;

--- a/packages/notifi-react-card/lib/components/ConfigAlertModal.tsx
+++ b/packages/notifi-react-card/lib/components/ConfigAlertModal.tsx
@@ -1,9 +1,10 @@
-import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
+import { CardConfigItem } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import React from 'react';
 
 import AlertActionIcon from './AlertBox/AlertActionIcon';
 import { AlertsPanel, AlertsPanelProps, FtuConfigStep } from './subscription';
+import { TopicsPanel } from './subscription/v2/TopicsPanel';
 
 export type ConfigAlertModalProps = Readonly<{
   classNames?: {
@@ -18,7 +19,7 @@ export type ConfigAlertModalProps = Readonly<{
     ctaIcon?: string;
   };
   setFtuConfigStep: (step: FtuConfigStep) => void;
-  data: CardConfigItemV1;
+  data: CardConfigItem;
   inputDisabled: boolean;
   inputs: Record<string, unknown>;
 }>;
@@ -83,60 +84,123 @@ export const ConfigAlertModal: React.FC<ConfigAlertModalProps> = ({
             />
           </div>
         </div>
-        <AlertsPanel
-          classNames={
-            classNames?.alertsPanel ?? {
-              EventTypeContainer: 'configAlertModal__EventTypeContainer',
-              EventTypeBroadcastRow: {
-                container: 'configAlertModal__EventTypeBroadcastRow',
-              },
-              EventTypeCustomHealthCheckRow: {
-                container: 'configAlertModal__EventTypeCustomHealthCheckRow',
-                content:
-                  'configAlertModal__EventTypeCustomHealthCheckRow__Subtitle',
-                buttonContainer:
-                  'configAlertModal__EventTypeCustomHealthCheckRow__ButtonContainer',
-              },
-              EventTypeDirectPushRow: {
-                container: 'configAlertModal__EventTypeDirectPushRow',
-              },
-              EventTypeHealthCheckRow: {
-                container: 'configAlertModal__EventTypeHealthCheckRow',
-                content: 'configAlertModal__EventTypeHealthCheckRow__Subtitle',
-                buttonContainer:
-                  'configAlertModal__EventTypeHealthCheckRow__ButtonContainer',
-              },
-              EventTypePriceChangeRow: {
-                container: 'configAlertModal__EventTypePriceChangeRow',
-              },
-              EventTypeTradingPairsRow: {
-                container: 'configAlertModal__EventTypeTradingPairsRow',
-              },
-              EventTypeFusionMultiThresholdRow: {
-                container: 'configAlertModal__EventTypeFusionMultiThresholdRow',
-              },
-              EventTypeWalletBalanceRow: {
-                container: 'configAlertModal__EventTypeWalletBalanceRow',
-              },
-              EventTypeXMTPRow: {
-                container: 'configAlertModal__EventTypeXMTPRow',
-              },
-              EventTypeFusionToggleRow: {
-                container: 'configAlertModal__EventTypeFusionToggleRow',
-              },
-              EventTypeFusionHealthCheckRow: {
-                container: 'configAlertModal__EventTypeFusionHealthCheckRow',
-                content:
-                  'configAlertModal__EventTypeFusionHealthCheckRow__Subtitle',
-                buttonContainer:
-                  'configAlertModal__EventTypeFusionHealthCheckRow__ButtonContainer',
-              },
+        {data.version === 'v1' ? (
+          <AlertsPanel
+            classNames={
+              classNames?.alertsPanel ?? {
+                EventTypeContainer: 'configAlertModal__EventTypeContainer',
+                EventTypeBroadcastRow: {
+                  container: 'configAlertModal__EventTypeBroadcastRow',
+                },
+                EventTypeCustomHealthCheckRow: {
+                  container: 'configAlertModal__EventTypeCustomHealthCheckRow',
+                  content:
+                    'configAlertModal__EventTypeCustomHealthCheckRow__Subtitle',
+                  buttonContainer:
+                    'configAlertModal__EventTypeCustomHealthCheckRow__ButtonContainer',
+                },
+                EventTypeDirectPushRow: {
+                  container: 'configAlertModal__EventTypeDirectPushRow',
+                },
+                EventTypeHealthCheckRow: {
+                  container: 'configAlertModal__EventTypeHealthCheckRow',
+                  content:
+                    'configAlertModal__EventTypeHealthCheckRow__Subtitle',
+                  buttonContainer:
+                    'configAlertModal__EventTypeHealthCheckRow__ButtonContainer',
+                },
+                EventTypePriceChangeRow: {
+                  container: 'configAlertModal__EventTypePriceChangeRow',
+                },
+                EventTypeTradingPairsRow: {
+                  container: 'configAlertModal__EventTypeTradingPairsRow',
+                },
+                EventTypeFusionMultiThresholdRow: {
+                  container:
+                    'configAlertModal__EventTypeFusionMultiThresholdRow',
+                },
+                EventTypeWalletBalanceRow: {
+                  container: 'configAlertModal__EventTypeWalletBalanceRow',
+                },
+                EventTypeXMTPRow: {
+                  container: 'configAlertModal__EventTypeXMTPRow',
+                },
+                EventTypeFusionToggleRow: {
+                  container: 'configAlertModal__EventTypeFusionToggleRow',
+                },
+                EventTypeFusionHealthCheckRow: {
+                  container: 'configAlertModal__EventTypeFusionHealthCheckRow',
+                  content:
+                    'configAlertModal__EventTypeFusionHealthCheckRow__Subtitle',
+                  buttonContainer:
+                    'configAlertModal__EventTypeFusionHealthCheckRow__ButtonContainer',
+                },
+              }
             }
-          }
-          data={data}
-          inputDisabled={inputDisabled}
-          inputs={inputs}
-        />
+            data={data}
+            inputDisabled={inputDisabled}
+            inputs={inputs}
+          />
+        ) : (
+          // TODO: MVP-3655
+          <TopicsPanel
+            classNames={
+              classNames?.alertsPanel ?? {
+                EventTypeContainer: 'configAlertModal__EventTypeContainer',
+                EventTypeBroadcastRow: {
+                  container: 'configAlertModal__EventTypeBroadcastRow',
+                },
+                EventTypeCustomHealthCheckRow: {
+                  container: 'configAlertModal__EventTypeCustomHealthCheckRow',
+                  content:
+                    'configAlertModal__EventTypeCustomHealthCheckRow__Subtitle',
+                  buttonContainer:
+                    'configAlertModal__EventTypeCustomHealthCheckRow__ButtonContainer',
+                },
+                EventTypeDirectPushRow: {
+                  container: 'configAlertModal__EventTypeDirectPushRow',
+                },
+                EventTypeHealthCheckRow: {
+                  container: 'configAlertModal__EventTypeHealthCheckRow',
+                  content:
+                    'configAlertModal__EventTypeHealthCheckRow__Subtitle',
+                  buttonContainer:
+                    'configAlertModal__EventTypeHealthCheckRow__ButtonContainer',
+                },
+                EventTypePriceChangeRow: {
+                  container: 'configAlertModal__EventTypePriceChangeRow',
+                },
+                EventTypeTradingPairsRow: {
+                  container: 'configAlertModal__EventTypeTradingPairsRow',
+                },
+                EventTypeFusionMultiThresholdRow: {
+                  container:
+                    'configAlertModal__EventTypeFusionMultiThresholdRow',
+                },
+                EventTypeWalletBalanceRow: {
+                  container: 'configAlertModal__EventTypeWalletBalanceRow',
+                },
+                EventTypeXMTPRow: {
+                  container: 'configAlertModal__EventTypeXMTPRow',
+                },
+                EventTypeFusionToggleRow: {
+                  container: 'configAlertModal__EventTypeFusionToggleRow',
+                },
+                EventTypeFusionHealthCheckRow: {
+                  container: 'configAlertModal__EventTypeFusionHealthCheckRow',
+                  content:
+                    'configAlertModal__EventTypeFusionHealthCheckRow__Subtitle',
+                  buttonContainer:
+                    'configAlertModal__EventTypeFusionHealthCheckRow__ButtonContainer',
+                },
+              }
+            }
+            data={data}
+            inputDisabled={inputDisabled}
+            inputs={inputs}
+          />
+        )}
+
         <div
           className={clsx(
             'configAlertModal__footerContainer',

--- a/packages/notifi-react-card/lib/components/SignupBanner.tsx
+++ b/packages/notifi-react-card/lib/components/SignupBanner.tsx
@@ -1,5 +1,5 @@
 import {
-  CardConfigItemV1,
+  CardConfigItem,
   ContactInfoConfig,
 } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
@@ -10,7 +10,7 @@ import { useNotifiSubscriptionContext } from '../context';
 import { DeepPartialReadonly } from '../utils';
 
 export type SignupBannerProps = Readonly<{
-  data: CardConfigItemV1;
+  data: CardConfigItem;
   classNames?: DeepPartialReadonly<{
     banner: string;
     bannerImage: string;

--- a/packages/notifi-react-card/lib/components/subscription/FetchedStateCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/FetchedStateCard.tsx
@@ -8,13 +8,19 @@ import {
 import { SubscriptionCardUnsupported } from './SubscriptionCardUnsupported';
 import type { SubscriptionCardV1Props } from './SubscriptionCardV1';
 import { SubscriptionCardV1 } from './SubscriptionCardV1';
+import {
+  SubscriptionCardV2,
+  SubscriptionCardV2Props,
+} from './v2/SubscriptionCardV2';
 
 export type FetchedStateCardProps = Readonly<{
   classNames?: Readonly<{
+    // TODO: MVP-3655
     SubscriptionCardV1?: SubscriptionCardV1Props['classNames'];
   }>;
   copy?: Readonly<{
     SubscriptionCardV1?: SubscriptionCardV1Props['copy'];
+    SubscriptionCardV2?: SubscriptionCardV2Props['copy'];
   }>;
   card: FetchedState;
   inputDisabled: boolean;
@@ -49,6 +55,23 @@ export const FetchedStateCard: React.FC<FetchedStateCardProps> = ({
           onClose={onClose}
         />
       );
+      break;
+    case 'v2':
+      contents = (
+        <SubscriptionCardV2
+          // TODO: MVP-3655
+          classNames={classNames?.SubscriptionCardV1}
+          // TODO: MVP-3655
+          copy={copy?.SubscriptionCardV2}
+          data={card.data}
+          inputs={inputs}
+          inputDisabled={inputDisabled}
+          inputLabels={inputLabels}
+          inputSeparators={inputSeparators}
+          onClose={onClose}
+        />
+      );
+      break;
   }
 
   return <>{contents}</>;

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/EditCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/EditCardView.tsx
@@ -1,4 +1,4 @@
-import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
+import { CardConfigItem } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import { DeepPartialReadonly } from 'notifi-react-card/lib/utils';
 import React from 'react';
@@ -13,12 +13,14 @@ import {
   NotifiInputFieldsText,
   NotifiInputSeparators,
 } from '../NotifiSubscriptionCard';
+import { NotifiSubscribeButtonV2 } from '../v2/NotifiSubscribeButtonV2';
+import { TopicListPreview } from '../v2/TopicListPreview';
 import { AlertListPreview, AlertListPreviewProps } from './AlertListPreview';
 import { InputFields, InputFieldsProps } from './InputFields';
 
 export type EditCardViewProps = Readonly<{
   buttonText: string;
-  data: CardConfigItemV1;
+  data: CardConfigItem;
   inputDisabled: boolean;
   showPreview?: boolean;
   copy?: Readonly<{
@@ -55,11 +57,19 @@ export const EditCardView: React.FC<EditCardViewProps> = ({
     <div
       className={clsx('NotifiInputContainer', classNames?.NotifiInputContainer)}
     >
-      {showPreview ? (
+      {/* TODO: Refactor */}
+      {showPreview && data.version === 'v1' ? (
         <AlertListPreview
           copy={copy?.AlertListPreview}
           classNames={classNames?.AlertListPreview}
           eventTypes={data.eventTypes}
+        />
+      ) : null}
+      {showPreview && data.version === 'v2' ? (
+        <TopicListPreview
+          copy={copy?.AlertListPreview}
+          classNames={classNames?.AlertListPreview}
+          eventTypes={data.topicTypes}
         />
       ) : null}
       {loading ? (
@@ -76,12 +86,22 @@ export const EditCardView: React.FC<EditCardViewProps> = ({
           inputTextFields={inputTextFields}
         />
       )}
-      <NotifiSubscribeButton
-        buttonText={buttonText}
-        data={data}
-        classNames={classNames?.NotifiSubscribeButton}
-        inputs={inputs}
-      />
+      {data.version === 'v1' ? (
+        <NotifiSubscribeButton
+          buttonText={buttonText}
+          data={data}
+          classNames={classNames?.NotifiSubscribeButton}
+          inputs={inputs}
+        />
+      ) : null}
+      {data.version === 'v2' ? (
+        <NotifiSubscribeButtonV2
+          buttonText={buttonText}
+          data={data}
+          classNames={classNames?.NotifiSubscribeButton}
+          inputs={inputs}
+        />
+      ) : null}
     </div>
   );
 };

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/InputFields.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/InputFields.tsx
@@ -1,4 +1,4 @@
-import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
+import { CardConfigItem } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import React from 'react';
 
@@ -23,7 +23,7 @@ import {
 } from '../../NotifiTelegramInput';
 
 export type InputFieldsProps = {
-  data: CardConfigItemV1;
+  data: CardConfigItem;
   inputSeparators?: NotifiInputSeparators;
   inputTextFields?: NotifiInputFieldsText;
   allowedCountryCodes: string[];

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/PreviewCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/PreviewCard.tsx
@@ -1,9 +1,10 @@
-import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
+import { CardConfigItem } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import { useDestinationState } from 'notifi-react-card/lib/hooks/useDestinationState';
 import React from 'react';
 
 import { DeepPartialReadonly } from '../../../utils';
+import { TopicsPanel } from '../v2/TopicsPanel';
 import { AlertsPanel, AlertsPanelProps } from './preview-panel/AlertsPanel';
 import {
   UserInfoPanel,
@@ -11,6 +12,7 @@ import {
 } from './preview-panel/UserInfoPanel';
 
 export type PreviewCardProps = Readonly<{
+  // TODO: MVP-3655
   classNames?: {
     NotifiPreviewCardSeparator?: string;
     NotifiPreviewCardContainer?: string;
@@ -20,7 +22,7 @@ export type PreviewCardProps = Readonly<{
     NotifiPreviewCardTitle?: string;
     NotifiPreviewCardDividerLine?: string;
   };
-  data: CardConfigItemV1;
+  data: CardConfigItem;
   inputDisabled: boolean;
   inputs: Record<string, unknown>;
 }>;
@@ -62,12 +64,22 @@ export const PreviewCard: React.FC<PreviewCardProps> = ({
       >
         Select the alerts you want to receive:
       </div>
-      <AlertsPanel
-        classNames={classNames?.AlertsPanel}
-        data={data}
-        inputDisabled={inputDisabled}
-        inputs={inputs}
-      />
+      {data.version === 'v1' ? (
+        <AlertsPanel
+          classNames={classNames?.AlertsPanel}
+          data={data}
+          inputDisabled={inputDisabled}
+          inputs={inputs}
+        />
+      ) : null}
+      {data.version === 'v2' ? (
+        <TopicsPanel // topics for v2 equivalent to alerts for v1
+          classNames={classNames?.AlertsPanel} // TODO: MVP-3655
+          data={data}
+          inputDisabled={inputDisabled}
+          inputs={inputs}
+        />
+      ) : null}
     </div>
   );
 };

--- a/packages/notifi-react-card/lib/components/subscription/v2/HistoryCardViewV2.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/v2/HistoryCardViewV2.tsx
@@ -1,0 +1,208 @@
+import { CardConfigItemV2 } from '@notifi-network/notifi-frontend-client';
+import { Types } from '@notifi-network/notifi-graphql';
+import clsx from 'clsx';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { Virtuoso } from 'react-virtuoso';
+
+import { NotificationEmptyBellIcon } from '../../../assets/NotificationEmptyBellIcon';
+import { useNotifiClientContext } from '../../../context';
+import {
+  DeepPartialReadonly,
+  getAlertNotificationViewBaseProps,
+  validateIsSupported,
+} from '../../../utils';
+import { MESSAGES_PER_PAGE } from '../../../utils/constants';
+import {
+  AlertNotificationRow,
+  AlertNotificationViewProps,
+} from '../../AlertHistory/AlertNotificationRow';
+import { LoadingStateCard, LoadingStateCardProps } from '../../common';
+
+export type HistoryCardViewV2Props = Readonly<{
+  noAlertDescription?: string;
+  isHidden: boolean;
+  data: CardConfigItemV2;
+  // TODO: MVP-3655
+  copy?: {
+    loadingHeader?: string;
+    loadingContent?: string;
+    loadingSpinnerSize?: string;
+    loadingRingColor?: string;
+  };
+  // TODO: MVP-3655
+  classNames?: DeepPartialReadonly<{
+    title: string;
+    header: string;
+    manageAlertLink: string;
+    noAlertDescription: string;
+    notificationDate: string;
+    notificationSubject: string;
+    notificationMessage: string;
+    notificationImage: string;
+    notificationList: string;
+    emptyAlertsBellIcon: string;
+    historyContainer: string;
+    virtuoso: string;
+    AlertCard: AlertNotificationViewProps['classNames'];
+    LoadingStateCard: LoadingStateCardProps['classNames'];
+  }>;
+  setAlertEntry: React.Dispatch<
+    React.SetStateAction<
+      Types.FusionNotificationHistoryEntryFragmentFragment | undefined
+    >
+  >;
+}>;
+
+export const HistoryCardViewV2: React.FC<HistoryCardViewV2Props> = ({
+  classNames,
+  isHidden,
+  noAlertDescription,
+  setAlertEntry,
+  copy,
+}) => {
+  noAlertDescription = noAlertDescription
+    ? noAlertDescription
+    : 'You haven’t received any notifications yet';
+
+  const [endCursor, setEndCursor] = useState<string | undefined>();
+  const [hasNextPage, setHasNextPage] = useState<boolean>();
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const fetched = useRef<boolean>(false);
+
+  const { frontendClient } = useNotifiClientContext();
+
+  const [allNodes, setAllNodes] = useState<
+    Types.FusionNotificationHistoryEntryFragmentFragment[]
+  >([]);
+
+  const { isClientInitialized, isClientAuthenticated } = useMemo(
+    () => ({
+      isClientInitialized: !!frontendClient.userState,
+      isClientAuthenticated:
+        frontendClient.userState?.status === 'authenticated',
+    }),
+    [frontendClient],
+  );
+
+  const getNotificationHistory = useCallback(
+    async ({ first, after }: Types.GetNotificationHistoryQueryVariables) => {
+      if (isLoading) {
+        return;
+      }
+      setIsLoading(true);
+
+      const result = await frontendClient.getFusionNotificationHistory({
+        first,
+        after,
+        includeHidden: false,
+      });
+
+      const nodes: Types.FusionNotificationHistoryEntryFragmentFragment[] =
+        result?.nodes ?? [];
+      setAllNodes((existing) => [...nodes, ...existing]);
+
+      setEndCursor(result?.pageInfo.endCursor);
+      setHasNextPage(result?.pageInfo.hasNextPage);
+
+      setIsLoading(false);
+      return result;
+    },
+    [frontendClient, setAllNodes, setEndCursor, setHasNextPage],
+  );
+
+  useEffect(() => {
+    if (!isClientInitialized || !isClientAuthenticated) {
+      return;
+    }
+
+    if (!fetched.current) {
+      fetched.current = true;
+      getNotificationHistory({
+        first: MESSAGES_PER_PAGE,
+      });
+    }
+  }, [frontendClient, isClientInitialized, isClientAuthenticated]);
+
+  useEffect(() => {
+    if (allNodes.length > 0) {
+      frontendClient
+        .markFusionNotificationHistoryAsRead({
+          ids: [],
+          beforeId: allNodes[0].id,
+        })
+        .catch((e) => console.log('Failed to mark as read', e));
+    }
+  }, [allNodes]);
+
+  if (isLoading) {
+    return (
+      <LoadingStateCard
+        copy={{
+          header: copy?.loadingHeader ?? '',
+          content: copy?.loadingContent,
+        }}
+        spinnerSize={copy?.loadingSpinnerSize}
+        ringColor={copy?.loadingRingColor}
+        classNames={classNames?.LoadingStateCard}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={clsx(
+        'NotifiAlertHistory__container',
+        classNames?.historyContainer,
+        { 'NotifiAlertHistory__container--hidden': isHidden },
+      )}
+    >
+      {allNodes.length > 0 ? (
+        <Virtuoso
+          className={clsx('NotifiAlertHistory__virtuoso', classNames?.virtuoso)}
+          style={{ flex: 1 }}
+          endReached={() => {
+            if (hasNextPage && endCursor) {
+              getNotificationHistory({
+                first: MESSAGES_PER_PAGE,
+                after: endCursor,
+              });
+            }
+          }}
+          data={allNodes.filter(validateIsSupported)}
+          itemContent={(_index, notification) => {
+            return (
+              <AlertNotificationRow
+                {...getAlertNotificationViewBaseProps(notification)}
+                handleAlertEntrySelection={() => setAlertEntry(notification)}
+                classNames={classNames?.AlertCard}
+              />
+            );
+          }}
+        />
+      ) : (
+        <div className="NotifiAlertHistory__noAlertContainer">
+          <NotificationEmptyBellIcon
+            className={clsx(
+              'NotifiAlertHistory__emptyAlertsBellIcon',
+              classNames?.emptyAlertsBellIcon,
+            )}
+          />
+          <span
+            className={clsx(
+              'NotifiAlertHistory_noAlertDescription',
+              classNames?.noAlertDescription,
+            )}
+          >
+            {noAlertDescription}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/notifi-react-card/lib/components/subscription/v2/NotifiSubscribeButtonV2.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/v2/NotifiSubscribeButtonV2.tsx
@@ -1,0 +1,188 @@
+import {
+  CardConfigItemV2,
+  TopicTypeItem,
+} from '@notifi-network/notifi-frontend-client';
+import clsx from 'clsx';
+import { isValidPhoneNumber } from 'libphonenumber-js';
+import React, { useCallback, useMemo } from 'react';
+
+import {
+  useNotifiClientContext,
+  useNotifiForm,
+  useNotifiSubscriptionContext,
+} from '../../../context';
+import { useFrontendClientLogin } from '../../../hooks/useFrontendClientLogin';
+import {
+  createConfigurations,
+  subscribeAlertsByFrontendClient,
+} from '../../../utils';
+import { formatTelegramForSubscription } from '../../../utils/stringUtils';
+
+export type NotifiSubscribeButtonProps = Readonly<{
+  classNames?: Readonly<{
+    button?: string;
+    label?: string;
+  }>;
+  buttonText: string;
+  data: CardConfigItemV2;
+  inputs: Record<string, unknown>;
+}>;
+
+type TargetGroupData = {
+  name: string;
+  emailAddress?: string;
+  phoneNumber?: string;
+  telegramId?: string;
+  discordId?: string;
+};
+
+export const NotifiSubscribeButtonV2: React.FC<NotifiSubscribeButtonProps> = ({
+  buttonText,
+  classNames,
+  data,
+  inputs,
+}) => {
+  const eventTypes = data.topicTypes;
+
+  const frontendClientLogin = useFrontendClientLogin();
+
+  const {
+    params: { multiWallet },
+    frontendClient,
+  } = useNotifiClientContext();
+
+  const isClientInitialized = useMemo(
+    () => !!frontendClient.userState,
+    [frontendClient],
+  );
+  const {
+    cardView,
+    connectedWallets,
+    loading,
+    setCardView,
+    useDiscord,
+    render,
+    setLoading,
+  } = useNotifiSubscriptionContext();
+
+  const { formErrorMessages, formState } = useNotifiForm();
+
+  const { phoneNumber, telegram: telegramId, email } = formState;
+
+  const { email: emailErrorMessage, phoneNumber: smsErrorMessage } =
+    formErrorMessages;
+
+  const isMultiWallet = (multiWallet?.ownedWallets?.length ?? 0) > 0;
+
+  const targetGroup: TargetGroupData = useMemo(
+    () => ({
+      name: 'Default',
+      emailAddress: email === '' ? undefined : email,
+      phoneNumber: isValidPhoneNumber(phoneNumber) ? phoneNumber : undefined,
+      telegramId:
+        telegramId === ''
+          ? undefined
+          : formatTelegramForSubscription(telegramId),
+      discordId: useDiscord ? 'Default' : undefined,
+    }),
+    [email, phoneNumber, telegramId, useDiscord],
+  );
+
+  const renewTargetGroups = useCallback(
+    async (targetGroup: TargetGroupData) => {
+      return frontendClient.ensureTargetGroup(targetGroup);
+    },
+    [frontendClient],
+  );
+
+  const subscribeAlerts = useCallback(
+    async (eventTypes: TopicTypeItem[], inputs: Record<string, unknown>) => {
+      await renewTargetGroups(targetGroup);
+
+      return subscribeAlertsByFrontendClient(
+        frontendClient,
+        eventTypes,
+        inputs,
+      );
+    },
+    [
+      targetGroup,
+      frontendClient,
+      connectedWallets,
+      renewTargetGroups,
+      subscribeAlertsByFrontendClient,
+      createConfigurations,
+    ],
+  );
+
+  const onClick = useCallback(async () => {
+    let isFirstTimeUser = false;
+    if (frontendClient.userState?.status !== 'authenticated') {
+      await frontendClientLogin();
+      const data = await frontendClient.fetchData();
+      isFirstTimeUser = (data.targetGroup?.length ?? 0) === 0;
+    }
+
+    setLoading(true);
+    try {
+      let success = false;
+      if (isFirstTimeUser && !isMultiWallet) {
+        const subEvents = eventTypes.filter((event) => {
+          return event.optOutAtSignup ? false : true;
+        });
+        const result = await subscribeAlerts(subEvents, inputs);
+        success = !!result;
+      } else {
+        const result = await renewTargetGroups(targetGroup);
+        success = !!result;
+      }
+
+      if (success) {
+        const newData = await frontendClient.fetchData();
+        render(newData);
+      }
+
+      if (success === true) {
+        const nextState = !isMultiWallet
+          ? 'history'
+          : cardView.state === 'signup'
+          ? 'verifyonboarding'
+          : 'verify';
+        setCardView({
+          state: nextState,
+        });
+      }
+    } catch (e) {
+      setCardView({ state: 'error', reason: e });
+    }
+    setLoading(false);
+  }, [
+    isMultiWallet,
+    frontendClient,
+    eventTypes,
+    frontendClientLogin,
+    setCardView,
+  ]);
+
+  const hasErrors = emailErrorMessage !== '' || smsErrorMessage !== '';
+  const isInputFieldsValid = useMemo(() => {
+    return data.isContactInfoRequired
+      ? email || phoneNumber || telegramId || useDiscord
+      : true;
+  }, [email, phoneNumber, telegramId, useDiscord, data.isContactInfoRequired]);
+
+  return (
+    <button
+      data-cy="notifiSubscribeButton"
+      className={clsx('NotifiSubscribeButton__button', classNames?.button)}
+      disabled={
+        !isClientInitialized || loading || hasErrors || !isInputFieldsValid
+      }
+      onClick={onClick}
+    >
+      <span className={clsx('NotifiSubscribeButton__label', classNames?.label)}>
+        {loading ? 'Loading' : buttonText}
+      </span>
+    </button>
+  );
+};

--- a/packages/notifi-react-card/lib/components/subscription/v2/SubscriptionCardV2.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/v2/SubscriptionCardV2.tsx
@@ -1,0 +1,440 @@
+import { CardConfigItemV2 } from '@notifi-network/notifi-frontend-client';
+import { Types } from '@notifi-network/notifi-graphql';
+import clsx from 'clsx';
+import { useDestinationState } from 'notifi-react-card/lib/hooks/useDestinationState';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  useNotifiClientContext,
+  useNotifiDemoPreviewContext,
+  useNotifiForm,
+  useNotifiSubscriptionContext,
+} from '../../../context';
+import { DeepPartialReadonly } from '../../../utils';
+import {
+  AlertDetailsCard,
+  AlertDetailsProps,
+} from '../../AlertHistory/AlertDetailsCard';
+import {
+  ConfigAlertModal,
+  ConfigAlertModalProps,
+} from '../../ConfigAlertModal';
+import {
+  ConfigDestinationModal,
+  ConfigDestinationModalProps,
+} from '../../ConfigDestinationModal';
+import NotifiAlertBox, {
+  NotifiAlertBoxButtonProps,
+  NotifiAlertBoxProps,
+} from '../../NotifiAlertBox';
+import { SignupBanner, SignupBannerProps } from '../../SignupBanner';
+import { VerifyBanner, VerifyBannerProps } from '../../VerifyBanner';
+import { ErrorStateCard } from '../../common';
+import {
+  NotifiInputFieldsText,
+  NotifiInputSeparators,
+} from '../NotifiSubscriptionCard';
+import {
+  EditCardView,
+  EditCardViewProps,
+} from '../subscription-card-views/EditCardView';
+import {
+  ExpiredTokenView,
+  ExpiredTokenViewCardProps,
+} from '../subscription-card-views/ExpiredTokenViewCard';
+import {
+  PreviewCard,
+  PreviewCardProps,
+} from '../subscription-card-views/PreviewCard';
+import { HistoryCardViewV2, HistoryCardViewV2Props } from './HistoryCardViewV2';
+import VerifyWalletViewV2, {
+  VerifyWalletViewV2Props,
+} from './VerifyWalletViewV2';
+
+export type SubscriptionCardV2Props = Readonly<{
+  //TODO: MVP-3655
+  copy?: DeepPartialReadonly<{
+    EditCard: EditCardViewProps['copy'];
+    AlertHistory: HistoryCardViewV2Props['copy'];
+    expiredHeader: string;
+    manageAlertsHeader: string;
+    signUpHeader: string;
+    editHeader: string;
+    verifyWalletsHeader: string;
+    historyHeader: string;
+    detailHeader: string;
+  }>;
+  //TODO: MVP-3655
+  classNames?: DeepPartialReadonly<{
+    alertContainer: string;
+    AlertHistoryView: HistoryCardViewV2Props['classNames'];
+    AlertDetailsCard: AlertDetailsProps['classNames'];
+    PreviewCard: PreviewCardProps['classNames'];
+    HistoryCard?: HistoryCardViewV2Props['classNames'];
+    EditCard: EditCardViewProps['classNames'];
+    ExpiredTokenView: ExpiredTokenViewCardProps['classNames'];
+    VerifyWalletView: VerifyWalletViewV2Props['classNames'];
+    NotifiAlertBox: NotifiAlertBoxProps['classNames'];
+    ErrorStateCard: string;
+    ConfigDestinationModal: ConfigDestinationModalProps['classNames'];
+    signupBanner: SignupBannerProps['classNames'];
+    ConfigAlertModal: ConfigAlertModalProps['classNames'];
+    dividerLine: string;
+    verifyBanner: VerifyBannerProps['classNames'];
+  }>;
+  inputDisabled: boolean;
+  data: CardConfigItemV2;
+  inputs: Record<string, unknown>;
+  inputLabels?: NotifiInputFieldsText;
+  inputSeparators?: NotifiInputSeparators;
+  onClose?: () => void;
+}>;
+
+export enum FtuConfigStep {
+  Destination = 'destination',
+  Alert = 'alert',
+  Done = 'done',
+}
+
+export const SubscriptionCardV2: React.FC<SubscriptionCardV2Props> = ({
+  classNames,
+  copy,
+  data,
+  inputDisabled,
+  inputs,
+  inputLabels,
+  inputSeparators,
+  onClose,
+}) => {
+  const allowedCountryCodes = [...data.contactInfo.sms.supportedCountryCodes];
+  const { cardView, email, phoneNumber, telegramId, setCardView } =
+    useNotifiSubscriptionContext();
+  const { demoPreview } = useNotifiDemoPreviewContext();
+
+  const {
+    setEmail,
+    setTelegram,
+    setPhoneNumber,
+    setEmailErrorMessage,
+    setTelegramErrorMessage,
+    setPhoneNumberErrorMessage,
+  } = useNotifiForm();
+
+  const [ftuConfigStep, setFtuConfigStep] = useState<FtuConfigStep>(
+    FtuConfigStep.Done,
+  );
+
+  const { frontendClient } = useNotifiClientContext();
+
+  const { isClientTokenExpired, isClientAuthenticated } = useMemo(
+    () => ({
+      isClientTokenExpired: frontendClient.userState?.status === 'expired',
+      isClientAuthenticated:
+        frontendClient.userState?.status === 'authenticated',
+    }),
+    [frontendClient.userState?.status],
+  );
+
+  const { unverifiedDestinations, isTargetsExist } = useDestinationState();
+
+  const [selectedAlertEntry, setAlertEntry] = useState<
+    Types.FusionNotificationHistoryEntryFragmentFragment | undefined
+  >(undefined);
+
+  let view = null;
+
+  const resetFormState = useCallback(() => {
+    setEmail(email);
+    setPhoneNumber(phoneNumber);
+    setTelegram(telegramId);
+    setEmailErrorMessage('');
+    setTelegramErrorMessage('');
+    setPhoneNumberErrorMessage('');
+  }, [email, phoneNumber, telegramId]);
+
+  useEffect(() => {
+    setCardView(() => {
+      if (demoPreview) {
+        return {
+          state: demoPreview.view,
+          reason:
+            demoPreview.view === 'error' ? 'test example reason' : undefined,
+        };
+      }
+
+      if (!isClientAuthenticated) {
+        if (data.isContactInfoRequired) {
+          setFtuConfigStep(FtuConfigStep.Destination);
+        } else {
+          setFtuConfigStep(FtuConfigStep.Alert);
+        }
+        return { state: 'signup' };
+      }
+
+      if (isClientTokenExpired) {
+        return { state: 'expired' };
+      }
+
+      return { state: 'history' };
+    });
+  }, []);
+
+  const rightIcon: NotifiAlertBoxButtonProps | undefined = useMemo(() => {
+    if (onClose === undefined) {
+      return undefined;
+    }
+
+    return {
+      name: 'close',
+      onClick: onClose,
+    };
+  }, [onClose]);
+
+  const useCustomTitles = data?.titles?.active === true;
+
+  const expiredHeader = () => {
+    return useCustomTitles && data?.titles.expiredView !== ''
+      ? data?.titles.expiredView
+      : copy?.expiredHeader ?? 'Welcome Back';
+  };
+
+  const previewHeader = () => {
+    return useCustomTitles && data?.titles.previewView !== ''
+      ? data?.titles.previewView
+      : copy?.manageAlertsHeader ?? 'Manage Alerts';
+  };
+
+  const signUpHeader = () => {
+    return useCustomTitles && data?.titles.signupView !== ''
+      ? data?.titles.signupView
+      : copy?.signUpHeader ?? 'Get Notified';
+  };
+
+  const editHeader = () => {
+    return useCustomTitles && data?.titles.editView !== ''
+      ? data?.titles.editView
+      : copy?.editHeader ?? 'Update Settings';
+  };
+
+  const verifyOnboardingHeader = () => {
+    return useCustomTitles && data?.titles.verifyWalletsView !== ''
+      ? data?.titles.verifyWalletsView
+      : copy?.verifyWalletsHeader ?? 'Verify Wallets';
+  };
+
+  const historyView = () => {
+    if (!useCustomTitles) {
+      return selectedAlertEntry ? 'Alert Details' : 'Alert History';
+    }
+
+    return selectedAlertEntry
+      ? data?.titles.alertDetailsView || 'Alert Details'
+      : data?.titles.historyView || 'Alert History';
+  };
+  // TODO: Consider refactor (Optional) - not to use switch case
+  switch (cardView.state) {
+    case 'expired':
+      view = (
+        <>
+          <NotifiAlertBox
+            classNames={classNames?.NotifiAlertBox}
+            rightIcon={rightIcon}
+          >
+            <h2>{expiredHeader()}</h2>
+          </NotifiAlertBox>
+          <div
+            className={clsx('DividerLine expired', classNames?.dividerLine)}
+          />
+          <ExpiredTokenView classNames={classNames?.ExpiredTokenView} />
+        </>
+      );
+      break;
+    case 'preview':
+      view = (
+        <>
+          <NotifiAlertBox
+            classNames={classNames?.NotifiAlertBox}
+            leftIcon={{
+              name: 'back',
+              onClick: () => setCardView({ state: 'history' }),
+            }}
+            rightIcon={rightIcon}
+          >
+            <h2>{previewHeader()}</h2>
+          </NotifiAlertBox>
+          <div
+            className={clsx('DividerLine preview', classNames?.dividerLine)}
+          />
+
+          {!isTargetsExist ? (
+            <SignupBanner data={data} classNames={classNames?.signupBanner} />
+          ) : null}
+          <PreviewCard
+            data={data}
+            inputs={inputs}
+            inputDisabled={inputDisabled}
+            classNames={classNames?.PreviewCard}
+          />
+        </>
+      );
+      break;
+    case 'edit':
+    case 'signup':
+      view = (
+        <>
+          <NotifiAlertBox
+            classNames={classNames?.NotifiAlertBox}
+            leftIcon={
+              cardView.state === 'signup'
+                ? undefined
+                : {
+                    name: 'back',
+                    onClick: () => {
+                      resetFormState();
+                      setCardView({ state: 'preview' });
+                    },
+                  }
+            }
+            rightIcon={rightIcon}
+          >
+            {cardView.state === 'signup' ? (
+              <h2>{signUpHeader()}</h2>
+            ) : (
+              <h2>{editHeader()}</h2>
+            )}
+          </NotifiAlertBox>
+          <div
+            className={clsx('DividerLine signup', classNames?.dividerLine)}
+          />
+          <EditCardView
+            buttonText={cardView.state === 'signup' ? 'Next' : 'Update'}
+            data={data}
+            copy={copy?.EditCard}
+            classNames={classNames?.EditCard}
+            inputDisabled={inputDisabled}
+            inputTextFields={inputLabels}
+            inputSeparators={inputSeparators}
+            allowedCountryCodes={allowedCountryCodes}
+            showPreview={cardView.state === 'signup'}
+            inputs={inputs}
+          />
+        </>
+      );
+      break;
+    case 'verifyonboarding':
+    case 'verify':
+      view = (
+        <>
+          <NotifiAlertBox
+            classNames={classNames?.NotifiAlertBox}
+            leftIcon={{
+              name: 'back',
+              onClick: () =>
+                setCardView({
+                  state:
+                    cardView.state === 'verifyonboarding'
+                      ? 'signup'
+                      : 'preview',
+                }),
+            }}
+            rightIcon={rightIcon}
+          >
+            <h2>{verifyOnboardingHeader()}</h2>
+          </NotifiAlertBox>
+          <div
+            className={clsx('DividerLine verify', classNames?.dividerLine)}
+          />
+          <VerifyWalletViewV2
+            classNames={classNames?.VerifyWalletView}
+            data={data}
+            inputs={inputs}
+            buttonText={
+              cardView.state === 'verifyonboarding' ? 'Next' : 'Confirm'
+            }
+          />
+        </>
+      );
+      break;
+    case 'history':
+      view = (
+        <>
+          {ftuConfigStep === FtuConfigStep.Alert ? (
+            <ConfigAlertModal
+              classNames={classNames?.ConfigAlertModal}
+              setFtuConfigStep={setFtuConfigStep}
+              data={data}
+              inputDisabled={inputDisabled}
+              inputs={inputs}
+            />
+          ) : null}
+          {ftuConfigStep === FtuConfigStep.Destination ? (
+            <ConfigDestinationModal
+              classNames={classNames?.ConfigDestinationModal}
+              setFtuConfigStep={setFtuConfigStep}
+              contactInfo={data.contactInfo}
+            />
+          ) : null}
+          <NotifiAlertBox
+            classNames={classNames?.NotifiAlertBox}
+            leftIcon={
+              selectedAlertEntry === undefined
+                ? {
+                    name: 'settings',
+                    onClick: () => setCardView({ state: 'preview' }),
+                  }
+                : {
+                    name: 'back',
+                    onClick: () => setAlertEntry(undefined),
+                  }
+            }
+            rightIcon={rightIcon}
+          >
+            <h2>{historyView()}</h2>
+          </NotifiAlertBox>
+          <div
+            className={clsx(
+              'NotifiSubscriptionCardV1__alertContainer',
+              classNames?.alertContainer,
+            )}
+          >
+            <div
+              className={clsx('DividerLine history', classNames?.dividerLine)}
+            />
+
+            {/* TODO: Consolidate banners (when it grows) */}
+            {unverifiedDestinations.length > 0 ? (
+              <VerifyBanner
+                classNames={classNames?.verifyBanner}
+                unVerifiedDestinations={unverifiedDestinations}
+              />
+            ) : null}
+            {!isTargetsExist ? (
+              <SignupBanner data={data} classNames={classNames?.signupBanner} />
+            ) : null}
+
+            {selectedAlertEntry === undefined ? null : (
+              <AlertDetailsCard
+                notificationEntry={selectedAlertEntry}
+                classNames={classNames?.AlertDetailsCard}
+              />
+            )}
+
+            <HistoryCardViewV2
+              classNames={classNames?.AlertHistoryView}
+              copy={copy?.AlertHistory}
+              isHidden={selectedAlertEntry !== undefined}
+              setAlertEntry={setAlertEntry}
+              data={data}
+            />
+          </div>
+        </>
+      );
+      break;
+    case 'error':
+      view = <ErrorStateCard reason={cardView.reason as string} />;
+      break;
+    default:
+      view = <div>Not supported view</div>;
+  }
+  return <>{view}</>;
+};

--- a/packages/notifi-react-card/lib/components/subscription/v2/TopicListPreview.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/v2/TopicListPreview.tsx
@@ -1,0 +1,76 @@
+import { CardConfigItemV2 } from '@notifi-network/notifi-frontend-client';
+import clsx from 'clsx';
+import { DeepPartialReadonly } from 'notifi-react-card/lib/utils';
+import React from 'react';
+
+import { CheckIcon } from '../../../assets/CheckIcon';
+
+export type AlertListPreviewProps = Readonly<{
+  alertList?: DeepPartialReadonly<{
+    container: string;
+    listItem: string;
+  }>;
+  eventTypes: CardConfigItemV2['topicTypes'];
+  // TODO: MVP-3655
+  copy?: DeepPartialReadonly<{
+    description: string;
+  }>;
+  // TODO: MVP-3655
+  classNames?: DeepPartialReadonly<{
+    checkmarkIcon: string;
+    container: string;
+    description: string;
+    eventListItem: string;
+  }>;
+}>;
+
+export const TopicListPreview: React.FC<AlertListPreviewProps> = ({
+  eventTypes,
+  copy,
+  classNames,
+}: AlertListPreviewProps) => {
+  const alertNames = eventTypes.map((topicType) => {
+    return (
+      <div className="NotifiAlertList__listItem" key={topicType.name}>
+        <CheckIcon
+          className={clsx(
+            'NotifiAlertListContainer__checkmarkIcon',
+            classNames?.checkmarkIcon,
+          )}
+        />
+        <label
+          className={clsx(
+            'NotifiAlertListContainer__listItemContent',
+            classNames?.eventListItem,
+          )}
+          key={topicType.name}
+        >
+          {topicType.type === 'fusion'
+            ? topicType.displayNameOverride ?? topicType.name
+            : topicType.name}
+        </label>
+      </div>
+    );
+  });
+
+  return (
+    <div
+      className={clsx(
+        'NotifiAlertListContainer__container',
+        classNames?.container,
+      )}
+    >
+      <label
+        className={clsx(
+          'NotifiAlertListPreview__descriptionText',
+          classNames?.description,
+        )}
+      >
+        {copy?.description ?? 'Subscribe to any of these alerts'}
+      </label>
+      <div className={clsx('NotifiAlertLisPreview__checkmarkContainer')}>
+        {alertNames}
+      </div>
+    </div>
+  );
+};

--- a/packages/notifi-react-card/lib/components/subscription/v2/TopicsPanel.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/v2/TopicsPanel.tsx
@@ -1,0 +1,83 @@
+import { CardConfigItemV2 } from '@notifi-network/notifi-frontend-client';
+import clsx from 'clsx';
+import React from 'react';
+
+import {
+  EventTypeFusionHealthCheckRow,
+  EventTypeFusionHealthCheckRowProps,
+} from '../EventTypeFusionHealthCheckRow';
+import {
+  EventTypeFusionMultiThresholdRow,
+  EventTypeFusionMultiThresholdRowProps,
+} from '../EventTypeFusionMultiThresholdRow';
+import {
+  EventTypeFusionRowProps,
+  EventTypeFusionToggleRow,
+} from '../EventTypeFusionToggleRow';
+
+export type AlertsPanelProps = Readonly<{
+  data: CardConfigItemV2;
+  inputDisabled: boolean;
+  // TODO: MVP-3655
+  classNames?: Readonly<{
+    EventTypeContainer?: string;
+    EventTypeFusionMultiThresholdRow?: EventTypeFusionMultiThresholdRowProps['classNames'];
+    EventTypeFusionToggleRow?: EventTypeFusionRowProps['classNames'];
+    EventTypeFusionHealthCheckRow?: EventTypeFusionHealthCheckRowProps['classNames'];
+  }>;
+  inputs: Record<string, unknown>;
+}>;
+export const TopicsPanel: React.FC<AlertsPanelProps> = ({
+  data,
+  inputDisabled,
+  classNames,
+  inputs,
+}) => {
+  return (
+    <div
+      className={clsx(
+        'NotifiEventTypeContainer',
+        classNames?.EventTypeContainer,
+      )}
+    >
+      {data.topicTypes.map((topicType) => {
+        switch (topicType.selectedUIType) {
+          case 'HEALTH_CHECK':
+            return (
+              // TODO: MVP-3698
+              <EventTypeFusionHealthCheckRow
+                key={topicType.name}
+                disabled={inputDisabled}
+                config={topicType}
+                classNames={classNames?.EventTypeFusionHealthCheckRow}
+                inputs={inputs}
+              />
+            );
+          case 'TOGGLE':
+            return (
+              // TODO:  MVP-3698
+              <EventTypeFusionToggleRow
+                key={topicType.name}
+                classNames={classNames?.EventTypeFusionToggleRow}
+                disabled={inputDisabled}
+                config={topicType}
+                inputs={inputs}
+              />
+            );
+          case 'MULTI_THRESHOLD':
+            return (
+              // TODO: MVP-3698
+              <EventTypeFusionMultiThresholdRow
+                key={topicType.name}
+                classNames={classNames?.EventTypeFusionMultiThresholdRow}
+                config={topicType}
+                inputs={inputs}
+              />
+            );
+          default:
+            throw new Error(`Unknown UI type`);
+        }
+      })}
+    </div>
+  );
+};

--- a/packages/notifi-react-card/lib/components/subscription/v2/VerifyWalletViewV2.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/v2/VerifyWalletViewV2.tsx
@@ -1,0 +1,124 @@
+import {
+  CardConfigItemV2,
+  TopicTypeItem,
+} from '@notifi-network/notifi-frontend-client';
+import clsx from 'clsx';
+import { isValidPhoneNumber } from 'libphonenumber-js';
+import { formatTelegramForSubscription } from 'notifi-react-card/lib/utils/stringUtils';
+import React, { useCallback, useMemo } from 'react';
+
+import {
+  useNotifiClientContext,
+  useNotifiForm,
+  useNotifiSubscriptionContext,
+} from '../../../context';
+import { subscribeAlertsByFrontendClient } from '../../../utils';
+import { WalletList } from '../../WalletList';
+import NotifiCardButton, {
+  NotifiCardButtonProps,
+} from '../../common/NotifiCardButton';
+
+export type VerifyWalletViewV2Props = Readonly<{
+  // TODO: MVP-3655
+  classNames?: Readonly<{
+    NotifiVerifyContainer?: string;
+    NotifiInputHeading?: string;
+    NotifiCardButtonProps?: NotifiCardButtonProps['classNames'];
+  }>;
+  buttonText: string;
+  data: CardConfigItemV2;
+  inputs: Record<string, unknown>;
+}>;
+
+const VerifyWalletViewV2: React.FC<VerifyWalletViewV2Props> = ({
+  classNames,
+  buttonText,
+  data,
+  inputs,
+}) => {
+  const {
+    cardView,
+    setCardView,
+    loading,
+    setLoading,
+    connectedWallets,
+    useDiscord,
+  } = useNotifiSubscriptionContext();
+
+  const {
+    formState: { phoneNumber, telegram: telegramId, email },
+  } = useNotifiForm();
+  const { frontendClient } = useNotifiClientContext();
+
+  const targetGroup = useMemo(
+    () => ({
+      name: 'Default',
+      emailAddress: email === '' ? undefined : email,
+      phoneNumber: isValidPhoneNumber(phoneNumber) ? phoneNumber : undefined,
+      telegramId:
+        telegramId === ''
+          ? undefined
+          : formatTelegramForSubscription(telegramId),
+      discordId: useDiscord ? 'Default' : undefined,
+    }),
+    [email, phoneNumber, telegramId, useDiscord],
+  );
+
+  const subscribeAlerts = useCallback(
+    async (eventTypes: TopicTypeItem[], inputs: Record<string, unknown>) => {
+      await frontendClient.ensureTargetGroup(targetGroup);
+      return subscribeAlertsByFrontendClient(
+        frontendClient,
+        eventTypes,
+        inputs,
+      );
+    },
+    [frontendClient, email, phoneNumber, telegramId, useDiscord],
+  );
+  const renewWallets = useCallback(
+    async () => frontendClient.updateWallets(),
+    [frontendClient],
+  );
+
+  const onClick = useCallback(async () => {
+    if (cardView.state === 'verifyonboarding') {
+      setLoading(true);
+
+      try {
+        const subEvents = data.topicTypes.filter((topic) => {
+          return topic.optOutAtSignup ? false : true;
+        });
+        await subscribeAlerts(subEvents, inputs);
+      } finally {
+        setLoading(false);
+      }
+    } else {
+      setLoading(true);
+
+      try {
+        await renewWallets();
+      } finally {
+        setLoading(false);
+      }
+    }
+    setCardView({ state: 'preview' });
+  }, [setLoading, data, inputs, connectedWallets, renewWallets]);
+
+  return (
+    <div
+      className={clsx(
+        'NotifiVerifyContainer',
+        classNames?.NotifiVerifyContainer,
+      )}
+    >
+      <WalletList />
+      <NotifiCardButton
+        buttonText={buttonText}
+        disabled={loading}
+        onClick={onClick}
+      />
+    </div>
+  );
+};
+
+export default VerifyWalletViewV2;

--- a/packages/notifi-react-card/lib/hooks/useSubscriptionCard.ts
+++ b/packages/notifi-react-card/lib/hooks/useSubscriptionCard.ts
@@ -1,4 +1,4 @@
-import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
+import { CardConfigItem } from '@notifi-network/notifi-frontend-client';
 import { Types } from '@notifi-network/notifi-graphql';
 import { useEffect, useState } from 'react';
 
@@ -17,7 +17,7 @@ export type LoadingState = Readonly<{
   state: 'loading';
 }>;
 
-export type Data = CardConfigItemV1;
+export type Data = CardConfigItem;
 
 export type FetchedState = Readonly<{
   state: 'fetched';
@@ -47,7 +47,7 @@ export const useSubscriptionCard = (
       }));
     }
 
-    let card: CardConfigItemV1 | undefined;
+    let card: CardConfigItem | undefined;
     setState({ state: 'loading' });
     (isUsingFrontendClient ? frontendClient : client)
       .fetchSubscriptionCard(input)
@@ -61,8 +61,8 @@ export const useSubscriptionCard = (
           card = result;
         }
 
-        if (card?.version !== 'v1') {
-          return Promise.reject(new Error('Unsupported config format'));
+        if (!card?.version) {
+          return Promise.reject(new Error('Failed to fetch data'));
         }
 
         setState({

--- a/packages/notifi-react-card/lib/utils/frontendClient.ts
+++ b/packages/notifi-react-card/lib/utils/frontendClient.ts
@@ -2,6 +2,7 @@ import {
   EventTypeConfig,
   EventTypeItem,
   NotifiFrontendClient,
+  TopicTypeItem,
 } from '@notifi-network/notifi-frontend-client';
 import { Types } from '@notifi-network/notifi-graphql';
 
@@ -63,7 +64,7 @@ export const unsubscribeAlertByFrontendClient = async (
 
 export const subscribeAlertsByFrontendClient = async (
   frontendClient: NotifiFrontendClient,
-  eventTypes: EventTypeConfig,
+  eventTypes: EventTypeConfig | TopicTypeItem[],
   inputs: Record<string, unknown>,
 ): Promise<SubscriptionData> => {
   for (const eventType of eventTypes) {


### PR DESCRIPTION

- [x] Describe the purpose of the change
Create a new type (`TopicTypeItem`) which will be 1:1 replacement with `EventTypeItem` for AP2.0 & SDK3.0. This new type will be used in `SubscriptionCardV2`'s topicTypeTypes field. 

- [x] Create test cases for your changes if needed
No need

- [x] Include the ticket id if possible (Collaborator only)
MVP-3641
