### PR TITLE
MVP-4751: Migrate Alert Name Identifier - notifi-react context

### DIFF
--- a/packages/notifi-react/lib/context/NotifiHistoryContext.tsx
+++ b/packages/notifi-react/lib/context/NotifiHistoryContext.tsx
@@ -78,7 +78,9 @@ export const NotifiHistoryContextProvider: FC<
               .filter((item) => !historyItemIdMap.has(item.id));
             if (newItems?.length && newItems.length > 0) {
               setHistoryItems((existing) => [...newItems, ...existing]);
-              setUnreadCount((prev) => (prev ? prev + newItems.length : null));
+              setUnreadCount((prev) =>
+                prev !== null ? prev + newItems.length : null,
+              );
             }
           });
       });

--- a/packages/notifi-react/lib/utils/topic.ts
+++ b/packages/notifi-react/lib/utils/topic.ts
@@ -11,6 +11,7 @@ import {
   UiType,
   UserInputParam,
   ValueType,
+  objectKeys,
 } from '@notifi-network/notifi-frontend-client';
 
 export type LabelWithSubTopicsEventTypeItem = LabelEventTypeItem & {
@@ -237,6 +238,51 @@ export const derivePrefixAndSuffixFromValueType = (
   }
 };
 
+export type AlertMetadataBase = {
+  fusionEventTypeId: string;
+};
+
+export type AlertMetadataForTopicStack = AlertMetadataBase & {
+  subscriptionValue: string;
+  subscriptionLabel: string;
+  timestamp: string;
+};
+
+export const isAlertMetadataForTopicStack = (
+  alertMetadata: AlertMetadata,
+): alertMetadata is AlertMetadataForTopicStack => {
+  return (
+    objectKeys(alertMetadata).length > 1 &&
+    'timestamp' in alertMetadata &&
+    'subscriptionValue' in alertMetadata &&
+    'subscriptionLabel' in alertMetadata
+  );
+};
+
+type AlertMetadata = AlertMetadataBase | AlertMetadataForTopicStack;
+
+export const resolveAlertName = (alertName: string): AlertMetadata => {
+  /** alertName always start with its corresponding `fusionEventTypeId`:
+   * 1. Alert created from normal topic (standalone topic or topic group): alert.name = fusionEventTypeId
+   * 2. Alert created from topic stack: alert.name = fusionEventTypeId:;:subscriptionValue:;:subscriptionLabel
+   * ... if more to come, add the identifier after fusionEventTypeId ex. fusionEventTypeId:;:<identifier>:;:<metadata>
+   */
+  const resolved = alertName.split(':;:');
+  if (resolved.length === 1) {
+    return {
+      fusionEventTypeId: resolved[0],
+    };
+  }
+  const [fusionEventTypeId, subscriptionValue, subscriptionLabel, timestamp] =
+    resolved;
+  return {
+    fusionEventTypeId,
+    subscriptionValue,
+    subscriptionLabel,
+    timestamp,
+  };
+};
+
 /** TopicStackRow related */
 
 export type TopicStackAlert = {
@@ -245,11 +291,12 @@ export type TopicStackAlert = {
   subscriptionValueInfo: InputObject;
 };
 
+/** @deprecated - Use resolveAlertName instead */
 export const resolveTopicStackAlertName = (alertName: string) => {
-  const [topicName, subscriptionValue, subscriptionLabel, timestamp] =
+  const [fusionEventTypeId, subscriptionValue, subscriptionLabel, timestamp] =
     alertName.split(':;:');
   return {
-    topicName,
+    fusionEventTypeId,
     subscriptionValue,
     subscriptionLabel,
     timestamp,
@@ -257,11 +304,11 @@ export const resolveTopicStackAlertName = (alertName: string) => {
 };
 
 export const composeTopicStackAlertName = (
-  topicName: string,
+  fusionEventTypeId: string,
   subscriptionValue: string,
   subscriptionLabel: string,
 ) => {
-  return `${topicName}:;:${subscriptionValue}:;:${subscriptionLabel}:;:${Date.now()}`;
+  return `${fusionEventTypeId}:;:${subscriptionValue}:;:${subscriptionLabel}:;:${Date.now()}`;
 };
 
 export enum ConvertOptionDirection {


### PR DESCRIPTION
- [x] Describe the purpose of the change
As title -> context update for using using `fusionEventId` as `alert.name`.
> This is the blocker of MVP-4752 & MVP-4753 
>  **Breaking change** - `notifi-react` and `notifi-dapp-example` need to change accordingly @marukohao 
- [ ] Create test cases for your changes if needed
No need
- [x] Include the ticket id if possible (Collaborator only)
MVP-4751