### PR TITLE
Allow variables in FusionMessage to have any shape

### DIFF
--- a/packages/notifi-dataplane/lib/types/CommunityManagerVariablesJsonPayload.ts
+++ b/packages/notifi-dataplane/lib/types/CommunityManagerVariablesJsonPayload.ts
@@ -1,0 +1,41 @@
+/**
+ * The variable shape that is used for publishing Fusion messages
+ * to Community Manager topics in `publishFusionMessage()`, used as
+ * the `variablesJson` field in `FusionMessage`
+ */
+export type CommunityManagerVariablesJsonPayload = {
+  Platform: CommunityManagerTargetVariables;
+} & {
+  [key in CommunityManagerOptionalTargetType]?: CommunityManagerTargetVariables;
+};
+
+/**
+ * An additional target type to send the Community Manager message to
+ */
+export type CommunityManagerOptionalTargetType =
+  | 'Sms'
+  | 'Telegram'
+  | 'Discord'
+  | 'Email';
+
+/**
+ * The set of variables provided for each target in Community manager messages
+ */
+export type CommunityManagerTargetVariables = {
+  /**
+   * The subject line for the message, if applicable
+   */
+  subject?: string;
+  /**
+   * The message, in either HTML or plain text
+   */
+  message?: string;
+  /**
+   * The message in Markdown format. If provided, will override `message`
+   */
+  message__markdown?: string;
+  /**
+   * Additional data to be provided with the message
+   */
+  [key: string]: string | undefined;
+};

--- a/packages/notifi-dataplane/lib/types/FusionMessage.ts
+++ b/packages/notifi-dataplane/lib/types/FusionMessage.ts
@@ -1,9 +1,8 @@
 import { Types } from 'notifi-graphql/dist';
 
-// If payload type undefined, fallback to default CommunityManagerJsonPayload
-export interface FusionMessage<T extends object = CommunityManagerJsonPayload> {
+export interface FusionMessage {
   eventTypeId: string;
-  variablesJson: VariablesJsonPayload<T>;
+  variablesJson: object;
   specificWallets?: ReadonlyArray<
     Readonly<{
       walletPublicKey: string;
@@ -11,23 +10,3 @@ export interface FusionMessage<T extends object = CommunityManagerJsonPayload> {
     }>
   >;
 }
-
-export type VariablesJsonPayload<T extends object> =
-  T extends CommunityManagerJsonPayload ? CommunityManagerJsonPayload : object;
-
-export type CommunityManagerJsonPayload = { Platform: TargetVariables } & {
-  [key in OptionalTargetType]?: TargetVariables;
-};
-
-export type OptionalTargetType = 'Sms' | 'Telegram' | 'Discord' | 'Email';
-
-/**
- * @param message - only plain text is supported.
- * @param message__markdown - markdown string here will be converted to html.
- */
-export type TargetVariables = {
-  subject?: string;
-  message?: string;
-  message__markdown?: string;
-  [key: string]: string | undefined;
-};

--- a/packages/notifi-node-sample/README.md
+++ b/packages/notifi-node-sample/README.md
@@ -151,8 +151,7 @@ If the request is successful, we can get a response body like this:
 
 > NOTE:
 > The `variablesJson` parameter is the set of variables that will be used when rendering your templates.
-> If you have a variable `fromAddress` in there, for example, you can display it in the template with the expression `{{ eventData.fromAddress }}`
-> The type `CommunityManagerJsonPayload` defines what this object should look like for the templates that Community Manager posts use.
+> If you have a variable `fromAddress`, for example, you can display it in the template with the expression `{{ eventData.fromAddress }}`
 
 If the request is successful, we can get a response body like this:
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < <☺
^
^           Thanks for your contribution!!
^
^ Before submitting your valuable work, pls review the checkboxes below.
^
^ For Notifi team collaborator, includes the ticket id as possible
^
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >   -->

- [x] Describe the purpose of the change
- Events attached to Community Manager have a specific message shape that segregates data by platform, while events of type "Sent from my server" have no such shape restriction.
- Hence, change the type of `variablesJson` in FusionMessage to `object` and remove `CommunityManagerJsonPayload`

- [ ] Create test cases for your changes if needed

- [ ] Include the ticket id if possible (Collaborator only)
