### PR TITLE
MVP-5114: workaround to display history display name

### DIFF
--- a/packages/notifi-graphql/codegen.yml
+++ b/packages/notifi-graphql/codegen.yml
@@ -1,4 +1,5 @@
-schema: https://api.dev.notifi.network/gql/
+# TODO: Temporary use prod to get rid of  dev breaking change (connectWallet being removed 20240710) -> Should change back to https://api.dev.notifi.network/gql/
+schema: https://api.notifi.network/gql/
 documents: ./lib/gql/**/*.gql.ts
 generates:
   ./lib/gql/generated.ts:

--- a/packages/notifi-react/lib/components/TopicRow.tsx
+++ b/packages/notifi-react/lib/components/TopicRow.tsx
@@ -5,7 +5,11 @@ import React from 'react';
 import { Icon } from '../assets/Icons';
 import { useNotifiTargetContext, useNotifiTopicContext } from '../context';
 import { useComponentPosition } from '../hooks/useComponentPosition';
-import { getUserInputParams, isTopicGroupValid } from '../utils';
+import {
+  getFusionEventMetadata,
+  getUserInputParams,
+  isTopicGroupValid,
+} from '../utils';
 import { Toggle } from './Toggle';
 import {
   TopicGroupRowMetadata,
@@ -63,8 +67,10 @@ export const TopicRow = <T extends TopicRowCategory>(
 
   const title = isTopicGroup
     ? props.topicGroupName
-    : benchmarkTopic.uiConfig.displayNameOverride ??
-      benchmarkTopic.uiConfig.name;
+    : getFusionEventMetadata(benchmarkTopic)?.uiConfigOverride
+        ?.topicDisplayName || // 1. Show topic displayname in fusionEventMetadata
+      benchmarkTopic.uiConfig.displayNameOverride || // 2. Fall back to cardConfig'displayNameOverride  (May deprecated sooner or later)
+      benchmarkTopic.uiConfig.name; // 3. Fall back to topic name
 
   const toggleStandAloneTopic = async (topic: FusionEventTopic) => {
     if (!targetGroupId) return;


### PR DESCRIPTION
- [x] Describe the purpose of the change
  - workaround to display history display name
  - also make use of fusionEventMetadata topic display name then fallback to card ui config for topic display name

> **NOTE**
> Temporary use prod gql schema to get rid of  dev breaking change (connectWallet being removed 20240710) 

- [ ] Create test cases for your changes if needed

- [x] Include the ticket id if possible (Collaborator only)
MVP-5114