### PR TITLE
MVP-4329: Define the interface for fusion Event Metadata

### DIFF
--- a/packages/notifi-frontend-client/lib/models/FilterOptions.ts
+++ b/packages/notifi-frontend-client/lib/models/FilterOptions.ts
@@ -14,6 +14,7 @@ export type ValueItemConfig = Readonly<{
 
 export type ThresholdDirection = 'above' | 'below';
 
+/**@deprecated this is for AP v1 infra, use fusionFilterOptions instead for new infra */
 export type FilterOptions = Partial<{
   alertFrequency: AlertFrequency;
   directMessageType: string;

--- a/packages/notifi-frontend-client/lib/models/FusionEvent.ts
+++ b/packages/notifi-frontend-client/lib/models/FusionEvent.ts
@@ -1,0 +1,53 @@
+export type FusionEventMetadata = {
+  uiConfigOverride?: {
+    topicDisplayName?: string;
+    historyDisplayName?: string;
+  };
+  filters: Array<AlertFilter>;
+  requiredParserVariables: Array<RequiredParserVariable>;
+};
+
+/**
+ * @param name - `string` unique name
+ */
+export type AlertFilter = {
+  name: string;
+  type: AlertFilterType;
+  executionPriority: number;
+  minimumDurationBetweenTriggersInMinutes: number;
+  userInputParams: UserInputParam<UiType>[];
+  staticFilterParams?: Record<string, object | string | number>;
+};
+
+export type RequiredParserVariable = {
+  variableName: string;
+  variableType: ValueType;
+  variableDescription: string;
+};
+
+export type ValueType = 'integer' | 'price' | 'percentage';
+
+/**
+ * @param UiType - `radio` or `button` (scalable). Define what component should be rendered in Card topic subscription view.
+ * @param defaultValue - The value for default alert subscription
+ */
+export type UserInputParam<T extends UiType> = {
+  name: string;
+  kind: T;
+  valueTypes?: ValueType;
+  options: (string | number)[];
+  defaultValue: string | number;
+  allowCustomInput?: boolean;
+};
+
+export type UiType = 'radio' | 'button';
+type AlertFilterType = 'alertFilter';
+
+export type FusionFilterOptions = {
+  input: Record<AlertFilter['name'], UserInputOptions>;
+};
+
+export type UserInputOptions = Record<
+  UserInputParam<UiType>['name'],
+  UserInputParam<UiType>['options'][number]
+>;

--- a/packages/notifi-frontend-client/lib/models/FusionEvent.ts
+++ b/packages/notifi-frontend-client/lib/models/FusionEvent.ts
@@ -1,10 +1,13 @@
+import { Types } from '@notifi-network/notifi-graphql';
+
 export type FusionEventMetadata = {
   uiConfigOverride?: {
     topicDisplayName?: string;
     historyDisplayName?: string;
+    icon?: Types.GenericEventIconHint;
+    customIconUrl?: string;
   };
   filters: Array<AlertFilter>;
-  requiredParserVariables: Array<RequiredParserVariable>;
 };
 
 /**
@@ -17,6 +20,7 @@ export type AlertFilterBase = {
   executionPriority: number;
   userInputParams: UserInputParam<UiType>[];
   staticFilterParams?: Record<string, object | string | number>;
+  requiredParserVariables: Array<RequiredParserVariable>;
 };
 
 export type AlertFrequencyFilter = AlertFilterBase & {

--- a/packages/notifi-frontend-client/lib/models/FusionEvent.ts
+++ b/packages/notifi-frontend-client/lib/models/FusionEvent.ts
@@ -7,7 +7,7 @@ export type FusionEventMetadata = {
     icon?: Types.GenericEventIconHint;
     customIconUrl?: string;
   };
-  filters: Array<AlertFilter>;
+  filters: Array<Filter>;
 };
 
 /**

--- a/packages/notifi-frontend-client/lib/models/FusionEvent.ts
+++ b/packages/notifi-frontend-client/lib/models/FusionEvent.ts
@@ -13,18 +13,22 @@ export type FusionEventMetadata = {
 /**
  * @param name - `string` unique name
  */
-export type AlertFilter = AlertFilterBase | AlertFrequencyFilter;
-export type AlertFilterBase = {
+export type Filter = AlertFilter | FrequencyFilter;
+export type FilterBase = {
   name: string;
-  type: AlertFilterType;
   executionPriority: number;
-  userInputParams: UserInputParam<UiType>[];
-  staticFilterParams?: Record<string, object | string | number>;
-  requiredParserVariables: Array<RequiredParserVariable>;
 };
 
-export type AlertFrequencyFilter = AlertFilterBase & {
+export type FrequencyFilter = FilterBase & {
   minimumDurationBetweenTriggersInMinutes: number;
+};
+
+export type AlertFilter = FilterBase & {
+  userInputParams: UserInputParam<UiType>[];
+  type: FilterType;
+  staticFilterParams?: Record<string, object | string | number>;
+  requiredParserVariables: Array<RequiredParserVariable>;
+  description: string;
 };
 
 export type RequiredParserVariable = {
@@ -33,7 +37,7 @@ export type RequiredParserVariable = {
   variableDescription: string;
 };
 
-export type ValueType = 'integer' | 'price' | 'percentage';
+export type ValueType = 'integer' | 'price' | 'percentage' | 'string';
 
 /**
  * @param UiType - `radio` or `button` (scalable). Define what component should be rendered in Card topic subscription view.
@@ -41,18 +45,19 @@ export type ValueType = 'integer' | 'price' | 'percentage';
  */
 export type UserInputParam<T extends UiType> = {
   name: string;
-  kind: T;
-  valueTypes?: ValueType;
+  kind: ValueType;
+  uiType: T;
+  description: string;
   options: (string | number)[];
   defaultValue: string | number;
   allowCustomInput?: boolean;
 };
 
 export type UiType = 'radio' | 'button';
-type AlertFilterType = 'alertFilter';
+export type FilterType = 'AlertFilter';
 
 export type FusionFilterOptions = {
-  input: Record<AlertFilter['name'], UserInputOptions>;
+  input: Record<Filter['name'], UserInputOptions>;
 };
 
 export type UserInputOptions = Record<

--- a/packages/notifi-frontend-client/lib/models/FusionEvent.ts
+++ b/packages/notifi-frontend-client/lib/models/FusionEvent.ts
@@ -10,13 +10,17 @@ export type FusionEventMetadata = {
 /**
  * @param name - `string` unique name
  */
-export type AlertFilter = {
+export type AlertFilter = AlertFilterBase | AlertFrequencyFilter;
+export type AlertFilterBase = {
   name: string;
   type: AlertFilterType;
   executionPriority: number;
-  minimumDurationBetweenTriggersInMinutes: number;
   userInputParams: UserInputParam<UiType>[];
   staticFilterParams?: Record<string, object | string | number>;
+};
+
+export type AlertFrequencyFilter = AlertFilterBase & {
+  minimumDurationBetweenTriggersInMinutes: number;
 };
 
 export type RequiredParserVariable = {

--- a/packages/notifi-frontend-client/lib/models/index.ts
+++ b/packages/notifi-frontend-client/lib/models/index.ts
@@ -1,2 +1,3 @@
 export * from './FilterOptions';
+export * from './FusionEvent';
 export * from './SubscriptionCardConfig';


### PR DESCRIPTION

- [x] Describe the purpose of the change
Define the interface for fusionEventDescriptor.metadata
> Located in `frontend-client`'s modal. This way other repo can also make use of it. ex. AP, `notifi-dapp-example`

- [ ] Create test cases for your changes if needed
No need
- [x] Include the ticket id if possible (Collaborator only)
MVP-4329