### PR TITLE
MVP-3643: new cardView historyDetail

### DIFF
--- a/packages/notifi-react-card/lib/components/AlertHistory/AlertDetailsCard.tsx
+++ b/packages/notifi-react-card/lib/components/AlertHistory/AlertDetailsCard.tsx
@@ -1,9 +1,14 @@
 import clsx from 'clsx';
 import DOMPurify from 'dompurify';
+import { useNotifiSubscriptionContext } from 'notifi-react-card/lib/context';
 import { getAlertDetailsContents } from 'notifi-react-card/lib/utils';
 import React, { useMemo } from 'react';
 
 import { formatAlertDetailsTimestamp } from '../../utils/AlertHistoryUtils';
+import NotifiAlertBox, {
+  NotifiAlertBoxButtonProps,
+  NotifiAlertBoxProps,
+} from '../NotifiAlertBox';
 import { NotificationHistoryEntry } from '../subscription';
 
 export type AlertDetailsProps = Readonly<{
@@ -11,12 +16,20 @@ export type AlertDetailsProps = Readonly<{
   classNames?: Readonly<{
     detailsContainer?: string;
     BackArrowIcon?: string;
+    NotifiAlertBox?: NotifiAlertBoxProps['classNames'];
+    dividerLine?: string;
   }>;
+  headerTitle: string;
+  headerRightIcon?: NotifiAlertBoxButtonProps;
+  onClose?: () => void;
 }>;
 export const AlertDetailsCard: React.FC<AlertDetailsProps> = ({
   notificationEntry,
   classNames,
+  headerTitle,
+  headerRightIcon,
 }) => {
+  const { setCardView } = useNotifiSubscriptionContext();
   const { bottomContent, otherContent, topContent, bottomContentHtml } =
     useMemo(
       () => getAlertDetailsContents(notificationEntry),
@@ -30,31 +43,46 @@ export const AlertDetailsCard: React.FC<AlertDetailsProps> = ({
   }, [bottomContentHtml]);
 
   return (
-    <div
-      className={clsx(
-        'NotifiAlertDetails__container',
-        classNames?.detailsContainer,
-      )}
-    >
-      <div className={clsx('NotifiAlertDetails__topContentContainer')}>
-        <div className={clsx('NotifiAlertDetails__topContent')}>
-          {topContent}
-        </div>
-        <div className={clsx('NotifiAlertDetails__timestamp')}>
-          {formatAlertDetailsTimestamp(notificationEntry.createdDate)}
-        </div>
-      </div>
-      <div className={clsx('NotifiAlertDetails__bottomContent')}>
-        {sanitizedBottomContentHtml ? (
-          // If `messageHtml` exists just use it, otherwise use `message` (which is plain text)
-          <div
-            dangerouslySetInnerHTML={{ __html: sanitizedBottomContentHtml }}
-          />
-        ) : (
-          <div>{bottomContent}</div>
+    <>
+      <NotifiAlertBox
+        classNames={classNames?.NotifiAlertBox}
+        leftIcon={{
+          name: 'back',
+          onClick: () => setCardView({ state: 'history' }),
+        }}
+        rightIcon={headerRightIcon}
+      >
+        <h2>{headerTitle}</h2>
+      </NotifiAlertBox>
+      <div
+        className={clsx(
+          'NotifiAlertDetails__container',
+          classNames?.detailsContainer,
         )}
-        <div>{otherContent}</div>
+      >
+        <div
+          className={clsx('DividerLine historyDetail', classNames?.dividerLine)}
+        />
+        <div className={clsx('NotifiAlertDetails__topContentContainer')}>
+          <div className={clsx('NotifiAlertDetails__topContent')}>
+            {topContent}
+          </div>
+          <div className={clsx('NotifiAlertDetails__timestamp')}>
+            {formatAlertDetailsTimestamp(notificationEntry.createdDate)}
+          </div>
+        </div>
+        <div className={clsx('NotifiAlertDetails__bottomContent')}>
+          {sanitizedBottomContentHtml ? (
+            // If `messageHtml` exists just use it, otherwise use `message` (which is plain text)
+            <div
+              dangerouslySetInnerHTML={{ __html: sanitizedBottomContentHtml }}
+            />
+          ) : (
+            <div>{bottomContent}</div>
+          )}
+          <div>{otherContent}</div>
+        </div>
       </div>
-    </div>
+    </>
   );
 };

--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -1862,10 +1862,6 @@ input::-webkit-inner-spin-button {
   margin: 0px 20px;
 }
 
-.NotifiAlertHistory__container.NotifiAlertHistory__container--hidden {
-  visibility: hidden;
-}
-
 .NotifiAlertHistory__virtuoso {
   overflow-x: hidden;
 }

--- a/packages/notifi-react-card/lib/components/defaults.css
+++ b/packages/notifi-react-card/lib/components/defaults.css
@@ -1862,6 +1862,16 @@ input::-webkit-inner-spin-button {
   margin: 0px 20px;
 }
 
+.NotifiAlertHistory__loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0;
+}
+
 .NotifiAlertHistory__virtuoso {
   overflow-x: hidden;
 }

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
@@ -33,7 +33,8 @@ import NotifiAlertBox, {
 } from '../../NotifiAlertBox';
 import { SignupBanner, SignupBannerProps } from '../../SignupBanner';
 import { VerifyBanner, VerifyBannerProps } from '../../VerifyBanner';
-import { LoadingStateCard, LoadingStateCardProps } from '../../common';
+import { LoadingStateCardProps } from '../../common';
+import Spinner from '../../common/Spinner';
 
 export type NotificationHistoryEntry =
   | Types.FusionNotificationHistoryEntryFragmentFragment
@@ -43,7 +44,13 @@ export type AlertHistoryViewProps = Readonly<{
   noAlertDescription?: string;
   data: CardConfigItemV1;
   copy?: {
+    /**
+     * @deprecated No longer have loading header when loading history
+     */
     loadingHeader?: string;
+    /**
+     * @deprecated No longer have loading content when loading history
+     */
     loadingContent?: string;
     loadingSpinnerSize?: string;
     loadingRingColor?: string;
@@ -64,7 +71,11 @@ export type AlertHistoryViewProps = Readonly<{
     historyContainer?: string;
     virtuoso?: string;
     AlertCard?: AlertNotificationViewProps['classNames'];
+    /**
+     * @deprecated Use `loadingSpinner` instead
+     */
     LoadingStateCard?: LoadingStateCardProps['classNames'];
+    loadingSpinner?: string;
     verifyBanner?: VerifyBannerProps['classNames'];
     signupBanner?: SignupBannerProps['classNames'];
     alertContainer?: string;
@@ -263,15 +274,17 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
           ) : null}
 
           {isLoading ? (
-            <LoadingStateCard
-              copy={{
-                header: copy?.loadingHeader ?? '',
-                content: copy?.loadingContent,
-              }}
-              spinnerSize={copy?.loadingSpinnerSize}
-              ringColor={copy?.loadingRingColor}
-              classNames={classNames?.LoadingStateCard}
-            />
+            <div
+              className={clsx(
+                'NotifiAlertHistory__loading',
+                classNames?.loadingSpinner,
+              )}
+            >
+              <Spinner
+                size={copy?.loadingSpinnerSize}
+                ringColor={copy?.loadingRingColor}
+              />
+            </div>
           ) : null}
         </div>
       </div>

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
@@ -33,7 +33,6 @@ import NotifiAlertBox, {
 } from '../../NotifiAlertBox';
 import { SignupBanner, SignupBannerProps } from '../../SignupBanner';
 import { VerifyBanner, VerifyBannerProps } from '../../VerifyBanner';
-import { LoadingStateCardProps } from '../../common';
 import Spinner from '../../common/Spinner';
 
 export type NotificationHistoryEntry =
@@ -44,14 +43,6 @@ export type AlertHistoryViewProps = Readonly<{
   noAlertDescription?: string;
   data: CardConfigItemV1;
   copy?: {
-    /**
-     * @deprecated No longer have loading header when loading history
-     */
-    loadingHeader?: string;
-    /**
-     * @deprecated No longer have loading content when loading history
-     */
-    loadingContent?: string;
     loadingSpinnerSize?: string;
     loadingRingColor?: string;
   };
@@ -71,10 +62,6 @@ export type AlertHistoryViewProps = Readonly<{
     historyContainer?: string;
     virtuoso?: string;
     AlertCard?: AlertNotificationViewProps['classNames'];
-    /**
-     * @deprecated Use `loadingSpinner` instead
-     */
-    LoadingStateCard?: LoadingStateCardProps['classNames'];
     loadingSpinner?: string;
     verifyBanner?: VerifyBannerProps['classNames'];
     signupBanner?: SignupBannerProps['classNames'];

--- a/packages/notifi-react-card/lib/hooks/useFetchedCardState.ts
+++ b/packages/notifi-react-card/lib/hooks/useFetchedCardState.ts
@@ -6,6 +6,11 @@ export type PreviewViewState = Readonly<{
 export type AlertHistoryViewState = Readonly<{
   state: 'history';
 }>;
+
+export type HistoryDetailState = Readonly<{
+  state: 'historyDetail';
+}>;
+
 export type EditInfoViewState = Readonly<{
   state: 'edit';
 }>;
@@ -35,7 +40,8 @@ export type FetchedCardViewState =
   | ExpiredTokenViewState
   | SignUpViewState
   | VerifyOnboardingViewState
-  | ErrorViewState;
+  | ErrorViewState
+  | HistoryDetailState;
 
 export const useFetchedCardState = () => {
   const [cardView, setCardView] = useState<FetchedCardViewState>({


### PR DESCRIPTION
- [x] Describe the purpose of the change

As the the following situations of history cardView , it becomes more and more difficult to follow and maintain.

includes not only history but also history detail view.

too much conditional logic between history and detail view

To get around this situation, we need to refactor history section in SubscriptionCardV1 by separating to hisotry & historyDetail.

- [x] Create test cases for your changes if needed
PASS

- [x] Include the ticket id if possible (Collaborator only)
MVP-3643
