### PR TITLE
MVP-3820: Update the the text format in VerifyBanner

### DIFF
--- a/packages/notifi-react-card/lib/components/VerifyBanner.tsx
+++ b/packages/notifi-react-card/lib/components/VerifyBanner.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import React, { useMemo } from 'react';
 
 import { CheckIcon } from '../assets/CheckIcon';
-import { useNotifiSubscriptionContext } from '../context';
+import { FormField, useNotifiSubscriptionContext } from '../context';
 import { DeepPartialReadonly } from '../utils';
 
 export type VerifyBannerProps = Readonly<{
@@ -16,7 +16,7 @@ export type VerifyBannerProps = Readonly<{
     bannerSubject?: string;
     bannerButton?: string;
   }>;
-  unVerifiedDestinations: ReadonlyArray<string>;
+  unVerifiedDestinations: ReadonlyArray<FormField>;
 }>;
 
 export const VerifyBanner: React.FC<VerifyBannerProps> = ({
@@ -26,9 +26,23 @@ export const VerifyBanner: React.FC<VerifyBannerProps> = ({
   const { setCardView } = useNotifiSubscriptionContext();
 
   const unVerifiedDestinationsString = useMemo(() => {
-    return unVerifiedDestinations.length > 1
-      ? unVerifiedDestinations.join(' and ')
-      : unVerifiedDestinations[0];
+    const convertedUnVerifiedDestinations = unVerifiedDestinations.map(
+      (target) => {
+        switch (target) {
+          case 'telegram':
+            return 'Telegram ID';
+          case 'discord':
+            return 'Discord';
+          case 'phoneNumber':
+            return 'Phone Number';
+          default:
+            return target;
+        }
+      },
+    );
+    return convertedUnVerifiedDestinations.length > 1
+      ? convertedUnVerifiedDestinations.join(' and ')
+      : convertedUnVerifiedDestinations[0];
   }, [unVerifiedDestinations]);
 
   const onClick = () => {


### PR DESCRIPTION

- [x] Describe the purpose of the change
Change the Banner content text to the correct format:
from
![Screenshot 2023-12-19 at 11 35 18](https://github.com/notifi-network/notifi-sdk-ts/assets/127958634/8207f84e-7936-47b7-bcbe-55e758620836)
to
![Screenshot 2023-12-19 at 11 34 11](https://github.com/notifi-network/notifi-sdk-ts/assets/127958634/9477951e-cd09-4021-94bc-19f804e14e9e)


- [x] Create test cases for your changes if needed
No need
- [x] Include the ticket id if possible (Collaborator only)
MVP-3820