### PR TITLE
Make NotifiEnvironment default to Production

### DIFF
--- a/packages/notifi-axios-utils/lib/utils/notifiConfigs.ts
+++ b/packages/notifi-axios-utils/lib/utils/notifiConfigs.ts
@@ -38,7 +38,8 @@ export const NOTIFI_CONFIGS: Record<NotifiEnvironment, EnvironmentConfig> = {
   },
 };
 
-const notifiConfigs = (environment: NotifiEnvironment): EnvironmentConfig => {
+const notifiConfigs = (environment?: NotifiEnvironment): EnvironmentConfig => {
+  if (!environment) environment = 'Production';
   return NOTIFI_CONFIGS[environment];
 };
 

--- a/packages/notifi-dapp-example/src/context/NotifiFrontendClientContext.tsx
+++ b/packages/notifi-dapp-example/src/context/NotifiFrontendClientContext.tsx
@@ -35,7 +35,7 @@ export const NotifiFrontendClientContext =
 
 export type NotifiFrontendClientProviderProps = {
   tenantId: string;
-  env: NotifiEnvironment;
+  env?: NotifiEnvironment;
 } & WalletWithSignParams;
 
 export const NotifiFrontendClientProvider: FC<
@@ -126,7 +126,7 @@ export const useNotifiFrontendClientContext = () =>
 
 const getFrontendConfigInput = (
   tenantId: string,
-  env: NotifiEnvironment,
+  env?: NotifiEnvironment,
   params: WalletWithSignParams,
 ): ConfigFactoryInput => {
   if ('accountAddress' in params) {

--- a/packages/notifi-frontend-client/lib/configuration/NotifiFrontendConfiguration.ts
+++ b/packages/notifi-frontend-client/lib/configuration/NotifiFrontendConfiguration.ts
@@ -91,7 +91,7 @@ export type ConfigFactoryInputDelegated = {
     delegatorAddress: string;
   }>;
   tenantId: string;
-  env: NotifiEnvironment;
+  env?: NotifiEnvironment;
   walletBlockchain: NotifiConfigWithPublicKeyAndAddress['walletBlockchain'];
   storageOption?: NotifiEnvironmentConfiguration['storageOption'];
 };
@@ -102,7 +102,7 @@ export type ConfigFactoryInputPublicKeyAndAddress = {
     publicKey: string;
   }>;
   tenantId: string;
-  env: NotifiEnvironment;
+  env?: NotifiEnvironment;
   walletBlockchain: NotifiConfigWithPublicKeyAndAddress['walletBlockchain'];
   storageOption?: NotifiEnvironmentConfiguration['storageOption'];
 };
@@ -112,7 +112,7 @@ export type ConfigFactoryInputPublicKey = {
     publicKey: string;
   }>;
   tenantId: string;
-  env: NotifiEnvironment;
+  env?: NotifiEnvironment;
   walletBlockchain: NotifiConfigWithPublicKey['walletBlockchain'];
   storageOption?: NotifiEnvironmentConfiguration['storageOption'];
 };
@@ -191,7 +191,8 @@ export const newFrontendConfig = (
     : configFactoryPublicKey(config);
 };
 
-export const envUrl = (env: NotifiEnvironment): string => {
+export const envUrl = (env?: NotifiEnvironment): string => {
+  if (!env) env = 'Production';
   switch (env) {
     case 'Development':
       return 'https://api.dev.notifi.network/gql';

--- a/packages/notifi-frontend-client/lib/configuration/NotifiFrontendConfiguration.ts
+++ b/packages/notifi-frontend-client/lib/configuration/NotifiFrontendConfiguration.ts
@@ -7,7 +7,7 @@ export type NotifiEnvironment =
   | 'Local';
 
 export type NotifiEnvironmentConfiguration = Readonly<{
-  env: NotifiEnvironment;
+  env?: NotifiEnvironment;
   tenantId: string;
   storageOption?: Readonly<{
     driverType?: 'LocalForage' | 'InMemory';
@@ -34,7 +34,7 @@ type WalletBlockchainWithPublicKey = Extract<
   | 'MONAD'
 >;
 
-type WalletBlockchainWithDelegate = 'XION'
+type WalletBlockchainWithDelegate = 'XION';
 
 type WalletBlockchainWithPublicKeyAndAddress = Exclude<
   Types.WalletBlockchain,

--- a/packages/notifi-frontend-client/lib/storage/InMemoryStorageDriver.ts
+++ b/packages/notifi-frontend-client/lib/storage/InMemoryStorageDriver.ts
@@ -22,8 +22,9 @@ const getEnvPrefix = (env: NotifiEnvironment): string => {
 export const createInMemoryStorageDriver = (
   config: NotifiFrontendConfiguration,
 ): StorageDriver => {
-  let keyPrefix = `${getEnvPrefix(config.env)}:${config.tenantId}:${config.walletBlockchain
-    }`;
+  let keyPrefix = `${getEnvPrefix(config.env || 'Production')}:${
+    config.tenantId
+  }:${config.walletBlockchain}`;
 
   if (checkIsConfigWithPublicKeyAndAddress(config)) {
     keyPrefix += `:${config.accountAddress}:${config.authenticationKey}`;

--- a/packages/notifi-frontend-client/lib/storage/InMemoryStorageDriver.ts
+++ b/packages/notifi-frontend-client/lib/storage/InMemoryStorageDriver.ts
@@ -6,7 +6,8 @@ import {
 } from '../configuration/NotifiFrontendConfiguration';
 import { StorageDriver } from './NotifiFrontendStorage';
 
-const getEnvPrefix = (env: NotifiEnvironment): string => {
+const getEnvPrefix = (env?: NotifiEnvironment): string => {
+  if (!env) env = 'Production';
   switch (env) {
     case 'Production':
       return 'notifi-jwt';

--- a/packages/notifi-frontend-client/lib/storage/LocalForageStorageDriver.ts
+++ b/packages/notifi-frontend-client/lib/storage/LocalForageStorageDriver.ts
@@ -12,7 +12,8 @@ localforage.config({
   name: 'notifi',
 });
 
-const getEnvPrefix = (env: NotifiEnvironment): string => {
+const getEnvPrefix = (env?: NotifiEnvironment): string => {
+  if (!env) env = 'Production';
   switch (env) {
     case 'Production':
       return 'notifi-jwt';
@@ -28,8 +29,9 @@ const getEnvPrefix = (env: NotifiEnvironment): string => {
 export const createLocalForageStorageDriver = (
   config: NotifiFrontendConfiguration,
 ): StorageDriver => {
-  let keyPrefix = `${getEnvPrefix(config.env)}:${config.tenantId}:${config.walletBlockchain
-    }`;
+  let keyPrefix = `${getEnvPrefix(config.env)}:${config.tenantId}:${
+    config.walletBlockchain
+  }`;
 
   if (checkIsConfigWithPublicKeyAndAddress(config)) {
     keyPrefix += `:${config.accountAddress}:${config.authenticationKey}`;

--- a/packages/notifi-node-sample/lib/index.ts
+++ b/packages/notifi-node-sample/lib/index.ts
@@ -36,7 +36,7 @@ app.get('/', (_req, res) => {
 
 const parseEnv = (envString: string | undefined): NotifiEnvironment => {
   const str = envString ?? process.env.NOTIFI_ENV;
-  let notifiEnv: NotifiEnvironment = 'Development';
+  let notifiEnv: NotifiEnvironment = 'Production';
   if (
     str === 'Production' ||
     str === 'Staging' ||

--- a/packages/notifi-node/README.md
+++ b/packages/notifi-node/README.md
@@ -12,13 +12,11 @@ Please reach out to us for help on [Discord](https://discord.gg/nAqR3mk3rv)!
 ```ts
 import {
   NotifiClient,
-  NotifiEnvironment,
   createGraphQLClient,
   createNotifiService,
 } from '@notifi-network/notifi-node';
 
-const env: NotifiEnvironment = 'Development'; // Or 'Production'
-const gqlClient = createGraphQLClient(env);
+const gqlClient = createGraphQLClient();
 const notifiService = createNotifiService(gqlClient);
 const client = new NotifiClient(notifiService);
 ```

--- a/packages/notifi-node/README.md
+++ b/packages/notifi-node/README.md
@@ -87,8 +87,7 @@ const result = await client.sendDirectPush(token, {
 import * as dotenv from 'dotenv';
 import { NotifiClient, NotifiEnvironment, createGraphQLClient, createNotifiService } from '@notifi-network/notifi-node';
 
-const env: NotifiEnvironment = 'Development';
-const gqlClient = createGraphQLClient(env);
+const gqlClient = createGraphQLClient();
 const notifiService = createNotifiService(gqlClient);
 const client = new NotifiClient(notifiService);
 

--- a/packages/notifi-node/lib/client/createNotifiService.ts
+++ b/packages/notifi-node/lib/client/createNotifiService.ts
@@ -4,7 +4,8 @@ import { NotifiDataplaneClient } from '@notifi-network/notifi-dataplane';
 import { NotifiService } from '@notifi-network/notifi-graphql';
 import { GraphQLClient } from 'graphql-request';
 
-export const createGraphQLClient = (env: NotifiEnvironment): GraphQLClient => {
+export const createGraphQLClient = (env?: NotifiEnvironment): GraphQLClient => {
+  if (!env) env = 'Production';
   const { gqlUrl } = notifiConfigs(env);
   const instance = new GraphQLClient(gqlUrl);
 
@@ -12,8 +13,9 @@ export const createGraphQLClient = (env: NotifiEnvironment): GraphQLClient => {
 };
 
 export const createDataplaneClient = (
-  env: NotifiEnvironment,
+  env?: NotifiEnvironment,
 ): NotifiDataplaneClient => {
+  if (!env) env = 'Production';
   const { dpapiUrl } = notifiConfigs(env);
   return new NotifiDataplaneClient(dpapiUrl);
 };

--- a/packages/notifi-node/lib/client/createSubscriptionClient.ts
+++ b/packages/notifi-node/lib/client/createSubscriptionClient.ts
@@ -5,10 +5,24 @@ import {
 import { SubscriptionClient } from 'subscriptions-transport-ws';
 import WebSocket from 'ws';
 
-export const createSubscriptionClient = (
+export function createSubscriptionClient(jwt: string): SubscriptionClient;
+export function createSubscriptionClient(
   env: NotifiEnvironment,
   jwt: string,
-) => {
+): SubscriptionClient;
+export function createSubscriptionClient(
+  param1: NotifiEnvironment | string,
+  param2?: string,
+): SubscriptionClient {
+  let env: NotifiEnvironment;
+  let jwt: string;
+  if (param2) {
+    env = param1 as NotifiEnvironment;
+    jwt = param2;
+  } else {
+    env = 'Production';
+    jwt = param1;
+  }
   const { wsUrl } = notifiConfigs(env);
   const client = new SubscriptionClient(
     wsUrl,
@@ -23,4 +37,4 @@ export const createSubscriptionClient = (
   );
 
   return client;
-};
+}

--- a/packages/notifi-react-card/lib/context/NotifiClientContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiClientContext.tsx
@@ -43,7 +43,7 @@ const getFrontendConfigInput = (params: NotifiParams): ConfigFactoryInput => {
       },
       tenantId: params.dappAddress,
       walletBlockchain: params.walletBlockchain,
-      env: params.env,
+      env: params.env || 'Production',
     };
   } else {
     return {
@@ -52,7 +52,7 @@ const getFrontendConfigInput = (params: NotifiParams): ConfigFactoryInput => {
       },
       tenantId: params.dappAddress,
       walletBlockchain: params.walletBlockchain,
-      env: params.env,
+      env: params.env || 'Production',
     };
   }
 };
@@ -74,7 +74,7 @@ export const NotifiClientContextProvider: React.FC<NotifiParams> = ({
     return updatedFrontendClient;
   }, [
     params.dappAddress,
-    params.env,
+    params.env || 'Production',
     params.walletBlockchain,
     params.walletPublicKey,
   ]);

--- a/packages/notifi-react-card/lib/context/NotifiContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiContext.tsx
@@ -138,7 +138,7 @@ type WalletParams =
 export type NotifiParams = Readonly<{
   alertConfigurations?: Record<string, AlertConfiguration | null>;
   dappAddress: string;
-  env: NotifiEnvironment;
+  env?: NotifiEnvironment;
   keepSubscriptionData?: boolean;
   multiWallet?: MultiWalletParams;
   isUsingFrontendClient?: boolean; // default is true

--- a/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
+++ b/packages/notifi-react-card/lib/context/NotifiSubscriptionContext.tsx
@@ -317,11 +317,12 @@ export const NotifiSubscriptionContextProvider: React.FC<
       const phoneNumberToSet = phoneNumber ?? '';
 
       if (!!phoneNumber && !isPhoneNumberConfirmed) {
+        const env = params.env || 'Production';
         setPhoneNumberErrorMessage({
           type: 'unrecoverableError',
           message: 'Messages stopped',
           tooltip: `Please text 'start' to the following number:\n${
-            params.env === 'Production' ? '+1 206 222 3465' : '+1 253 880 1477 '
+            env === 'Production' ? '+1 206 222 3465' : '+1 253 880 1477 '
           }`,
         });
       }

--- a/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
+++ b/packages/notifi-react-card/lib/hooks/useNotifiSubscribe.ts
@@ -183,11 +183,12 @@ export const useNotifiSubscribe: ({
       const phoneNumberToSet = phoneNumber ?? '';
 
       if (!isPhoneNumberConfirmed) {
+        const env = params.env || 'Production';
         setPhoneNumberErrorMessage({
           type: 'unrecoverableError',
           message: 'Messages stopped',
           tooltip: `Please text 'start' to the following number:\n${
-            params.env === 'Production' ? '+1 206 222 3465' : '+1 253 880 1477 '
+            env === 'Production' ? '+1 206 222 3465' : '+1 253 880 1477 '
           }`,
         });
       }

--- a/packages/notifi-react-example/cypress.config.ts
+++ b/packages/notifi-react-example/cypress.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
       'https://mainnet.infura.io/v3/9c9ff698105d4f6b9b2b93eddc0dff72',
     DAPP_ADDRESS: 'notifie2e',
     CARD_ID: '718f2bb0fd80401887643764017cc780',
-    ENV: 'Production',
+    ENV: '',
     MNEMONIC:
       'civil squeeze word coach always source aunt believe yard urge night alert',
     WALLET_BLOCKCHAIN: 'ETHEREUM',

--- a/packages/notifi-react-example/package.json
+++ b/packages/notifi-react-example/package.json
@@ -47,10 +47,10 @@
   },
   "scripts": {
     "start": "BROWSER=none react-app-rewired start",
-    "test": "cypress run --component --spec 'cypress/component/NotifiSubscriptionCard.cy.tsx' --browser firefox",
+    "test": "cypress run --component --spec 'cypress/component/NotifiSubscriptionCard.cy.tsx' --browser chrome",
     "eject": "react-app-rewired eject",
     "cypress:open": "cypress open",
-    "cypress:ci": "cypress run --component --group notifi-e2e --spec 'cypress/component/NotifiSubscriptionCard.cy.tsx' --browser firefox --record"
+    "cypress:ci": "cypress run --component --group notifi-e2e --spec 'cypress/component/NotifiSubscriptionCard.cy.tsx' --browser chrome --record"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/notifi-react-example/package.json
+++ b/packages/notifi-react-example/package.json
@@ -47,10 +47,10 @@
   },
   "scripts": {
     "start": "BROWSER=none react-app-rewired start",
-    "test": "cypress run --component --spec 'cypress/component/NotifiSubscriptionCard.cy.tsx' --browser chrome",
+    "test": "cypress run --component --spec 'cypress/component/NotifiSubscriptionCard.cy.tsx' --browser firefox",
     "eject": "react-app-rewired eject",
     "cypress:open": "cypress open",
-    "cypress:ci": "cypress run --component --group notifi-e2e --spec 'cypress/component/NotifiSubscriptionCard.cy.tsx' --browser chrome --record"
+    "cypress:ci": "cypress run --component --group notifi-e2e --spec 'cypress/component/NotifiSubscriptionCard.cy.tsx' --browser firefox --record"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
'Production' is now the only setting for NotifiEnvironment that is used by external customers. Therefore, in all places where a NotifiEnvironment is passed (React card, frontend configuration, Node.js clients, etc.), make omitting the NotifiEnvironment parameter default to 'Production'.


<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < <☺
^
^           Thanks for your contribution!!
^
^ Before submitting your valuable work, pls review the checkboxes below.
^
^ For Notifi team collaborator, includes the ticket id as possible
^
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >   -->

- [x] Describe the purpose of the change

- [x] Create test cases for your changes if needed

- [x] Include the ticket id if possible (Collaborator only)
