### PR TITLE
MVP-3669+3670+3644: presist FTU state & e2e test

### DIFF
--- a/packages/notifi-react-card/lib/components/ConfigAlertModal.tsx
+++ b/packages/notifi-react-card/lib/components/ConfigAlertModal.tsx
@@ -2,8 +2,9 @@ import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import React from 'react';
 
+import { FtuStage } from '../context';
 import AlertActionIcon from './AlertBox/AlertActionIcon';
-import { AlertsPanel, AlertsPanelProps, FtuConfigStep } from './subscription';
+import { AlertsPanel, AlertsPanelProps } from './subscription';
 
 export type ConfigAlertModalProps = Readonly<{
   classNames?: {
@@ -13,11 +14,10 @@ export type ConfigAlertModalProps = Readonly<{
     headerContainer?: string;
     backIcon?: string;
     headerTitle?: string;
-    closeIcon?: string;
     footerContainer?: string;
     ctaIcon?: string;
   };
-  setFtuConfigStep: (step: FtuConfigStep) => void;
+  updateFtuStage: (step: FtuStage) => void;
   data: CardConfigItemV1;
   inputDisabled: boolean;
   inputs: Record<string, unknown>;
@@ -25,7 +25,7 @@ export type ConfigAlertModalProps = Readonly<{
 
 export const ConfigAlertModal: React.FC<ConfigAlertModalProps> = ({
   classNames,
-  setFtuConfigStep,
+  updateFtuStage,
   data,
   inputDisabled,
   inputs,
@@ -51,7 +51,9 @@ export const ConfigAlertModal: React.FC<ConfigAlertModalProps> = ({
                 'configAlertModal__backIcon',
                 classNames?.backIcon,
               )}
-              onClick={() => setFtuConfigStep(FtuConfigStep.Destination)}
+              onClick={() => {
+                updateFtuStage(FtuStage.Destination);
+              }}
             >
               <AlertActionIcon
                 name="back"
@@ -69,18 +71,6 @@ export const ConfigAlertModal: React.FC<ConfigAlertModalProps> = ({
             )}
           >
             <div>Select alerts</div>
-          </div>
-          <div
-            className={clsx(
-              'configAlertModal__closeIcon',
-              classNames?.closeIcon,
-            )}
-            onClick={() => setFtuConfigStep(FtuConfigStep.Done)}
-          >
-            <AlertActionIcon
-              name="close"
-              className={clsx('configAlertModal__ctaIcon', classNames?.ctaIcon)}
-            />
           </div>
         </div>
         <AlertsPanel
@@ -145,7 +135,9 @@ export const ConfigAlertModal: React.FC<ConfigAlertModalProps> = ({
         >
           <button
             data-cy="configAlertModalDoneButton"
-            onClick={() => setFtuConfigStep(FtuConfigStep.Done)}
+            onClick={() => {
+              updateFtuStage(FtuStage.Done);
+            }}
           >
             Done
           </button>

--- a/packages/notifi-react-card/lib/components/ConfigDestinationModal.tsx
+++ b/packages/notifi-react-card/lib/components/ConfigDestinationModal.tsx
@@ -6,8 +6,7 @@ import { DiscordIcon } from '../assets/DiscordIcon';
 import { EmailIcon } from '../assets/EmailIcon';
 import { SmsIcon } from '../assets/SmsIcon';
 import { TelegramIcon } from '../assets/TelegramIcon';
-import { useNotifiSubscriptionContext } from '../context';
-import { FtuConfigStep } from './subscription';
+import { FtuStage, useNotifiSubscriptionContext } from '../context';
 import { DestinationErrorMessage } from './subscription/subscription-card-views/preview-panel/DestinationErrorMessage';
 
 export type ConfigDestinationModalProps = Readonly<{
@@ -38,13 +37,13 @@ export type ConfigDestinationModalProps = Readonly<{
     verifyButtonMessage?: string;
     verifyButtonContainer?: string;
   };
-  setFtuConfigStep: (step: FtuConfigStep) => void;
+  updateFtuStage: (step: FtuStage) => void;
   contactInfo: CardConfigItemV1['contactInfo'];
 }>;
 
 export const ConfigDestinationModal: React.FC<ConfigDestinationModalProps> = ({
   classNames,
-  setFtuConfigStep,
+  updateFtuStage,
   contactInfo,
 }) => {
   const {
@@ -332,7 +331,11 @@ export const ConfigDestinationModal: React.FC<ConfigDestinationModalProps> = ({
             classNames?.footerContainer,
           )}
         >
-          <button onClick={() => setFtuConfigStep(FtuConfigStep.Alert)}>
+          <button
+            onClick={() => {
+              updateFtuStage(FtuStage.Alerts);
+            }}
+          >
             Next
           </button>
         </div>

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
@@ -158,11 +158,7 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
       }
 
       if (success === true) {
-        syncFtuStage(data.isContactInfoRequired)
-          .catch((e) => {
-            console.log(`Failed to syncFtuStage: ${e}`);
-          })
-          .finally(() => setLoading(false));
+        await syncFtuStage(data.isContactInfoRequired);
         const nextState = !isMultiWallet
           ? 'history'
           : cardView.state === 'signup'

--- a/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/NotifiSubscribeButton.tsx
@@ -64,6 +64,7 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
     useDiscord,
     render,
     setLoading,
+    syncFtuStage,
   } = useNotifiSubscriptionContext();
 
   const { formErrorMessages, formState } = useNotifiForm();
@@ -157,6 +158,11 @@ export const NotifiSubscribeButton: React.FC<NotifiSubscribeButtonProps> = ({
       }
 
       if (success === true) {
+        syncFtuStage(data.isContactInfoRequired)
+          .catch((e) => {
+            console.log(`Failed to syncFtuStage: ${e}`);
+          })
+          .finally(() => setLoading(false));
         const nextState = !isMultiWallet
           ? 'history'
           : cardView.state === 'signup'

--- a/packages/notifi-react-example/cypress/component/NotifiSubscriptionCard.cy.tsx
+++ b/packages/notifi-react-example/cypress/component/NotifiSubscriptionCard.cy.tsx
@@ -58,7 +58,7 @@ describe('Sign-up', () => {
       .wait('@gqlFetchDataQuery')
       .wait('@gqlFetchDataQuery');
 
-    cy.get('[data-cy="configAlertModalDoneButton"').should('not.exist');
+    cy.get('[data-cy="configAlertModalDoneButton"').should('exist').click();
     cy.get('[data-cy="verifyBannerButton"').should('exist').click();
     cy.get('[data-cy="previewCard"').should('exist');
   });

--- a/packages/notifi-react-example/cypress/component/NotifiSubscriptionCard.cy.tsx
+++ b/packages/notifi-react-example/cypress/component/NotifiSubscriptionCard.cy.tsx
@@ -16,12 +16,14 @@ describe('Sign-up', () => {
       aliasQuery(req, 'findTenantConfig');
       aliasMutation(req, 'updateTargetGroup');
       aliasQuery(req, 'fetchData');
+      aliasQuery(req, 'getUserSettings');
     });
   });
 
   it('W/O destination', () => {
     cy.overrideTenantConfigWithFixture({ isContactInfoRequired: false });
     cy.mountNotifiSubscriptionCard();
+    cy.overrideUserSettingsWithFixture('userSettingsFtuNull.json');
 
     cy.wait('@gqlFindTenantConfigQuery').then(({ response }) => {
       expect(response.statusCode).to.equal(200);
@@ -37,7 +39,8 @@ describe('Sign-up', () => {
     cy.get('[data-cy="notifiSubscribeButton"').click();
     cy.wait('@gqlLogInFromDappQuery')
       .wait('@gqlFetchDataQuery')
-      .wait('@gqlFetchDataQuery');
+      .wait('@gqlFetchDataQuery')
+      .wait('@gqlGetUserSettingsQuery');
 
     cy.get('[data-cy="configAlertModal"').should('exist');
     cy.get('[data-cy="configAlertModalDoneButton"').should('exist').click();
@@ -65,6 +68,7 @@ describe('Sign-up', () => {
     cy.overrideTenantConfigWithFixture({ isContactInfoRequired: true });
     cy.mountNotifiSubscriptionCard();
     cy.overrideFetchDataTargetGroupWithFixture('confirmedTargetGroup.json');
+    cy.overrideUserSettingsWithFixture('userSettingsFtuNull.json');
 
     cy.wait('@gqlFindTenantConfigQuery').then(({ response }) => {
       expect(response.statusCode).to.equal(200);
@@ -81,7 +85,8 @@ describe('Sign-up', () => {
       .wait('@gqlUpdateTargetGroupMutation')
       .wait('@gqlFetchDataQuery')
       .wait('@gqlFetchDataQuery')
-      .wait('@gqlFetchDataQuery');
+      .wait('@gqlFetchDataQuery')
+      .wait('@gqlGetUserSettingsQuery');
 
     cy.get('[data-cy="configDestinationModalVerifyLabel"').should('exist');
     cy.get('[data-cy="configDestinationModalNextButton"')
@@ -96,6 +101,7 @@ describe('Sign-up', () => {
     cy.overrideTenantConfigWithFixture({ isContactInfoRequired: true });
     cy.mountNotifiSubscriptionCard();
     cy.overrideFetchDataTargetGroupWithFixture('notConfirmedTargetGroup.json');
+    cy.overrideUserSettingsWithFixture('userSettingsFtuNull.json');
 
     cy.wait('@gqlFindTenantConfigQuery').then(({ response }) => {
       expect(response.statusCode).to.equal(200);
@@ -115,7 +121,8 @@ describe('Sign-up', () => {
       .wait('@gqlUpdateTargetGroupMutation')
       .wait('@gqlFetchDataQuery')
       .wait('@gqlFetchDataQuery')
-      .wait('@gqlFetchDataQuery');
+      .wait('@gqlFetchDataQuery')
+      .wait('@gqlGetUserSettingsQuery');
 
     cy.get('[data-cy="configDestinationModalConfirmTelegramButton"').should(
       'exist',
@@ -125,5 +132,40 @@ describe('Sign-up', () => {
       .click();
     cy.get('[data-cy="configAlertModal"').should('exist');
     // ... the rest of the test is the same as the "W/O destination" test
+  });
+});
+
+describe('Ftu stage persistence', () => {
+  beforeEach(() => {
+    cy.wait(2000); // Wait for previous test's requests to finish
+  });
+  it('Case#1: FTU stage AlertsModal persisted', () => {
+    // AlertModal is persisted if FTU process is not completed
+    cy.overrideTenantConfigWithFixture({ isContactInfoRequired: false });
+    cy.mountNotifiSubscriptionCard();
+    cy.overrideUserSettingsWithFixture('userSettingsFtuAlerts.json');
+
+    cy.wait('@gqlFindTenantConfigQuery').then(({ response }) => {
+      expect(response.statusCode).to.equal(200);
+      const tenantConfig = response.body.data.findTenantConfig;
+      expect(tenantConfig.type).to.equal('SUBSCRIPTION_CARD');
+    });
+
+    cy.get('[data-cy="configAlertModal"').should('exist');
+  });
+  it('Case#2: FTU stage DestinationModal persisted', () => {
+    // DestinationModal is persisted if FTU process is not completed
+    cy.overrideTenantConfigWithFixture({ isContactInfoRequired: true });
+    cy.mountNotifiSubscriptionCard();
+    cy.overrideFetchDataTargetGroupWithFixture('notConfirmedTargetGroup.json');
+    cy.overrideUserSettingsWithFixture('userSettingsFtuDestinations.json');
+
+    cy.wait('@gqlFindTenantConfigQuery').then(({ response }) => {
+      expect(response.statusCode).to.equal(200);
+      const tenantConfig = response.body.data.findTenantConfig;
+      expect(tenantConfig.type).to.equal('SUBSCRIPTION_CARD');
+    });
+
+    cy.get('[data-cy="configDestinationModalNextButton"').should('exist');
   });
 });

--- a/packages/notifi-react-example/cypress/fixtures/userSettingsFtuAlerts.json
+++ b/packages/notifi-react-example/cypress/fixtures/userSettingsFtuAlerts.json
@@ -1,0 +1,5 @@
+{
+  "detailedAlertHistoryEnabled": true,
+  "ftuStage": 2,
+  "serHasChatEnabled": false
+}

--- a/packages/notifi-react-example/cypress/fixtures/userSettingsFtuDestinations.json
+++ b/packages/notifi-react-example/cypress/fixtures/userSettingsFtuDestinations.json
@@ -1,0 +1,5 @@
+{
+  "detailedAlertHistoryEnabled": true,
+  "ftuStage": 3,
+  "serHasChatEnabled": false
+}

--- a/packages/notifi-react-example/cypress/fixtures/userSettingsFtuNull.json
+++ b/packages/notifi-react-example/cypress/fixtures/userSettingsFtuNull.json
@@ -1,0 +1,5 @@
+{
+  "detailedAlertHistoryEnabled": true,
+  "ftuStage": null,
+  "serHasChatEnabled": false
+}

--- a/packages/notifi-react-example/cypress/support/commands.tsx
+++ b/packages/notifi-react-example/cypress/support/commands.tsx
@@ -24,6 +24,7 @@ declare global {
       ): void;
       mountNotifiSubscriptionCard(): void;
       overrideFetchDataTargetGroupWithFixture(fixtureName: string): void;
+      overrideUserSettingsWithFixture(fixtureName: string): void;
     }
   }
 }
@@ -102,6 +103,23 @@ const overrideFetchDataTargetGroupWithFixture = (fixtureName: string) => {
   });
 };
 
+const overrideUserSettingsWithFixture = (fixtureName: string) => {
+  cy.fixture(fixtureName).then((userSettings) => {
+    const env = Cypress.env('ENV');
+    cy.intercept('POST', envUrl(env), (req) => {
+      aliasQuery(req, 'getUserSettings');
+      if (hasOperationName(req, 'getUserSettings')) {
+        req.reply((res) => {
+          res.body.data = {
+            ...res.body.data,
+            userSettings,
+          };
+        });
+      }
+    });
+  });
+};
+
 const emptyDefaultTargetGroup = async () => {
   const dappAddress = Cypress.env('DAPP_ADDRESS');
   const env = Cypress.env('ENV');
@@ -161,4 +179,8 @@ Cypress.Commands.add(
 Cypress.Commands.add(
   'overrideFetchDataTargetGroupWithFixture',
   overrideFetchDataTargetGroupWithFixture,
+);
+Cypress.Commands.add(
+  'overrideUserSettingsWithFixture',
+  overrideUserSettingsWithFixture,
 );


### PR DESCRIPTION

- [x] Describe the purpose of the change
1. Remove "x" button from FTU flow
2.  Page persists if a user hasn’t yet finished FTU process
3. E2E cypress test script


- [x] Create test cases for your changes if needed
Ready

- [x] Include the ticket id if possible (Collaborator only)
MVP-3669+3670+3644

https://github.com/notifi-network/notifi-sdk-ts/assets/127958634/f76d7956-a6b4-42ab-839b-6df73c8a15b2


