### PR TITLE
Store client initialization params in indexed db

### DIFF
--- a/packages/notifi-web-push-service-worker/lib/utils/constants.ts
+++ b/packages/notifi-web-push-service-worker/lib/utils/constants.ts
@@ -7,3 +7,9 @@ export const notifiDefaultDbStore = 'keyvaluepairs';
 export const defaultIconUrl = 'https://notifi.network/logo.png';
 
 export const notifiServiceWorkerDefaultFilePath = '/notifi-service-worker.js';
+
+export const notifiEnvKey = 'notifiEnv';
+
+export const notifiUserAccountKey = 'notifiUserAccount';
+
+export const notifiDappIdKey = 'notifiDappId';

--- a/packages/notifi-web-push-service-worker/lib/utils/dbHelpers.ts
+++ b/packages/notifi-web-push-service-worker/lib/utils/dbHelpers.ts
@@ -1,0 +1,39 @@
+import { NotifiEnvironment } from '@notifi-network/notifi-frontend-client';
+
+import { IndexedDb } from '../types';
+import {
+  notifiDappIdKey,
+  notifiEnvKey,
+  notifiUserAccountKey,
+} from './constants';
+
+export async function storeNotifiEnv(db: IndexedDb, env: NotifiEnvironment) {
+  await db.set(notifiEnvKey, env);
+}
+
+export async function storeNotifiUserAccount(
+  db: IndexedDb,
+  userAccount: string,
+) {
+  await db.set(notifiUserAccountKey, userAccount);
+}
+
+export async function storeNotifiDappId(db: IndexedDb, dappId: string) {
+  await db.set(notifiDappIdKey, dappId);
+}
+
+export async function getNotifiEnv(db: IndexedDb): Promise<string | undefined> {
+  return await db.get(notifiEnvKey);
+}
+
+export async function getNotifiUserAccount(
+  db: IndexedDb,
+): Promise<string | undefined> {
+  return await db.get(notifiUserAccountKey);
+}
+
+export async function getNotifiDappId(
+  db: IndexedDb,
+): Promise<string | undefined> {
+  return await db.get(notifiDappIdKey);
+}

--- a/packages/notifi-web-push-service-worker/lib/utils/index.ts
+++ b/packages/notifi-web-push-service-worker/lib/utils/index.ts
@@ -2,3 +2,4 @@ export * from './conversion';
 export * from './db';
 export * from './constants';
 export * from './service-worker';
+export * from './dbHelpers';


### PR DESCRIPTION
Overview of changes
- Ensure that target exists when Browser Subscription exists
- Initialize client from indexedDb
  - I had assumed that the local context would be active even when the service worker 'shuts down'. Turns out, that was not the case. With these changes, we store the dappId, env, and userAccount in the indexedDb so that the service worker can instantiate the Notifi client whenever it needs to