### PR TITLE
MVP-5396-1: Add deprecated warning into legacy packages

### DIFF
--- a/packages/notifi-axios-adapter/README.md
+++ b/packages/notifi-axios-adapter/README.md
@@ -1,11 +1,6 @@
 # `@notifi-network/notifi-axios-adapter`
 
-> TODO: description
+This package is deprecated and will no longer be maintained.
+Please use `@notifi-network/notifi-graphql` instead.
 
-## Usage
-
-```
-const notifiAxiosAdapter = require('@notifi-network/notifi-axios-adapter');
-
-// TODO: DEMONSTRATE API
-```
+> **IMPORTANT**: Do not use companion packages (`@notifi-network/*`) version over `~1.1.1` with this package.

--- a/packages/notifi-axios-utils/README.md
+++ b/packages/notifi-axios-utils/README.md
@@ -1,11 +1,9 @@
 # `@notifi-network/notifi-axios-utils`
 
-> TODO: description
+This package is deprecated and will no longer be maintained.
+Please use the following package instead.
 
-## Usage
+- `@notifi-network/notifi-graphql`
+- `@notifi-network/notifi-frontend-client`
 
-```
-const notifiAxiosUtils = require('@notifi-network/notifi-axios-utils');
-
-// TODO: DEMONSTRATE API
-```
+> **IMPORTANT**: Do not use companion packages (`@notifi-network/*`) version over `~1.1.1` with this package.

--- a/packages/notifi-core/README.md
+++ b/packages/notifi-core/README.md
@@ -1,11 +1,8 @@
 # `@notifi-network/notifi-core`
 
-> TODO: description
+This package is deprecated and will no longer be maintained.
+Please use the following package instead.
 
-## Usage
+- `@notifi-network/notifi-graphql`
 
-```
-const notifiCore = require('@notifi-network/notifi-core');
-
-// TODO: DEMONSTRATE API
-```
+> **IMPORTANT**: Do not use companion packages (`@notifi-network/*`) version over `~1.1.1` with this package.

--- a/packages/notifi-react-card/README.md
+++ b/packages/notifi-react-card/README.md
@@ -1,5 +1,12 @@
 # `@notifi-network/notifi-react-card`
 
+> This package is deprecated and will no longer be maintained.
+> Please use the following package instead.
+>
+> - `@notifi-network/notifi-react`
+>
+> **IMPORTANT**: Do not use companion packages (`@notifi-network/*`) version over `~1.1.1` with this package.
+
 A drop-in component that can get your dapp up and running with alert notifications in minutes.
 
 We currently support the following blockchains:

--- a/packages/notifi-react-example/README.md
+++ b/packages/notifi-react-example/README.md
@@ -1,5 +1,13 @@
 # @notifi/notifi-react-example
 
+This package is deprecated and will no longer be maintained.
+Please use the following package instead.
+
+- `@notifi-network/notifi-react`
+- `@notifi-network/notifi-react-example-v2`
+
+> **IMPORTANT**: Do not use companion packages (`@notifi-network/*`) version over `~1.1.1` with this package.
+
 ## 🙋🏻‍♀️ Introduction
 
 This example is aim to demonstrate the Dapp integration with notifi SDK (notifi-react-card) across multi supported blockchains.

--- a/packages/notifi-react-hooks/README.md
+++ b/packages/notifi-react-hooks/README.md
@@ -1,6 +1,12 @@
 # `@notifi/notifi-react-hooks`
 
-> _Updated Oct 11, 2022_
+This package is deprecated and will no longer be maintained.
+Please use the following package instead.
+
+- `@notifi-network/notifi-frontend-client`
+- `@notifi-network/notifi-react`
+
+> **IMPORTANT**: Do not use companion packages (`@notifi-network/*`) version over `~1.1.1` with this package.
 
 ## 🙋🏻‍♀️ Introduction
 


### PR DESCRIPTION


- [x] Describe the purpose of the change

The pre PR of MVP-5936 by adding the deprecate warning to legacy packages
This will be published to npm as `v1.1.2`, the final version of these legacy package.

- [ ] Create test cases for your changes if needed
No need
- [x] Include the ticket id if possible (Collaborator only)
MVP-5396