### PR TITLE
MVP-5037: de-expose refreshTargetDocument from NotifiTargetContext

### DIFF
--- a/packages/notifi-dapp-example/src/components/SignUpButton.tsx
+++ b/packages/notifi-dapp-example/src/components/SignUpButton.tsx
@@ -36,7 +36,6 @@ export const SignUpButton: React.FC<NotifiSignUpButtonProps> = ({
 
   const {
     renewTargetGroup,
-    refreshTargetDocument,
     targetDocument: {
       targetInputs: { email, phoneNumber, telegram, slack, discord, wallet },
     },
@@ -80,8 +79,6 @@ export const SignUpButton: React.FC<NotifiSignUpButtonProps> = ({
           } else {
             await updateFtuStage(FtuStage.Alerts);
           }
-          const newData = await frontendClient.fetchData();
-          refreshTargetDocument(newData);
           await handleRoute('/notifi/ftu');
         }
       } catch (e: unknown) {

--- a/packages/notifi-react/lib/context/NotifiTargetContext.tsx
+++ b/packages/notifi-react/lib/context/NotifiTargetContext.tsx
@@ -148,7 +148,6 @@ export type NotifiTargetContextType = {
   isChangingTargets: Record<Target, boolean>;
   targetDocument: TargetDocument;
   unVerifiedTargets: Target[];
-  refreshTargetDocument: (newData: Types.FetchFusionDataQuery) => void;
 };
 
 const NotifiTargetContext = createContext<NotifiTargetContextType>(
@@ -808,7 +807,6 @@ export const NotifiTargetContextProvider: FC<
   return (
     <NotifiTargetContext.Provider
       value={{
-        refreshTargetDocument, // TODO: Consider to remove (Only consumed by `notifi-dapp-example` Signup button)
         error,
         errorWallet,
         isLoading,


### PR DESCRIPTION
- [x] Describe the purpose of the change
As title.
Will be appreciated if can double confirm if @marukohao   the `notifi-dapp-example` will be working as expected so that integration can rebase it without issue.

- [ ] Create test cases for your changes if needed
No need
- [ ] Include the ticket id if possible (Collaborator only)
MVP-5037