### PR TITLE
MVP-4975+5067: new frontendClient method `fetchFusionData` & CBW target UAT feedbacks 

### DIFF
--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -721,8 +721,13 @@ export class NotifiFrontendClient {
     await Promise.all([saveAuthorizationPromise, saveRolesPromise]);
   }
 
+  /** @deprecated use fetchFusionData instead. This is for legacy  */
   async fetchData(): Promise<Types.FetchDataQuery> {
     return this._service.fetchData({});
+  }
+
+  async fetchFusionData(): Promise<Types.FetchFusionDataQuery> {
+    return this._service.fetchFusionData({});
   }
 
   async beginLoginViaTransaction({

--- a/packages/notifi-graphql/lib/NotifiService.ts
+++ b/packages/notifi-graphql/lib/NotifiService.ts
@@ -275,12 +275,19 @@ export class NotifiService
     const headers = this._requestHeaders();
     return this._typedClient.deleteWebhookTarget(variables, headers);
   }
-
+  /** @deprecated use fetchFusionData instead. This is for legacy  */
   async fetchData(
     variables: Generated.FetchDataQueryVariables,
   ): Promise<Generated.FetchDataQuery> {
     const headers = this._requestHeaders();
     return this._typedClient.fetchData(variables, headers);
+  }
+
+  async fetchFusionData(
+    variables: Generated.FetchFusionDataQueryVariables,
+  ): Promise<Generated.FetchFusionDataQuery> {
+    const headers = this._requestHeaders();
+    return this._typedClient.fetchFusionData(variables, headers);
   }
 
   async findTenantConfig(

--- a/packages/notifi-graphql/lib/gql/queries/fetchFusionData.gql.ts
+++ b/packages/notifi-graphql/lib/gql/queries/fetchFusionData.gql.ts
@@ -1,0 +1,22 @@
+import { gql } from 'graphql-request';
+
+import { AlertFragment } from '../fragments/AlertFragment.gql';
+import { ConnectedWalletFragment } from '../fragments/ConnectedWalletFragment.gql';
+import { TargetGroupFragment } from '../fragments/TargetGroupFragment.gql';
+
+export const fetchFusionData = gql`
+  query fetchFusionData {
+    alert {
+      ...AlertFragment
+    }
+    connectedWallet {
+      ...ConnectedWalletFragment
+    }
+    targetGroup {
+      ...TargetGroupFragment
+    }
+  }
+  ${AlertFragment}
+  ${ConnectedWalletFragment}
+  ${TargetGroupFragment}
+`;

--- a/packages/notifi-graphql/lib/operations/FetchFusionData.ts
+++ b/packages/notifi-graphql/lib/operations/FetchFusionData.ts
@@ -1,0 +1,10 @@
+import {
+  FetchFusionDataQuery,
+  FetchFusionDataQueryVariables,
+} from '../gql/generated';
+
+export type FetchFusionDataService = Readonly<{
+  fetchFusionData: (
+    variables: FetchFusionDataQueryVariables,
+  ) => Promise<FetchFusionDataQuery>;
+}>;

--- a/packages/notifi-react/lib/components/Connect.tsx
+++ b/packages/notifi-react/lib/components/Connect.tsx
@@ -208,8 +208,8 @@ const validateDefaultTargetGroup = async (
   frontendClient: NotifiFrontendClient,
 ) => {
   // NOTE: this extra request is necessary as the targetGroupId state in NotifiTargetContext will not be updated constantly right after login
-  const targetGroup = (await frontendClient?.fetchData())?.targetGroup?.find(
-    (group) => group?.name === 'Default',
-  );
+  const targetGroup = (
+    await frontendClient?.fetchFusionData()
+  )?.targetGroup?.find((group) => group?.name === 'Default');
   return !!targetGroup;
 };

--- a/packages/notifi-react/lib/components/Connect.tsx
+++ b/packages/notifi-react/lib/components/Connect.tsx
@@ -57,15 +57,21 @@ export const Connect: React.FC<ConnectProps> = (props) => {
 
   const onClick = async () => {
     setIsLoading(true);
-    const frontendClient = await login();
-    if (props.loginWithoutSubscription) return;
-    if (!frontendClient) return;
-    const isDefaultTargetExist = await validateDefaultTargetGroup(
-      frontendClient,
-    );
+    try {
+      const frontendClient = await login();
+      if (props.loginWithoutSubscription) return;
+      if (!frontendClient) return;
+      const isDefaultTargetExist = await validateDefaultTargetGroup(
+        frontendClient,
+      );
 
-    if (!isDefaultTargetExist) {
-      await renewTargetGroup();
+      if (!isDefaultTargetExist) {
+        await renewTargetGroup();
+      }
+    } catch (error) {
+      console.error(error);
+      setIsLoading(false);
+      return;
     }
   };
 

--- a/packages/notifi-react/lib/components/NotifiCardModal.tsx
+++ b/packages/notifi-react/lib/components/NotifiCardModal.tsx
@@ -94,7 +94,6 @@ export const NotifiCardModal: React.FC<NotifiCardModalProps> = (props) => {
 
   useEffect(() => {
     if (
-      clientError ||
       userSettingError ||
       historyError ||
       tenantError ||
@@ -106,7 +105,7 @@ export const NotifiCardModal: React.FC<NotifiCardModalProps> = (props) => {
           `In 
               ${
                 clientError?.message
-                  ? ` ClientContext: \n ${clientError.message}`
+                  ? ` FrontendClientContext: \n ${clientError.message}`
                   : ''
               } 
               ${

--- a/packages/notifi-react/lib/components/TargetStateBanner.tsx
+++ b/packages/notifi-react/lib/components/TargetStateBanner.tsx
@@ -33,6 +33,7 @@ export type TargetStateBannerProps = {
     signup?: {
       text?: string;
       cta?: string;
+      textInConfig?: string;
     };
   };
   onClickCta?: () => void;
@@ -70,78 +71,23 @@ export const TargetStateBanner: React.FC<TargetStateBannerProps> = (props) => {
         props.classNames?.container,
       )}
     >
-      {!hasTarget(targetData) && parentComponent === 'config' ? (
-        <div
-          className={clsx(
-            'notifi-target-state-banner-signup',
-            props.classNames?.signupBanner,
-          )}
-        >
-          <div
-            className={clsx(
-              'notifi-target-state-banner-signup-content',
-              props.classNames?.signupBannerContent,
-            )}
-          >
-            <div
-              className={clsx(
-                'notifi-target-state-banner-signup-icon',
-                props.classNames?.signupBannerIcon,
-              )}
-            >
-              <Icon type="bell-circle" />
-            </div>
-            <div
-              className={clsx(
-                'notifi-target-state-banner-signup-text',
-                props.classNames?.signupBannerText,
-              )}
-            >
-              {props.copy?.signup?.text ??
-                defaultCopy.targetStateBanner.Signup.text}
-              {''}
-              {/* Only the last element should be joined with ', or', others should be joined with ', ' */}
-              {activeTargets.length > 1
-                ? activeTargets.length === 2
-                  ? `${activeTargets[0]} or ${activeTargets[1]}`
-                  : `${activeTargets
-                      .slice(0, -1)
-                      .join(', ')}, or ${activeTargets.slice(-1)}`
-                : activeTargets.slice(-1)}
-            </div>
-          </div>
-          <button
-            className={clsx(
-              'notifi-target-state-banner-signup-cta',
-              props.classNames?.signupBannerCta,
-            )}
-            onClick={props.onClickCta}
-          >
-            {props.copy?.signup?.cta ??
-              defaultCopy.targetStateBanner.Signup.cta}
-          </button>
-        </div>
-      ) : null}
-
       {!hasTarget(targetData) && parentComponent === 'history' ? (
         <div
           className={clsx(
             'notifi-target-state-banner-signup',
-            parentComponent === 'history' && 'history',
             props.classNames?.signupBanner,
           )}
         >
           <div
             className={clsx(
               'notifi-target-state-banner-signup-content',
-              parentComponent === 'history' && 'history',
               props.classNames?.signupBannerContent,
             )}
           >
             <div
               className={clsx(
                 'notifi-target-state-banner-signup-icon',
-                parentComponent === 'history' && 'history',
+
                 props.classNames?.signupBannerIcon,
               )}
             >
@@ -154,7 +100,7 @@ export const TargetStateBanner: React.FC<TargetStateBannerProps> = (props) => {
               )}
             >
               {props.copy?.signup?.text ??
-                defaultCopy.targetStateBanner.Signup.text}{' '}
+                defaultCopy.targetStateBanner.Signup.textInHistory}{' '}
               {activeTargets.length > 1
                 ? `${activeTargets
                     .slice(0, -1)
@@ -165,18 +111,17 @@ export const TargetStateBanner: React.FC<TargetStateBannerProps> = (props) => {
           <button
             className={clsx(
               'notifi-target-state-banner-signup-cta',
-              parentComponent === 'history' && 'history',
               props.classNames?.signupBannerCta,
             )}
             onClick={props.onClickCta}
           >
             {props.copy?.signup?.cta ??
-              defaultCopy.targetStateBanner.Signup.cta}
+              defaultCopy.targetStateBanner.Signup.ctaInHistory}
           </button>
         </div>
       ) : null}
 
-      {hasTarget(targetData) && parentComponent === 'config' ? (
+      {parentComponent === 'config' ? (
         <div
           className={clsx(
             'notifi-target-state-banner-verify',
@@ -204,8 +149,11 @@ export const TargetStateBanner: React.FC<TargetStateBannerProps> = (props) => {
                 props.classNames?.verifyBannerTitle,
               )}
             >
-              {props.copy?.verify?.title ??
-                defaultCopy.targetStateBanner.verify.title}
+              {hasTarget(targetData)
+                ? props.copy?.verify?.title ??
+                  defaultCopy.targetStateBanner.verify.title
+                : props.copy?.signup?.textInConfig ??
+                  defaultCopy.targetStateBanner.Signup.textInConfig}
             </div>
             {unVerifiedTargets.length > 0 && (
               <div

--- a/packages/notifi-react/lib/context/NotifiFrontendClientContext.tsx
+++ b/packages/notifi-react/lib/context/NotifiFrontendClientContext.tsx
@@ -75,7 +75,7 @@ export const NotifiFrontendClientContextProvider: FC<
       })
       .catch((error) => {
         setError(error);
-        console.log(error);
+        console.error(error);
       })
       .finally(() => setIsLoading(false));
   }, [walletWithSignParams.walletPublicKey]);
@@ -95,7 +95,14 @@ export const NotifiFrontendClientContextProvider: FC<
       setFrontendClient(frontendClient);
       setError(null);
     } catch (error) {
-      setError(error as Error);
+      if (error instanceof Error) {
+        const newError = {
+          ...error,
+          message: `login: User rejects to sign, or mis-impl the signMessage method: ${error.message}`,
+        };
+        setError(newError);
+        console.error(newError);
+      }
     } finally {
       setIsLoading(false);
     }

--- a/packages/notifi-react/lib/context/NotifiTopicContext.tsx
+++ b/packages/notifi-react/lib/context/NotifiTopicContext.tsx
@@ -1,7 +1,6 @@
 import {
   FusionEventTopic,
   FusionFilterOptions,
-  InputObject,
   UserInputOptions,
   resolveObjectArrayRef,
   resolveStringRef,
@@ -79,7 +78,7 @@ export const NotifiTopicContextProvider: FC<PropsWithChildren> = ({
 
   useEffect(() => {
     if (!frontendClientStatus.isAuthenticated) return;
-    frontendClient.fetchData().then(refreshAlerts);
+    frontendClient.fetchFusionData().then(refreshAlerts);
   }, [frontendClientStatus.isAuthenticated]);
 
   const unsubscribeAlert = useCallback(
@@ -90,7 +89,7 @@ export const NotifiTopicContextProvider: FC<PropsWithChildren> = ({
       frontendClient
         .deleteAlert({ id: alert.id })
         .then(() => {
-          frontendClient.fetchData().then(refreshAlerts);
+          frontendClient.fetchFusionData().then(refreshAlerts);
           setError(null);
         })
         .catch((e) => {
@@ -177,7 +176,7 @@ export const NotifiTopicContextProvider: FC<PropsWithChildren> = ({
 
     try {
       await frontendClient.ensureFusionAlerts({ alerts: createAlertInputs });
-      const data = await frontendClient.fetchData();
+      const data = await frontendClient.fetchFusionData();
       refreshAlerts(data);
       setError(null);
     } catch (e) {
@@ -273,7 +272,7 @@ export const NotifiTopicContextProvider: FC<PropsWithChildren> = ({
 
     try {
       await frontendClient.ensureFusionAlerts({ alerts: createAlertInputs });
-      const data = await frontendClient.fetchData();
+      const data = await frontendClient.fetchFusionData();
       refreshAlerts(data);
       setError(null);
     } catch (e) {
@@ -295,7 +294,7 @@ export const NotifiTopicContextProvider: FC<PropsWithChildren> = ({
     [alerts],
   );
 
-  const refreshAlerts = (newData: Types.FetchDataQuery) => {
+  const refreshAlerts = (newData: Types.FetchFusionDataQuery) => {
     const alerts: Record<string, Types.AlertFragmentFragment> = {};
     newData.alert?.forEach((alert) => {
       if (alert?.name) {

--- a/packages/notifi-react/lib/style/target-list.css
+++ b/packages/notifi-react/lib/style/target-list.css
@@ -29,12 +29,17 @@
 .notifi-target-list-target-verify-message {
   font-size: 0.9rem;
   color: var(--notifi-target-list-target-verify-message-text);
+  display: flex;
+  align-items: center;
 }
 
 .notifi-target-list-target-confirmed-message {
   font-size: 0.875rem;
   color: var(--notifi-target-list-target-verify-message-text);
   text-align: center;
+  text-align: center;
+  display: flex;
+  align-items: center;
 }
 
 .notifi-target-list-target-confirmed-message.inbox {
@@ -44,7 +49,8 @@
 .notifi-target-list-item-tooltip {
   display: inline-block;
   position: relative;
-  height: 1rem;
+  height: 1.5rem;
+  width: 1.5rem;
 }
 
 .notifi-target-list-item-tooltip-content {
@@ -104,8 +110,6 @@
 }
 
 .notifi-target-list-item-tooltip-icon {
-  position: absolute;
-  top: 0rem;
 }
 
 .notifi-target-list-icon {
@@ -139,7 +143,7 @@
 .notifi-target-cta-button {
   background-color: var(--notifi-target-list-cat-button-bg);
   color: var(--notifi-target-list-cat-button-text);
-  padding: 0.5rem 2rem;
+  padding: 0.5rem 1rem;
   text-align: center;
   cursor: pointer;
   border-radius: 6px;

--- a/packages/notifi-react/lib/style/target-list.css
+++ b/packages/notifi-react/lib/style/target-list.css
@@ -143,8 +143,9 @@
   text-align: center;
   cursor: pointer;
   border-radius: 6px;
+  min-width: 5.5rem;
+  min-height: 1.25rem;
   display: flex;
-  align-items: center;
   justify-content: center;
 }
 

--- a/packages/notifi-react/lib/style/target-state-banner.css
+++ b/packages/notifi-react/lib/style/target-state-banner.css
@@ -70,11 +70,8 @@
 
 .notifi-target-state-banner-signup {
   display: flex;
-  flex-direction: column;
   align-items: center;
   padding: 0.7rem 1rem;
-}
-.notifi-target-state-banner-signup.history {
   flex-direction: row;
   background-color: var(--notifi-target-state-banner-signup-history-bg);
   border-radius: 6px;
@@ -85,9 +82,6 @@
   align-items: center;
   width: 70%;
   margin-bottom: 0.5rem;
-}
-
-.notifi-target-state-banner-signup-content.history {
   margin-bottom: 0;
 }
 
@@ -99,8 +93,6 @@
 .notifi-target-state-banner-signup-icon {
   color: var(--notifi-target-state-banner-signup-icon-color);
   margin-right: 0.8rem;
-}
-.notifi-target-state-banner-signup-icon.history {
   color: inherit;
 }
 
@@ -111,8 +103,5 @@
   border-radius: 6px;
   cursor: pointer;
   font-size: 0.9rem;
-}
-
-.notifi-target-state-banner-signup-cta.history {
   width: 7rem;
 }

--- a/packages/notifi-react/lib/utils/constants.ts
+++ b/packages/notifi-react/lib/utils/constants.ts
@@ -119,8 +119,9 @@ export const defaultCopy = {
       ctaText: 'Verify',
     },
     Signup: {
-      text: 'Get alerts via',
-      cta: 'Sign Up',
+      textInHistory: 'Get alerts via',
+      ctaInHistory: 'Sign Up',
+      textInConfig: 'Get notifications to the destinations of your choice.',
     },
   },
   inboxConfigTargetList: {


### PR DESCRIPTION
- [x] Describe the purpose of the change
  - Expose new frontendClient method `fetchFusionData` which is consumed by `notifi-react` (CC: @nimesh-notifi  for viz)
  - Address Wallet target UAT feedbacks

- [ ] Create test cases for your changes if needed

- [ ] Include the ticket id if possible (Collaborator only)
MVP-4975/ MVP-5067