### PR TITLE
Change specificWallets to match the shape of the dataplane API

### DIFF
--- a/packages/notifi-dataplane/lib/types/FusionMessage.ts
+++ b/packages/notifi-dataplane/lib/types/FusionMessage.ts
@@ -3,24 +3,21 @@ export interface FusionMessage {
   variablesJson: any;
   specificWallets?: ReadonlyArray<
     Readonly<{
-      walletPublicKey: string;
-      // NOTE: Blockchain duplicated here because there would be a circular reference otherwise
-      walletBlockchain:
-        | 'SOLANA'
-        | 'ETHEREUM'
-        | 'AVALANCHE'
-        | 'APTOS'
-        | 'ACALA'
-        | 'POLYGON'
-        | 'ARBITRUM'
-        | 'BINANCE'
-        | 'NEAR'
-        | 'OPTIMISM'
-        | 'INJECTIVE'
-        | 'OSMOSIS'
-        | 'NIBIRU'
-        | 'SUI'
-        | 'ZKSYNC';
+      [walletAddress in string]: | 'SOLANA'
+      | 'ETHEREUM'
+      | 'AVALANCHE'
+      | 'APTOS'
+      | 'ACALA'
+      | 'POLYGON'
+      | 'ARBITRUM'
+      | 'BINANCE'
+      | 'NEAR'
+      | 'OPTIMISM'
+      | 'INJECTIVE'
+      | 'OSMOSIS'
+      | 'NIBIRU'
+      | 'SUI'
+      | 'ZKSYNC'
     }>
   >;
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < <☺
^
^           Thanks for your contribution!!
^
^ Before submitting your valuable work, pls review the checkboxes below.
^
^ For Notifi team collaborator, includes the ticket id as possible
^
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >   -->

- [x] Describe the purpose of the change
The `FusionIngest` endpoint in the Dataplane API takes specific wallet targets as a JSON object with the wallet addresses as keys and the wallet blockchain names as values. This changes that API to match.

- [x] Create test cases for your changes if needed
No need

- [x] Include the ticket id if possible (Collaborator only)
