### PR TITLE
MVP-3984: Add frontendClientStatus in NotifiClientContext

### DIFF
--- a/packages/notifi-react-card/lib/components/subscription/subscription-card-views/ExpiredTokenViewCard.tsx
+++ b/packages/notifi-react-card/lib/components/subscription/subscription-card-views/ExpiredTokenViewCard.tsx
@@ -1,4 +1,3 @@
-import { SignMessageParams } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import {
   useNotifiClientContext,

--- a/packages/notifi-react-card/lib/hooks/index.ts
+++ b/packages/notifi-react-card/lib/hooks/index.ts
@@ -3,3 +3,4 @@ export * from './useSubscriptionCard';
 export * from './SubscriptionCardConfig';
 export * from './useFetchedCardState';
 export * from './useUnreadState';
+export * from './useFrontendClientLogin';

--- a/packages/notifi-react-card/lib/hooks/useFrontendClientLogin.ts
+++ b/packages/notifi-react-card/lib/hooks/useFrontendClientLogin.ts
@@ -7,7 +7,8 @@ import {
 } from '../context';
 
 export const useFrontendClientLogin = () => {
-  const { params, frontendClient } = useNotifiClientContext();
+  const { params, frontendClient, updateFrontendClientStatus } =
+    useNotifiClientContext();
 
   const { useHardwareWallet } = useNotifiSubscriptionContext();
 
@@ -30,9 +31,11 @@ export const useFrontendClientLogin = () => {
       if (logInResult?.completeLogInByTransaction === undefined) {
         throw new Error('Log in failed');
       }
+      updateFrontendClientStatus();
       return logInResult.completeLogInByTransaction;
     } else {
       const result = await frontendClient.logIn(params);
+      updateFrontendClientStatus();
       return result;
     }
   }, [useHardwareWallet, frontendClient, params]);


### PR DESCRIPTION
- [x] Describe the purpose of the change
 (notifi-react-card) To reflect the frontendClient status changes, add `frontendClientStatus` in NotifiClientContext. By doing this, developer using this context variables will be able to get the effect when frontendClient status changes

- [x] Create test cases for your changes if needed
No need (TEST PASSED)

- [x] Include the ticket id if possible (Collaborator only)
MVP-3984
