### PR TITLE
MVP-5423: Add new frontend-client and graphql methods for webPushTarget

### DIFF
--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -1377,4 +1377,11 @@ export class NotifiFrontendClient {
     const mutation = await this._service.updateWebPushTarget(input);
     return mutation;
   }
+
+  async deleteWebPushTarget(
+    input: Types.DeleteWebPushTargetMutationVariables,
+  ): Promise<Types.DeleteWebPushTargetMutation> {
+    const mutation = await this._service.deleteWebPushTarget(input);
+    return mutation;
+  }
 }

--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -1384,4 +1384,15 @@ export class NotifiFrontendClient {
     const mutation = await this._service.deleteWebPushTarget(input);
     return mutation;
   }
+
+  async getWebPushTargets(
+    input: Types.GetWebPushTargetsQueryVariables,
+  ): Promise<Types.GetWebPushTargetsQuery['webPushTargets']> {
+    const query = await this._service.getWebPushTargets(input);
+    const result = query.webPushTargets;
+    if (!result) {
+      throw new Error('Failed to fetch webpush targets');
+    }
+    return result;
+  }
 }

--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -1370,4 +1370,11 @@ export class NotifiFrontendClient {
     const mutation = await this._service.createWebPushTarget(input);
     return mutation;
   }
+
+  async updateWebPushTarget(
+    input: Types.UpdateWebPushTargetMutationVariables,
+  ): Promise<Types.UpdateWebPushTargetMutation> {
+    const mutation = await this._service.updateWebPushTarget(input);
+    return mutation;
+  }
 }

--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -1363,4 +1363,11 @@ export class NotifiFrontendClient {
     const mutation = await this._service.verifyXmtpTargetViaXip42(input);
     return mutation;
   }
+
+  async createWebPushTarget(
+    input: Types.CreateWebPushTargetMutationVariables,
+  ): Promise<Types.CreateWebPushTargetMutation> {
+    const mutation = await this._service.createWebPushTarget(input);
+    return mutation;
+  }
 }

--- a/packages/notifi-graphql/lib/NotifiService.ts
+++ b/packages/notifi-graphql/lib/NotifiService.ts
@@ -611,6 +611,13 @@ export class NotifiService
     return this._typedClient.verifyXmtpTargetViaXip42(variables, headers);
   }
 
+  async createWebPushTarget(
+    variables: Generated.CreateWebPushTargetMutationVariables,
+  ): Promise<Generated.CreateWebPushTargetMutation> {
+    const headers = this._requestHeaders();
+    return this._typedClient.createWebPushTarget(variables, headers);
+  }
+
   private _requestHeaders(): HeadersInit {
     const requestId = uuid();
     const headers: HeadersInit = {

--- a/packages/notifi-graphql/lib/NotifiService.ts
+++ b/packages/notifi-graphql/lib/NotifiService.ts
@@ -618,6 +618,13 @@ export class NotifiService
     return this._typedClient.createWebPushTarget(variables, headers);
   }
 
+  async updateWebPushTarget(
+    variables: Generated.UpdateWebPushTargetMutationVariables,
+  ): Promise<Generated.UpdateWebPushTargetMutation> {
+    const headers = this._requestHeaders();
+    return this._typedClient.updateWebPushTarget(variables, headers);
+  }
+
   private _requestHeaders(): HeadersInit {
     const requestId = uuid();
     const headers: HeadersInit = {

--- a/packages/notifi-graphql/lib/NotifiService.ts
+++ b/packages/notifi-graphql/lib/NotifiService.ts
@@ -632,6 +632,13 @@ export class NotifiService
     return this._typedClient.deleteWebPushTarget(variables, headers);
   }
 
+  async getWebPushTargets(
+    variables: Generated.GetWebPushTargetsQueryVariables,
+  ): Promise<Generated.GetWebPushTargetsQuery> {
+    const headers = this._requestHeaders();
+    return this._typedClient.getWebPushTargets(variables, headers);
+  }
+
   private _requestHeaders(): HeadersInit {
     const requestId = uuid();
     const headers: HeadersInit = {

--- a/packages/notifi-graphql/lib/NotifiService.ts
+++ b/packages/notifi-graphql/lib/NotifiService.ts
@@ -625,6 +625,13 @@ export class NotifiService
     return this._typedClient.updateWebPushTarget(variables, headers);
   }
 
+  async deleteWebPushTarget(
+    variables: Generated.DeleteWebPushTargetMutationVariables,
+  ): Promise<Generated.DeleteWebPushTargetMutation> {
+    const headers = this._requestHeaders();
+    return this._typedClient.deleteWebPushTarget(variables, headers);
+  }
+
   private _requestHeaders(): HeadersInit {
     const requestId = uuid();
     const headers: HeadersInit = {

--- a/packages/notifi-graphql/lib/gql/fragments/WebPushTargetFragment.gql.ts
+++ b/packages/notifi-graphql/lib/gql/fragments/WebPushTargetFragment.gql.ts
@@ -1,0 +1,9 @@
+import { gql } from 'graphql-request';
+
+export const WebPushTargetFragment = gql`
+  fragment WebPushTargetFragment on WebPushTarget {
+    id
+    createdDate
+    name
+  }
+`;

--- a/packages/notifi-graphql/lib/gql/mutations/createWebPushTarget.gql.ts
+++ b/packages/notifi-graphql/lib/gql/mutations/createWebPushTarget.gql.ts
@@ -1,0 +1,34 @@
+import { gql } from 'graphql-request';
+
+import { WebPushTargetFragment } from '../fragments/WebPushTargetFragment.gql';
+
+export const CreateWebPushTarget = gql`
+  mutation createWebPushTarget(
+    $vapidPublicKey: String!
+    $endpoint: String!
+    $auth: String!
+    $p256dh: String!
+  ) {
+    createWebPushTarget(
+      input: {
+        vapidPublicKey: $vapidPublicKey
+        endpoint: $endpoint
+        auth: $auth
+        p256dh: $p256dh
+      }
+    ) {
+      webPushTarget {
+        ...WebPushTargetFragment
+      }
+      errors {
+        ... on TargetLimitExceededError {
+          message
+        }
+        ... on UnexpectedError {
+          message
+        }
+      }
+    }
+  }
+  ${WebPushTargetFragment}
+`;

--- a/packages/notifi-graphql/lib/gql/mutations/deleteWebPushTarget.gql.ts
+++ b/packages/notifi-graphql/lib/gql/mutations/deleteWebPushTarget.gql.ts
@@ -1,0 +1,17 @@
+import { gql } from 'graphql-request';
+
+export const DeleteWebPushTarget = gql`
+  mutation deleteWebPushTarget($id: String!) {
+    deleteWebPushTarget(input: { id: $id }) {
+      success
+      errors {
+        ... on TargetDoesNotExistError {
+          message
+        }
+        ... on UnexpectedError {
+          message
+        }
+      }
+    }
+  }
+`;

--- a/packages/notifi-graphql/lib/gql/mutations/updateWebPushTarget.gql.ts
+++ b/packages/notifi-graphql/lib/gql/mutations/updateWebPushTarget.gql.ts
@@ -1,0 +1,29 @@
+import { gql } from 'graphql-request';
+
+import { WebPushTargetFragment } from '../fragments/WebPushTargetFragment.gql';
+
+export const UpdateWebPushTarget = gql`
+  mutation updateWebPushTarget(
+    $id: String!
+    $endpoint: String!
+    $auth: String!
+    $p256dh: String!
+  ) {
+    updateWebPushTarget(
+      input: { id: $id, endpoint: $endpoint, auth: $auth, p256dh: $p256dh }
+    ) {
+      webPushTarget {
+        ...WebPushTargetFragment
+      }
+      errors {
+        ... on TargetDoesNotExistError {
+          message
+        }
+        ... on UnexpectedError {
+          message
+        }
+      }
+    }
+  }
+  ${WebPushTargetFragment}
+`;

--- a/packages/notifi-graphql/lib/gql/queries/getWebPushTargets.gql.ts
+++ b/packages/notifi-graphql/lib/gql/queries/getWebPushTargets.gql.ts
@@ -1,0 +1,27 @@
+import { gql } from 'graphql-request';
+
+import { WebPushTargetFragment } from '../fragments/WebPushTargetFragment.gql';
+
+export const GetWebPushTargets = gql`
+  query getWebPushTargets($ids: [String!], $first: Int, $after: String) {
+    webPushTargets(
+      input: { ids: $ids, first: $first, after: $after }
+      first: $first
+      after: $after
+    ) {
+      pageInfo {
+        ...PageInfoFragment
+      }
+      nodes {
+        ...WebPushTargetFragment
+      }
+      edges {
+        cursor
+        node {
+          ...WebPushTargetFragment
+        }
+      }
+    }
+  }
+  ${WebPushTargetFragment}
+`;

--- a/packages/notifi-graphql/lib/operations/CreateWebPushTarget.ts
+++ b/packages/notifi-graphql/lib/operations/CreateWebPushTarget.ts
@@ -1,0 +1,10 @@
+import {
+  CreateWebPushTargetMutation,
+  CreateWebPushTargetMutationVariables,
+} from '../gql/generated';
+
+export type CreateWebPushTargetService = Readonly<{
+  createWebPushTarget: (
+    variables: CreateWebPushTargetMutationVariables,
+  ) => Promise<CreateWebPushTargetMutation['createWebPushTarget']>;
+}>;

--- a/packages/notifi-graphql/lib/operations/DeleteWebPushTarget.ts
+++ b/packages/notifi-graphql/lib/operations/DeleteWebPushTarget.ts
@@ -1,0 +1,10 @@
+import {
+  DeleteWebPushTargetMutation,
+  DeleteWebPushTargetMutationVariables,
+} from '../gql/generated';
+
+export type DeleteWebPushTargetService = Readonly<{
+  deleteWebPushTarget: (
+    variables: DeleteWebPushTargetMutationVariables,
+  ) => Promise<DeleteWebPushTargetMutation['deleteWebPushTarget']>;
+}>;

--- a/packages/notifi-graphql/lib/operations/GetWebPushTargets.ts
+++ b/packages/notifi-graphql/lib/operations/GetWebPushTargets.ts
@@ -1,0 +1,10 @@
+import {
+  GetWebPushTargetsQuery,
+  GetWebPushTargetsQueryVariables,
+} from '../gql/generated';
+
+export type GetWebPushTargetsService = Readonly<{
+  getWebPushTargets: (
+    variables: GetWebPushTargetsQueryVariables,
+  ) => Promise<GetWebPushTargetsQuery>;
+}>;

--- a/packages/notifi-graphql/lib/operations/UpdateWebPushTarget.ts
+++ b/packages/notifi-graphql/lib/operations/UpdateWebPushTarget.ts
@@ -1,0 +1,10 @@
+import {
+  UpdateWebPushTargetMutation,
+  UpdateWebPushTargetMutationVariables,
+} from '../gql/generated';
+
+export type UpdateWebPushTargetService = Readonly<{
+  updateWebPushTarget: (
+    variables: UpdateWebPushTargetMutationVariables,
+  ) => Promise<UpdateWebPushTargetMutation['updateWebPushTarget']>;
+}>;

--- a/packages/notifi-graphql/lib/operations/index.ts
+++ b/packages/notifi-graphql/lib/operations/index.ts
@@ -63,3 +63,4 @@ export * from './GetWeb3Targets';
 export * from './VerifyCbwTarget';
 export * from './VerifyXmtpTarget';
 export * from './VerifyXmtpTargetViaXip42';
+export * from './CreateWebPushTarget';

--- a/packages/notifi-graphql/lib/operations/index.ts
+++ b/packages/notifi-graphql/lib/operations/index.ts
@@ -66,3 +66,4 @@ export * from './VerifyXmtpTargetViaXip42';
 export * from './CreateWebPushTarget';
 export * from './UpdateWebPushTarget';
 export * from './DeleteWebPushTarget';
+export * from './GetWebPushTargets';

--- a/packages/notifi-graphql/lib/operations/index.ts
+++ b/packages/notifi-graphql/lib/operations/index.ts
@@ -64,3 +64,4 @@ export * from './VerifyCbwTarget';
 export * from './VerifyXmtpTarget';
 export * from './VerifyXmtpTargetViaXip42';
 export * from './CreateWebPushTarget';
+export * from './UpdateWebPushTarget';

--- a/packages/notifi-graphql/lib/operations/index.ts
+++ b/packages/notifi-graphql/lib/operations/index.ts
@@ -65,3 +65,4 @@ export * from './VerifyXmtpTarget';
 export * from './VerifyXmtpTargetViaXip42';
 export * from './CreateWebPushTarget';
 export * from './UpdateWebPushTarget';
+export * from './DeleteWebPushTarget';


### PR DESCRIPTION

- [x] Describe the purpose of the change
Support the following 4 service calls in `notifi-graphql` and `notifi-frontend-client`
    - `createWebPushTarget`  (Mutation)

    - `updateWebPushTarget` (Mutation)

    - `deleteWebPushTarget` (Mutation)

    - `webPushTargets`  (Query)

The pre-release canary version is available [herewith](https://www.npmjs.com/package/@notifi-network/notifi-frontend-client/v/1.1.3-alpha.3). See the usage below:
```ts
frontendClient.createWebPushTarget(/* args */)
frontendClient.updateWebPushTarget(/* args */)
frontendClient.deleteWebPushTarget(/* args */)
frontendClient.getWebPushTargets(/* args */)
```

- [ ] Create test cases for your changes if needed

- [x] Include the ticket id if possible (Collaborator only)
MVP-5423

- TODOs
   - [ ] [BE] `webPushTargets` endpoint input arguments duplication requires relator. CC: @kai-notifi 
   - [ ] Documentation