### PR TITLE
CS-379: fix  disappearing Notifications on scroll

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47880,26 +47880,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "packages/notifi-node-sample/node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "packages/notifi-node/node_modules/ws": {
       "version": "8.11.0",
       "license": "MIT",
@@ -54684,28 +54664,9 @@
         "ts-node": "^10.7.0"
       },
       "dependencies": {
-        "@notifi-network/notifi-node": {
-          "version": "https://registry.npmjs.org/@notifi-network/notifi-node/-/notifi-node-0.89.4.tgz",
-          "integrity": "sha512-K1bq1QZ1ZDpwdFJImZ5bXLImuwmPKgrAYF5jaF2hcWRhAR8kKJk/m4/agDJmMJ4hs4DS2v4LpKBRSvdia4jukw==",
-          "requires": {
-            "@notifi-network/notifi-axios-utils": "^0.89.4",
-            "@notifi-network/notifi-core": "^0.89.4",
-            "@notifi-network/notifi-graphql": "^0.89.4",
-            "graphql": "^16.6.0",
-            "graphql-request": "^6.0.0",
-            "subscriptions-transport-ws": "^0.11.0",
-            "ws": "^8.11.0"
-          }
-        },
         "@types/node": {
           "version": "17.0.45",
           "dev": true
-        },
-        "ws": {
-          "version": "8.16.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-          "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
-          "requires": {}
         }
       }
     },

--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/HistoryCardView.tsx
@@ -14,7 +14,6 @@ import { NotificationEmptyBellIcon } from '../../../assets/NotificationEmptyBell
 import { useNotifiClientContext } from '../../../context';
 import {
   DeepPartialReadonly,
-  concatHistoryNodes,
   getAlertNotificationViewBaseProps,
   validateIsSupported,
 } from '../../../utils';
@@ -96,7 +95,6 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
       if (isLoading) {
         return;
       }
-      setIsLoading(true);
 
       const result = isUsingFrontendClient
         ? await frontendClient.getFusionNotificationHistory({
@@ -110,7 +108,7 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
           });
 
       const nodes: NotificationHistoryEntry[] = result?.nodes ?? [];
-      setAllNodes((existing) => concatHistoryNodes(existing, nodes));
+      setAllNodes((existing) => existing.concat(nodes));
 
       setEndCursor(result?.pageInfo.endCursor);
       setHasNextPage(result?.pageInfo.hasNextPage);
@@ -135,9 +133,10 @@ export const AlertHistoryView: React.FC<AlertHistoryViewProps> = ({
 
     if (!fetched.current) {
       fetched.current = true;
+      setIsLoading(true);
       getNotificationHistory({
         first: MESSAGES_PER_PAGE,
-      });
+      }).finally(() => setIsLoading(false));
     }
   }, [client, frontendClient, isUsingFrontendClient]);
 

--- a/packages/notifi-react-card/lib/utils/NotificationHistoryUtils.tsx
+++ b/packages/notifi-react-card/lib/utils/NotificationHistoryUtils.tsx
@@ -66,7 +66,7 @@ supportedEventDetails.set('DirectTenantMessageEventDetails', {
   getViewProps: (notification: NotificationHistoryEntry) => {
     const detail = notification.detail as DirectTenantMessageEventDetails;
     const templateVariablesJson: Record<string, string> = JSON.parse(
-      detail.templateVariablesJson || '',
+      detail.templateVariablesJson || '{}',
     );
     return {
       notificationTitle: templateVariablesJson.title ?? 'Announcement',
@@ -79,7 +79,7 @@ supportedEventDetails.set('DirectTenantMessageEventDetails', {
   getAlertDetailsContents: (notification: NotificationHistoryEntry) => {
     const detail = notification.detail as DirectTenantMessageEventDetails;
     const templateVariablesJson: Record<string, string> = JSON.parse(
-      detail.templateVariablesJson || '',
+      detail.templateVariablesJson || '{}',
     );
     return {
       topContent: templateVariablesJson.subject ?? '',

--- a/packages/notifi-react-card/lib/utils/NotificationHistoryUtils.tsx
+++ b/packages/notifi-react-card/lib/utils/NotificationHistoryUtils.tsx
@@ -261,29 +261,8 @@ const getAlertDetailsContents = (
       };
 };
 
-const concatHistoryNodes = (
-  nodes: NotificationHistoryEntry[],
-  nodesToConcat: NotificationHistoryEntry[],
-) => {
-  switch (nodes[0]?.__typename) {
-    case 'FusionNotificationHistoryEntry':
-      if (nodesToConcat[0]?.__typename !== 'FusionNotificationHistoryEntry') {
-        return nodes;
-      }
-      return [...nodes, ...nodesToConcat];
-    case 'NotificationHistoryEntry':
-      if (nodesToConcat[0]?.__typename !== 'NotificationHistoryEntry') {
-        return nodes;
-      }
-      return [...nodes, ...nodesToConcat];
-    default:
-      return nodesToConcat;
-  }
-};
-
 export {
   getAlertDetailsContents,
   getAlertNotificationViewBaseProps,
   validateIsSupported,
-  concatHistoryNodes,
 };


### PR DESCRIPTION
- [x] Describe the purpose of the change
As title, fix  disappearing Notifications on scroll

> REASON:  card is not able to parse the correct notificationHistory type using `__typename`. Seems BE is no longer output `__typename` for `FusionNotificationHistoryEntry` and `NotificationHistoryEntry`.

- [x] Create test cases for your changes if needed
No need (PASSED)

- [x] Include the ticket id if possible (Collaborator only)
CS-379
