### PR TITLE
MVP-3880: Prevent double rendering from frontendClient & hook

### DIFF
--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -77,6 +77,7 @@ export const useNotifiSubscribe: ({
   reload: () => Promise<SubscriptionData>;
 }> = ({ targetGroupName = 'Default' }: useNotifiSubscribeProps) => {
   const { demoPreview } = useNotifiDemoPreviewContext();
+  const { isUsingFrontendClient } = useNotifiClientContext();
 
   const { client } = useNotifiClientContext();
 
@@ -309,11 +310,7 @@ export const useNotifiSubscribe: ({
       setUseDiscord(true);
     }
 
-    if (
-      client.isAuthenticated &&
-      !didFetch.current &&
-      !params.isUsingFrontendClient
-    ) {
+    if (client.isAuthenticated && !didFetch.current && !isUsingFrontendClient) {
       didFetch.current = true;
       client
         .fetchData()


### PR DESCRIPTION
- [x] Describe the purpose of the change
Card gets rendered every time when frontendClient & hookClient are authed. Fix the double rendering issue to improve performance & avoid potential mis-rendering.

- [x] Create test cases for your changes if needed
NO NEED (PASSED)

- [x] Include the ticket id if possible (Collaborator only)
MVP-3880