### PR TITLE
MVP-3877: Support rendering DirectTenantMessageEventDetails in card

### DIFF
--- a/packages/notifi-react-card/lib/utils/NotificationHistoryUtils.tsx
+++ b/packages/notifi-react-card/lib/utils/NotificationHistoryUtils.tsx
@@ -15,6 +15,11 @@ type AccountBalanceChangedEventDetails = Extract<
   { __typename: 'AccountBalanceChangedEventDetails' }
 >;
 
+type DirectTenantMessageEventDetails = Extract<
+  Types.NotificationHistoryEntryFragmentFragment['detail'],
+  { __typename: 'DirectTenantMessageEventDetails' }
+>;
+
 type BroadcastMessageEventDetails = Extract<
   | Types.NotificationHistoryEntryFragmentFragment['detail']
   | Types.FusionNotificationHistoryEntryFragmentFragment['detail'],
@@ -56,6 +61,32 @@ type SupportedEventDetailPropsMap = Map<
 >;
 
 const supportedEventDetails: SupportedEventDetailPropsMap = new Map();
+
+supportedEventDetails.set('DirectTenantMessageEventDetails', {
+  getViewProps: (notification: NotificationHistoryEntry) => {
+    const detail = notification.detail as DirectTenantMessageEventDetails;
+    const templateVariablesJson: Record<string, string> = JSON.parse(
+      detail.templateVariablesJson || '',
+    );
+    return {
+      notificationTitle: 'Announcement',
+      notificationImage: <AnnouncementIcon />,
+      notificationSubject: templateVariablesJson.subject ?? '',
+      notificationDate: notification.createdDate,
+      notificationMessage: templateVariablesJson.message ?? '',
+    };
+  },
+  getAlertDetailsContents: (notification: NotificationHistoryEntry) => {
+    const detail = notification.detail as DirectTenantMessageEventDetails;
+    const templateVariablesJson: Record<string, string> = JSON.parse(
+      detail.templateVariablesJson || '',
+    );
+    return {
+      topContent: templateVariablesJson.subject ?? '',
+      bottomContent: templateVariablesJson.message ?? '',
+    };
+  },
+});
 
 supportedEventDetails.set('BroadcastMessageEventDetails', {
   getViewProps: (notification: NotificationHistoryEntry) => {

--- a/packages/notifi-react-card/lib/utils/NotificationHistoryUtils.tsx
+++ b/packages/notifi-react-card/lib/utils/NotificationHistoryUtils.tsx
@@ -69,7 +69,7 @@ supportedEventDetails.set('DirectTenantMessageEventDetails', {
       detail.templateVariablesJson || '',
     );
     return {
-      notificationTitle: 'Announcement',
+      notificationTitle: templateVariablesJson.title ?? 'Announcement',
       notificationImage: <AnnouncementIcon />,
       notificationSubject: templateVariablesJson.subject ?? '',
       notificationDate: notification.createdDate,


### PR DESCRIPTION
- [x] Describe the purpose of the change
We do not have rendering DirectTenantMessageEventDetails logic, add it back

- [x] Create test cases for your changes if needed
NO NEED
- [x] Include the ticket id if possible (Collaborator only)
MVP-3877

- Demo video



https://github.com/notifi-network/notifi-sdk-ts/assets/127958634/ba25c59b-2c82-4ee2-8c63-ad43fd85ae31



