### PR TITLE
MVP-5447-stage: Refactor to typescript (single file: stage version - reference only)

### DIFF
--- a/packages/notifi-web-push-service-worker/package.json
+++ b/packages/notifi-web-push-service-worker/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build": "npm run clean && npm run compile",
-    "compile": "tsup lib/index.ts --format cjs,esm --dts --clean && esbuild ./lib/notifi-service-worker.js --bundle --outfile=./dist/notifi-service-worker.js",
+    "compile": "tsup lib/index.ts --format cjs,esm --dts --clean && esbuild ./lib/notifi-service-worker.ts --bundle --outfile=./dist/notifi-service-worker.js",
     "clean": "rimraf ./dist",
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepublishOnly": "npm run build"

--- a/packages/notifi-web-push-service-worker/tsconfig.json
+++ b/packages/notifi-web-push-service-worker/tsconfig.json
@@ -1,3 +1,15 @@
 {
   "extends": "../../tsconfig.json",
+  "target": "ESNext",
+  "module": "ESNext",
+  "declaration": true,
+  "declarationDir": "./dist",
+  "outDir": "./dist",
+  "strict": true,
+  "esModuleInterop": true,
+  "skipLibCheck": true,
+  "forceConsistentCasingInFileNames": true,
+  "compilerOptions": {
+    "lib": ["WebWorker", "ESNext", "DOM"]
+  }
 }


### PR DESCRIPTION
- [x] Describe the purpose of the change
As title. 

> **NOTE**:
> - Keeps single file structure (Avoid breaking existing use case: compatible with `1.1.3-alpha20` )
> - `ESbuild` is still needed as `rollup`, `tsup` and `tsc` not able to bundle single js file.
> - This PR is only for reference only. **DO NOT MERGE**

- [ ] Create test cases for your changes if needed

- [x] Include the ticket id if possible (Collaborator only)
MVP-5447