### PR TITLE
pre-MVP-4708: Update fusionEventMetadata to support PrefixAndSuffix

### DIFF
--- a/packages/notifi-frontend-client/lib/models/FusionEvent.ts
+++ b/packages/notifi-frontend-client/lib/models/FusionEvent.ts
@@ -53,8 +53,12 @@ export type RequiredParserVariable = {
   variableDescription: string;
 };
 
-export type ValueType = 'integer' | 'price' | 'percentage' | 'string';
-
+// price is deprecated: use float or integer with {prefix: '$', suffix: ''} as userInputParam.prefixAndSuffix
+export type ValueType = 'integer' | 'price' | 'percentage' | 'string' | 'float';
+export type PrefixAndSuffix = {
+  prefix: string;
+  suffix: string;
+};
 /**
  * @param UiType - `radio` or `button` (scalable). Define what component should be rendered in Card topic subscription view.
  * @param defaultValue - The value for default alert subscription
@@ -67,6 +71,7 @@ export type UserInputParam<T extends UiType> = {
   options: (string | number)[];
   defaultValue: string | number;
   allowCustomInput?: boolean;
+  prefixAndSuffix?: PrefixAndSuffix;
 };
 
 export type UiType = 'radio' | 'button';

--- a/packages/notifi-react/lib/utils/topic.ts
+++ b/packages/notifi-react/lib/utils/topic.ts
@@ -214,6 +214,7 @@ export const getUpdatedAlertFilterOptions = (
   };
 };
 
+/** @deprecated use `userInputParam.prefixAndSuffix` */
 export const derivePrefixAndSuffixFromValueType = (
   kind: ValueType,
 ): { prefix: string; suffix: string } => {
@@ -230,6 +231,11 @@ export const derivePrefixAndSuffixFromValueType = (
       };
     case 'string':
     case 'integer':
+      return {
+        prefix: '',
+        suffix: '',
+      };
+    default:
       return {
         prefix: '',
         suffix: '',


### PR DESCRIPTION
- [x] Describe the purpose of the change
As title. 
> This is the blocker for AP & `notifi-react` to support custom prefix & suffix
> CC: @nimesh-notifi @marukohao 
- [ ] Create test cases for your changes if needed
No need
- [x] Include the ticket id if possible (Collaborator only)
MVP-4708