### PR TITLE
MVP-4620: Update NotifiTopicContext valueType render logic

### DIFF
--- a/packages/notifi-react/lib/context/NotifiTopicContext.tsx
+++ b/packages/notifi-react/lib/context/NotifiTopicContext.tsx
@@ -20,6 +20,7 @@ import React, {
 
 import {
   TopicStackAlert,
+  convertOptionValue,
   getFusionEventMetadata,
   isAlertFilter,
   isFusionFilterOptions,
@@ -171,23 +172,20 @@ export const NotifiTopicContextProvider: FC<PropsWithChildren> = ({
       const fusionEventMetadataJson = fusionEventDescriptor.metadata;
       const fusionEventId = fusionEventDescriptor.id;
       if (fusionEventMetadataJson && fusionEventId) {
-        // TODO: might need impl validator for metadata
-        const fusionEventMetadata = JSON.parse(
-          fusionEventMetadataJson,
-        ) as FusionEventMetadata;
-        const filters = (fusionEventMetadata.filters as Filter[])?.filter(
-          isAlertFilter,
-        );
+        const fusionEventMetadata = getFusionEventMetadata(topic);
+        const filters = fusionEventMetadata?.filters?.filter(isAlertFilter);
         const fusionFilterOptionsInput: FusionFilterOptions['input'] = {};
-
         if (filters && filters.length > 0) {
           // NOTE: for now we only consider 1 to 1 relationship (1 filter for 1 topic)
 
           const userInputParams = filters[0].userInputParams;
           const userInputOptions: UserInputOptions = {};
           //TODO: O(n^2) to fix
-          userInputParams.forEach((userInput) => {
-            userInputOptions[userInput.name] = userInput.defaultValue;
+          userInputParams.forEach((userInputParm) => {
+            userInputOptions[userInputParm.name] = convertOptionValue(
+              userInputParm.defaultValue,
+              userInputParm.kind,
+            );
           });
           fusionFilterOptionsInput[filters[0].name] = userInputOptions;
         }

--- a/packages/notifi-react/lib/utils/topic.ts
+++ b/packages/notifi-react/lib/utils/topic.ts
@@ -263,3 +263,24 @@ export const composeTopicStackAlertName = (
 ) => {
   return `${topicName}:;:${subscriptionValue}:;:${subscriptionLabel}:;:${Date.now()}`;
 };
+
+export enum ConvertOptionDirection {
+  /**Note: Convert the value rendered in browser to notifi backend acceptable format */
+  FtoB = 'frontendToBackend',
+  /**Note: Convert the value received from notifi backend to frontend renderable format */
+  BtoF = 'BackendToFrontend',
+}
+
+export const convertOptionValue = (
+  value: string | number,
+  type: ValueType,
+  direction?: ConvertOptionDirection,
+) => {
+  direction = direction ?? ConvertOptionDirection.FtoB;
+  if (type === 'percentage') {
+    return direction === ConvertOptionDirection.FtoB
+      ? Number(value) / 100
+      : Number(value) * 100;
+  }
+  return value;
+};


### PR DESCRIPTION
- [x] Describe the purpose of the change
  - Update NotifiTopicContext: Support `convertOptionValue`
  - Update `subscribeAlertsDefault`: utilize `convertOptionValue`
> This Ticket is the blocker of  MVP-4621 (Also GMX valueType render component logic). Need to merge this first then impl condition valueType rendering logic. 
> CC: @marukohao 
- [ ] Create test cases for your changes if needed
No need
- [ ] Include the ticket id if possible (Collaborator only)
MVP-4621