### PR TITLE
SDK3.0/MVP-3832: Refactor cardView Preview

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
@@ -1,6 +1,5 @@
 import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
-import { useDestinationState } from 'notifi-react-card/lib/hooks/useDestinationState';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import {
@@ -25,7 +24,6 @@ import NotifiAlertBox, {
   NotifiAlertBoxButtonProps,
   NotifiAlertBoxProps,
 } from '../NotifiAlertBox';
-import { SignupBanner, SignupBannerProps } from '../SignupBanner';
 import { ErrorStateCard, LoadingStateCard } from '../common';
 import {
   NotifiInputFieldsText,
@@ -76,8 +74,6 @@ export type SubscriptionCardV1Props = Readonly<{
     NotifiAlertBox: NotifiAlertBoxProps['classNames'];
     ErrorStateCard: string;
     ConfigDestinationModal: ConfigDestinationModalProps['classNames'];
-    // TODO: deprecate after all refactor ( /* Deprecated: use NotifiAlertBox in each cardView */)
-    signupBanner: SignupBannerProps['classNames'];
     ConfigAlertModal: ConfigAlertModalProps['classNames'];
     // TODO: deprecate after all refactor ( /* Deprecated: use NotifiAlertBox in each cardView */)
     dividerLine: string;
@@ -149,8 +145,6 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
     isUsingFrontendClient,
   ]);
 
-  const { isTargetsExist } = useDestinationState();
-
   const [selectedAlertEntry, setAlertEntry] = useState<
     NotificationHistoryEntry | undefined
   >(undefined);
@@ -213,12 +207,6 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
       : copy?.expiredHeader ?? 'Welcome Back';
   };
 
-  const previewHeader = () => {
-    return useCustomTitles && data?.titles.previewView !== ''
-      ? data?.titles.previewView
-      : copy?.manageAlertsHeader ?? 'Manage Alerts';
-  };
-
   const signUpHeader = () => {
     return useCustomTitles && data?.titles.signupView !== ''
       ? data?.titles.signupView
@@ -256,31 +244,13 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
       break;
     case 'preview':
       view = (
-        <>
-          <NotifiAlertBox
-            classNames={classNames?.NotifiAlertBox}
-            leftIcon={{
-              name: 'back',
-              onClick: () => setCardView({ state: 'history' }),
-            }}
-            rightIcon={rightIcon}
-          >
-            <h2>{previewHeader()}</h2>
-          </NotifiAlertBox>
-          <div
-            className={clsx('DividerLine preview', classNames?.dividerLine)}
-          />
-
-          {!isTargetsExist ? (
-            <SignupBanner data={data} classNames={classNames?.signupBanner} />
-          ) : null}
-          <PreviewCard
-            data={data}
-            inputs={inputs}
-            inputDisabled={inputDisabled}
-            classNames={classNames?.PreviewCard}
-          />
-        </>
+        <PreviewCard
+          data={data}
+          inputs={inputs}
+          inputDisabled={inputDisabled}
+          classNames={classNames?.PreviewCard}
+          headerRightIcon={rightIcon}
+        />
       );
       break;
     case 'edit':

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/PreviewCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/PreviewCard.tsx
@@ -1,9 +1,15 @@
 import { CardConfigItemV1 } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
+import { useNotifiSubscriptionContext } from 'notifi-react-card/lib/context';
 import { useDestinationState } from 'notifi-react-card/lib/hooks/useDestinationState';
 import React from 'react';
 
 import { DeepPartialReadonly } from '../../../utils';
+import NotifiAlertBox, {
+  NotifiAlertBoxButtonProps,
+  NotifiAlertBoxProps,
+} from '../../NotifiAlertBox';
+import { SignupBanner, SignupBannerProps } from '../../SignupBanner';
 import { AlertsPanel, AlertsPanelProps } from './preview-panel/AlertsPanel';
 import {
   UserInfoPanel,
@@ -14,15 +20,22 @@ export type PreviewCardProps = Readonly<{
   classNames?: {
     NotifiPreviewCardSeparator?: string;
     NotifiPreviewCardContainer?: string;
+    NotifiAlertBox?: NotifiAlertBoxProps['classNames'];
     AlertsPanel?: DeepPartialReadonly<AlertsPanelProps['classNames']>;
     backArrowContainer?: string;
     UserInfoPanel?: DeepPartialReadonly<UserInfoPanelProps['classNames']>;
     NotifiPreviewCardTitle?: string;
     NotifiPreviewCardDividerLine?: string;
+    dividerLine?: string;
+    signupBanner?: SignupBannerProps['classNames'];
+  };
+  copy?: {
+    alertRowsHeader?: string;
   };
   data: CardConfigItemV1;
   inputDisabled: boolean;
   inputs: Record<string, unknown>;
+  headerRightIcon?: NotifiAlertBoxButtonProps;
 }>;
 
 export const PreviewCard: React.FC<PreviewCardProps> = ({
@@ -30,44 +43,66 @@ export const PreviewCard: React.FC<PreviewCardProps> = ({
   data,
   inputDisabled,
   inputs = {},
+  headerRightIcon,
+  copy,
 }) => {
   const { isTargetsExist } = useDestinationState();
+  const { setCardView } = useNotifiSubscriptionContext();
   return (
-    <div
-      data-cy="previewCard"
-      className={clsx(
-        'NotifiPreviewCard__container',
-        classNames?.NotifiPreviewCardContainer,
-      )}
-    >
-      {isTargetsExist ? (
-        <UserInfoPanel
-          classNames={classNames?.UserInfoPanel}
-          contactInfo={data.contactInfo}
-        />
+    <>
+      <NotifiAlertBox
+        classNames={classNames?.NotifiAlertBox}
+        leftIcon={{
+          name: 'back',
+          onClick: () => setCardView({ state: 'history' }),
+        }}
+        rightIcon={headerRightIcon}
+      >
+        <h2>
+          {(data.titles?.active && data.titles.previewView) || 'Manage Alerts'}
+        </h2>
+      </NotifiAlertBox>
+      <div className={clsx('DividerLine preview', classNames?.dividerLine)} />
+
+      {!isTargetsExist ? (
+        <SignupBanner data={data} classNames={classNames?.signupBanner} />
       ) : null}
-
       <div
+        data-cy="previewCard"
         className={clsx(
-          'NotifiPreviewCard__dividerLine',
-          classNames?.NotifiPreviewCardDividerLine,
-        )}
-      />
-
-      <div
-        className={clsx(
-          'NotifiPreviewCard__title',
-          classNames?.NotifiPreviewCardTitle,
+          'NotifiPreviewCard__container',
+          classNames?.NotifiPreviewCardContainer,
         )}
       >
-        Select the alerts you want to receive:
+        {isTargetsExist ? (
+          <UserInfoPanel
+            classNames={classNames?.UserInfoPanel}
+            contactInfo={data.contactInfo}
+          />
+        ) : null}
+
+        <div
+          className={clsx(
+            'NotifiPreviewCard__dividerLine',
+            classNames?.NotifiPreviewCardDividerLine,
+          )}
+        />
+
+        <div
+          className={clsx(
+            'NotifiPreviewCard__title',
+            classNames?.NotifiPreviewCardTitle,
+          )}
+        >
+          {copy?.alertRowsHeader ?? 'Select the alerts you want to receive:'}
+        </div>
+        <AlertsPanel
+          classNames={classNames?.AlertsPanel}
+          data={data}
+          inputDisabled={inputDisabled}
+          inputs={inputs}
+        />
       </div>
-      <AlertsPanel
-        classNames={classNames?.AlertsPanel}
-        data={data}
-        inputDisabled={inputDisabled}
-        inputs={inputs}
-      />
-    </div>
+    </>
   );
 };


### PR DESCRIPTION
- [x] Describe the purpose of the change
As handling too much conditional cardView logic , `subscriptionCardV1.tsx` becomes more and more difficult to follow and maintain. we need to refactor SubscriptionCardV1. 
This PR is specifically for `PreviewCard`

- [x] Create test cases for your changes if needed
No Need
- [x] Include the ticket id if possible (Collaborator only)
MVP-3832
