### PR TITLE
Add html to generic event details

### DIFF
--- a/packages/notifi-axios-adapter/lib/fragments/fusionNotificationHistoryEntryFragment.ts
+++ b/packages/notifi-axios-adapter/lib/fragments/fusionNotificationHistoryEntryFragment.ts
@@ -83,6 +83,7 @@ fragment FusionNotificationHistoryEntry on FusionNotificationHistoryEntry {
       sourceName
       notificationTypeName
       genericMessage: message
+      genericMessageHtml: messageHtml
       eventDetailsJson
       action {
         name

--- a/packages/notifi-axios-adapter/lib/fragments/notificationHistoryEntryFragment.ts
+++ b/packages/notifi-axios-adapter/lib/fragments/notificationHistoryEntryFragment.ts
@@ -103,6 +103,7 @@ fragment NotificationHistoryEntry on NotificationHistoryEntry {
       sourceName
       notificationTypeName
       genericMessage: message
+      genericMessageHtml: messageHtml
       eventDetailsJson
       action {
         name

--- a/packages/notifi-graphql/lib/gql/fragments/FusionNotificationHistoryEntryFragment.gql.ts
+++ b/packages/notifi-graphql/lib/gql/fragments/FusionNotificationHistoryEntryFragment.gql.ts
@@ -85,6 +85,7 @@ export const FusionNotificationHistoryEntryFragment = gql`
         sourceName
         notificationTypeName
         genericMessage: message
+        genericMessageHtml: messageHtml
         eventDetailsJson
         action {
           name

--- a/packages/notifi-graphql/lib/gql/fragments/NotificationHistoryEntryFragment.gql.ts
+++ b/packages/notifi-graphql/lib/gql/fragments/NotificationHistoryEntryFragment.gql.ts
@@ -92,6 +92,7 @@ export const NotificationHistoryEntryFragment = gql`
         sourceName
         notificationTypeName
         genericMessage: message
+        genericMessageHtml: messageHtml
         eventDetailsJson
         action {
           name

--- a/packages/notifi-react-card/lib/utils/NotificationHistoryUtils.tsx
+++ b/packages/notifi-react-card/lib/utils/NotificationHistoryUtils.tsx
@@ -124,6 +124,7 @@ supportedEventDetails.set('GenericEventDetails', {
     return {
       topContent: detail.notificationTypeName,
       bottomContent: detail.genericMessage,
+      bottomContentHtml: detail.genericMessageHtml ?? '',
     };
   },
 });


### PR DESCRIPTION
Add html content for generic message html. This is to support html for the new fusion broadcast that will be generic event details instead of broadcast event details.
