### PR TITLE
notifi-react/MVP-4752: Update Topic and History related components

### DIFF
--- a/packages/notifi-react/lib/components/HistoryRow.tsx
+++ b/packages/notifi-react/lib/components/HistoryRow.tsx
@@ -4,12 +4,8 @@ import { format, isToday, isWithinInterval, subDays } from 'date-fns';
 import React from 'react';
 
 import { Icon } from '../assets/Icons';
-import {
-  HistoryItem,
-  useNotifiHistoryContext,
-  useNotifiTenantConfigContext,
-} from '../context';
-import { defaultCopy, getFusionEventMetadata } from '../utils';
+import { HistoryItem, useNotifiHistoryContext } from '../context';
+import { defaultCopy } from '../utils';
 
 export type HistoryRowProps = {
   className?: {
@@ -28,21 +24,7 @@ export type HistoryRowProps = {
 
 export const HistoryRow: React.FC<HistoryRowProps> = (props) => {
   const icon = props.historyItem.icon as Types.GenericEventIconHint;
-  // const [read, setRead] = React.useState<boolean>(props.historyItem.read);
-
-  const { fusionEventTopics } = useNotifiTenantConfigContext();
   const { markAsRead } = useNotifiHistoryContext();
-
-  const titleDisplay = React.useMemo(() => {
-    const topicName = props.historyItem.topic;
-    const topic = fusionEventTopics.find(
-      (topic) => topic.uiConfig.name === topicName,
-    );
-    return topic
-      ? getFusionEventMetadata(topic)?.uiConfigOverride?.historyDisplayName ??
-          topicName
-      : defaultCopy.historyRow.legacyTopic;
-  }, [fusionEventTopics, props]);
 
   return (
     <div
@@ -76,7 +58,7 @@ export const HistoryRow: React.FC<HistoryRowProps> = (props) => {
               props.className?.titleText,
             )}
           >
-            {titleDisplay}
+            {props.historyItem.topic ?? defaultCopy.historyRow.legacyTopic}
           </div>
           <div
             className={clsx(

--- a/packages/notifi-react/lib/components/TopicOptions.tsx
+++ b/packages/notifi-react/lib/components/TopicOptions.tsx
@@ -48,6 +48,7 @@ export const TopicOptions = <T extends TopicRowCategory>(
 ) => {
   const isTopicGroup = isTopicGroupOptions(props);
   const benchmarkTopic = isTopicGroup ? props.topics[0] : props.topic;
+  if (!benchmarkTopic.fusionEventDescriptor.id) return null;
   /* NOTE: benchmarkTopic is either the 'first topic in the group' or the 'standalone topic'. This represent the target topic to be rendered. */
   const {
     customInput,
@@ -57,7 +58,7 @@ export const TopicOptions = <T extends TopicRowCategory>(
     uiType,
     setCustomInput,
   } = useUserInputParmToFilterOption(
-    benchmarkTopic.uiConfig.name,
+    benchmarkTopic.fusionEventDescriptor.id,
     props.userInputParam,
   );
   const { isLoading: isLoadingTopic } = useNotifiTopicContext();

--- a/packages/notifi-react/lib/components/TopicStackRow.tsx
+++ b/packages/notifi-react/lib/components/TopicStackRow.tsx
@@ -24,9 +24,11 @@ export type TopicStackRowProps = {
 } & TopicStandaloneRowMetadata;
 
 export const TopicStackRow: React.FC<TopicStackRowProps> = (props) => {
-  const { getTopicStackAlertsFromTopicName } = useNotifiTopicContext();
-  const topicStackAlerts = getTopicStackAlertsFromTopicName(
-    props.topic.uiConfig.name,
+  const { getTopicStackAlerts } = useNotifiTopicContext();
+  if (!props.topic.fusionEventDescriptor.id) return null;
+
+  const topicStackAlerts = getTopicStackAlerts(
+    props.topic.fusionEventDescriptor.id,
   );
 
   const [isTopicStackRowInputVisible, setIsTopicStackRowInputVisible] =

--- a/packages/notifi-react/lib/hooks/useTopicStackRowInput.tsx
+++ b/packages/notifi-react/lib/hooks/useTopicStackRowInput.tsx
@@ -68,9 +68,9 @@ export const useTopicStackRowInput = (
   );
 
   const subscribeTopic = async () => {
-    if (!isTopicReadyToSubscribe) return;
+    if (!isTopicReadyToSubscribe || !topic.fusionEventDescriptor.id) return;
     const alertName = composeTopicStackAlertName(
-      topic.uiConfig.name,
+      topic.fusionEventDescriptor.id,
       subscriptionValue.value,
       subscriptionValue.label,
     );

--- a/packages/notifi-react/lib/hooks/useUserInputParmToFilterOption.tsx
+++ b/packages/notifi-react/lib/hooks/useUserInputParmToFilterOption.tsx
@@ -14,7 +14,7 @@ import {
 } from '../utils';
 
 export const useUserInputParmToFilterOption = (
-  topicName: string,
+  alertName: string,
   userInputParam: UserInputParam<UiType>,
 ) => {
   const { getAlertFilterOptions, subscribeAlertsWithFilterOptions } =
@@ -22,7 +22,7 @@ export const useUserInputParmToFilterOption = (
   const {
     targetDocument: { targetGroupId },
   } = useNotifiTargetContext();
-  const alertFilterOptions = getAlertFilterOptions(topicName);
+  const alertFilterOptions = getAlertFilterOptions(alertName);
 
   const filterName: string | undefined = Object.keys(
     alertFilterOptions?.input ?? [],


### PR DESCRIPTION
- [x] Describe the purpose of the change
 Update Topic and History related components (notifi-react) according to the the change of migrating alert.name from topicName to fusionEventTypeId
> This is the for migrating alert.name from topicName to fusionEventTypeId 2nd part - Components update. 
> Per discussed, we can also adopt this change to GMX (`notifi-dapp-example`) CC: @marukohao @nimesh-notifi 

- [ ] Create test cases for your changes if needed

- [ ] Include the ticket id if possible (Collaborator only)
