### PR TITLE
notifi-dapp-example (ODF specific): make sure localStorage is removed before route back to root

### DIFF
--- a/packages/notifi-dapp-example/src/hooks/useNotifiRouter.ts
+++ b/packages/notifi-dapp-example/src/hooks/useNotifiRouter.ts
@@ -53,12 +53,16 @@ export const useNotifiRouter = () => {
 
   useEffect(() => {
     if (loginError) {
-      handleRoute('/');
       if (selectedWallet) {
         wallets[selectedWallet].disconnect();
       } else if (injectiveSelectedWallet) {
         injectiveWallets[injectiveSelectedWallet].disconnect();
       }
+      setTimeout(() => {
+        /** NOTE: preserve 0.5s to make sure cache is cleaned before route back to root dir*/
+        console.log(`LOGIN ERROR: ${JSON.stringify(loginError)}`);
+        handleRoute('/');
+      }, 5000);
     }
   }, [loginError]);
 


### PR DESCRIPTION
- [x] Describe the purpose of the change
As title, Try to resolve the edge case the the infinite spin showing up after re-deploying

- [ ] Create test cases for your changes if needed
No need
- [ ] Include the ticket id if possible (Collaborator only)
N/A