### PR TITLE
MVP-5434: Fix cypress test according to the BE update

### DIFF
--- a/packages/notifi-react-example-v2/cypress/component/NotifiCardModal.cy.tsx
+++ b/packages/notifi-react-example-v2/cypress/component/NotifiCardModal.cy.tsx
@@ -108,10 +108,7 @@ describe('NotifiCardModal First Time User Test', () => {
       cy.wait('@gqlGetUnreadNotificationHistoryCountQuery'); // --> NotifiHistoryContext
       cy.wait('@gqlFetchFusionDataQuery'); // --> NotifiTargetContext
       cy.wait('@gqlFetchFusionDataQuery'); // --> NotifiTopicContext
-      // NOTE: Ensure targets and subscribe topics
-      cy.wait('@gqlGetTargetGroupsQuery'); // --> Create new target group#1:  frontendClient.ensureTargetGroup()
-      cy.wait('@gqlCreateTargetGroupMutation'); // -->  Create new target group#1#2: frontendClient.ensureTargetGroup()
-      cy.wait('@gqlFetchFusionDataQuery'); // --> Refresh target data after ensuring targetGroup:  frontendClient.ensureTargetGroup().then(()=>fetchFusionData())
+      // NOTE: Ensure targets and subscribe topics (Note: targetGroup is auto created upon user creation)
       cy.wait('@gqlGetAlertsQuery'); // --> subscribe default alerts#1:  (in useConnect.ts --> ensureFusionAlerts)
       cy.wait('@gqlCreateFusionAlertsMutation'); // --> subscribe default alerts#2:  (in useConnect.ts --> ensureFusionAlerts)
       cy.wait('@gqlFetchFusionDataQuery'); // --> Update and render updated alerts after subscribing (ensureFusionAlerts.then)
@@ -202,10 +199,7 @@ describe('NotifiCardModal First Time User Test', () => {
       cy.wait('@gqlGetUnreadNotificationHistoryCountQuery'); // --> NotifiHistoryContext
       cy.wait('@gqlFetchFusionDataQuery'); // --> NotifiTargetContext
       cy.wait('@gqlFetchFusionDataQuery'); // --> NotifiTopicContext
-      // NOTE: Ensure targets and subscribe topics
-      cy.wait('@gqlGetTargetGroupsQuery'); // --> Create new target group#1:  frontendClient.ensureTargetGroup()
-      cy.wait('@gqlCreateTargetGroupMutation'); // -->  Create new target group#1#2: frontendClient.ensureTargetGroup()
-      cy.wait('@gqlFetchFusionDataQuery'); // --> Refresh target data after ensuring targetGroup:  frontendClient.ensureTargetGroup().then(()=>fetchFusionData())
+      // NOTE: Ensure targets and subscribe topics (Note: targetGroup is auto created upon user creation)
       cy.wait('@gqlGetAlertsQuery'); // --> subscribe default alerts#1:  (in useConnect.ts --> ensureFusionAlerts)
       cy.wait('@gqlCreateFusionAlertsMutation'); // --> subscribe default alerts#2:  (in useConnect.ts --> ensureFusionAlerts)
       cy.wait('@gqlFetchFusionDataQuery'); // --> Update and render updated alerts after subscribing (ensureFusionAlerts.then)

--- a/packages/notifi-react/lib/hooks/useConnect.tsx
+++ b/packages/notifi-react/lib/hooks/useConnect.tsx
@@ -83,7 +83,7 @@ export const useConnect = (
       const isDefaultTargetExist = await validateDefaultTargetGroup(
         frontendClient,
       );
-
+      // ⬇ Ensure default target group is created (This should be created automatically by the backend upon new user creation). Here is just a double check.
       if (!isDefaultTargetExist) {
         await renewTargetGroup();
       }


### PR DESCRIPTION

- [x] Describe the purpose of the change
This is new behavior introduced from this (`EnsureSystemNotificationsForUser()`) fn in UserManager service, which upon user creation, will ensure the user is subscribed to certain internal events (this wasn't happening properly before).
When we subscribe to system events, it uses `CreateFusionAlert` path, 
**which ensures creation of the Default target group.**
So, the cypress test needs to skip the request check of creating new targetGroup.

- [x] Create test cases for your changes if needed
Update FTU related test blocks
- [x] Include the ticket id if possible (Collaborator only)
MVP-5434