### PR TITLE
MVP-4331-patch: Set the inital isLoading value as true to avoid flickering

### DIFF
--- a/packages/notifi-react/lib/context/NotifiHistoryContext.tsx
+++ b/packages/notifi-react/lib/context/NotifiHistoryContext.tsx
@@ -46,7 +46,7 @@ export type NotifiHistoryProviderProps = {
 export const NotifiHistoryContextProvider: FC<
   PropsWithChildren<NotifiHistoryProviderProps>
 > = ({ children, notificationCountPerPage = 20 }) => {
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<Error | null>(null);
   const { frontendClient, frontendClientStatus } =
     useNotifiFrontendClientContext();
@@ -99,9 +99,10 @@ export const NotifiHistoryContextProvider: FC<
         setError(new Error('No more notification history to fetch'));
         return;
       }
-      if (isLoading) {
+      if (isLoading && isInitialLoaded.current) {
         return;
       }
+      isInitialLoaded.current = true;
       setIsLoading(true);
       try {
         const result = await frontendClient.getFusionNotificationHistory({
@@ -146,7 +147,6 @@ export const NotifiHistoryContextProvider: FC<
       !isInitialLoaded.current &&
       cardConfig
     ) {
-      isInitialLoaded.current = true;
       getHistoryItems(true);
       frontendClient.getUnreadNotificationHistoryCount().then(({ count }) => {
         setUnreadCount(count);


### PR DESCRIPTION
- [x] Describe the purpose of the change
Set the `isLoading` as true to resolve the issue of seeing a glance of empty inbox view before getting into HistoryList. 

- [ ] Create test cases for your changes if needed
No need
- [x] Include the ticket id if possible (Collaborator only)
MVP-4331