### PR TITLE
CS-381: fix notifi-react-card does not land on expiredView when jwt is expired

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/SubscriptionCardV1.tsx
@@ -175,6 +175,9 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
             demoPreview.view === 'error' ? 'test example reason' : undefined,
         };
       }
+      if (isClientTokenExpired) {
+        return { state: 'expired' };
+      }
 
       if (!isClientAuthenticated) {
         return { state: 'signup' };
@@ -185,10 +188,6 @@ export const SubscriptionCardV1: React.FC<SubscriptionCardV1Props> = ({
           console.log(`Failed to syncFtuStage: ${e}`);
         })
         .finally(() => setLoading(false));
-
-      if (isClientTokenExpired) {
-        return { state: 'expired' };
-      }
 
       return { state: 'history' };
     });


### PR DESCRIPTION

- [x] Describe the purpose of the change
As title: fix notifi-react-card does not land on expiredView when jwt is expired

- [x] Create test cases for your changes if needed
No need (PASSED)

- [x] Include the ticket id if possible (Collaborator only)
CS-381