### PR TITLE
MVP-5586: GQL subscription refactor #1 - restructure

### DIFF
--- a/packages/notifi-graphql/lib/NotifiService.ts
+++ b/packages/notifi-graphql/lib/NotifiService.ts
@@ -2,13 +2,13 @@ import { GraphQLClient } from 'graphql-request';
 import { v4 as uuid } from 'uuid';
 
 import { version } from '../package.json';
-import {
-  NotifiSubscriptionService,
-  SubscriptionQueries,
-} from './NotifiSubscriptionService';
+import { NotifiSubscriptionService } from './NotifiSubscriptionService';
 import * as Generated from './gql/generated';
 import { getSdk } from './gql/generated';
 import type * as Operations from './operations';
+import { stateChangedSubscriptionQuery } from './gql';
+import { tenantEntityChangedSubscriptionQuery } from './gql/subscriptions/tenantEntityChanged';
+import { ExecutionResult } from 'graphql-ws';
 
 export class NotifiService
   implements
@@ -449,7 +449,21 @@ export class NotifiService
   ): Promise<void> {
     this._notifiSubService.subscribe(
       this._jwt,
-      SubscriptionQueries.StateChanged,
+      stateChangedSubscriptionQuery,
+      onMessageReceived,
+      onError,
+      onComplete,
+    );
+  }
+
+  async subscribeTenantEntityUpdated(
+    onMessageReceived: (data: ExecutionResult) => void,
+    onError?: (error: Error) => void,
+    onComplete?: () => void | undefined,
+  ): Promise<void> {
+    this._notifiSubService.subscribe(
+      this._jwt,
+      tenantEntityChangedSubscriptionQuery,
       onMessageReceived,
       onError,
       onComplete,

--- a/packages/notifi-graphql/lib/NotifiSubscriptionService.ts
+++ b/packages/notifi-graphql/lib/NotifiSubscriptionService.ts
@@ -2,8 +2,7 @@ import { createClient, Client } from 'graphql-ws';
 export class NotifiSubscriptionService {
   private wsClient: Client | undefined;
   private jwt: string | undefined;
-  constructor(private wsurl: string) {
-  }
+  constructor(private wsurl: string) {}
 
   disposeClient = () => {
     if (this.wsClient) {
@@ -13,15 +12,22 @@ export class NotifiSubscriptionService {
     }
   };
 
-  subscribe = (jwt: string | undefined, subscriptionQuery: string, onMessageReceived: (data: any) => void | undefined, onError?: (data: any) => void | undefined, onComplete?: () => void | undefined) => {
+  subscribe = (
+    jwt: string | undefined,
+    subscriptionQuery: string,
+    onMessageReceived: (data: any) => void | undefined,
+    onError?: (data: any) => void | undefined,
+    onComplete?: () => void | undefined,
+  ) => {
     this.jwt = jwt;
     this.initializeClientIfUndefined();
-    this.wsClient?.subscribe({
-      query: subscriptionQuery,
-      extensions: {
-        type: 'start'
-      }
-    },
+    this.wsClient?.subscribe(
+      {
+        query: subscriptionQuery,
+        extensions: {
+          type: 'start',
+        },
+      },
       {
         next: (data) => {
           if (onMessageReceived) {
@@ -29,7 +35,7 @@ export class NotifiSubscriptionService {
           }
         },
         error: (error) => {
-          if (onError) {
+          if (onError && error instanceof Error) {
             onError(error);
           }
         },
@@ -38,14 +44,15 @@ export class NotifiSubscriptionService {
             onComplete();
           }
         },
-      })
-  }
+      },
+    );
+  };
 
   private initializeClientIfUndefined = () => {
     if (!this.wsClient) {
       this.initializeClient();
     }
-  }
+  };
 
   private initializeClient = () => {
     this.wsClient = createClient({
@@ -54,13 +61,5 @@ export class NotifiSubscriptionService {
         Authorization: `Bearer ${this.jwt}`,
       },
     });
-  }
-}
-
-export const SubscriptionQueries = {
-  StateChanged: `subscription {
-    stateChanged {
-      __typename
-    }
-  }`
+  };
 }

--- a/packages/notifi-graphql/lib/gql/index.ts
+++ b/packages/notifi-graphql/lib/gql/index.ts
@@ -1,0 +1,1 @@
+export * from './subscriptions';

--- a/packages/notifi-graphql/lib/gql/subscriptions/index.ts
+++ b/packages/notifi-graphql/lib/gql/subscriptions/index.ts
@@ -1,0 +1,1 @@
+export * from './stateChanged';

--- a/packages/notifi-graphql/lib/gql/subscriptions/stateChanged.ts
+++ b/packages/notifi-graphql/lib/gql/subscriptions/stateChanged.ts
@@ -1,0 +1,8 @@
+// TODO: Try import fragment from fragment file
+export const stateChangedSubscriptionQuery = `
+  subscription {
+    stateChanged {
+      __typename
+    }
+  }
+`;

--- a/packages/notifi-graphql/lib/gql/subscriptions/tenantEntityChanged.ts
+++ b/packages/notifi-graphql/lib/gql/subscriptions/tenantEntityChanged.ts
@@ -1,0 +1,60 @@
+// TODO: Try import fragment from fragment file
+export const tenantEntityChangedSubscriptionQuery = `
+fragment TenantUserAlertFragment on TenantUserAlert {
+  id
+  name
+  groupName
+  filter {
+    id
+    name
+    filterType
+  }
+  filterOptions
+  sourceGroup {
+    id
+    name
+    sources {
+      id
+      name
+      type
+      blockchainAddress
+    }
+  }
+}
+
+fragment TenantUserFragment on TenantUser {
+  id
+  alerts {
+    ...TenantUserAlertFragment
+  }
+  connectedWallets {
+    address
+    walletBlockchain
+  }
+}
+
+subscription {
+  tenantEntityChanged {
+    __typename
+    ... on UserCreatedEvent {
+      user {
+        ...TenantUserFragment
+      }
+    }
+    ... on AlertCreatedEvent {
+      alert {
+        ...TenantUserAlertFragment
+      }
+      user {
+        ...TenantUserFragment
+      }
+    }
+    ... on AlertDeletedEvent {
+      alertId
+      user {
+        ...TenantUserFragment
+      }
+    }
+  }
+}
+`;

--- a/packages/notifi-node/lib/client/NotifiNodeClient.ts
+++ b/packages/notifi-node/lib/client/NotifiNodeClient.ts
@@ -146,4 +146,36 @@ export class NotifiNodeClient {
     }
     return recreated;
   };
+
+  subscribeTenantEntityUpdated = (
+    onTenantEntityUpdate: (
+      event: Gql.TenantEntityChangeEvent,
+    ) => void | undefined,
+  ) => {
+    this.service.subscribeTenantEntityUpdated(
+      (data) => {
+        if (isTenantEntityUpdateEvent(data)) onTenantEntityUpdate(data);
+      },
+      (error) => {
+        if (error instanceof Error) {
+          throw error;
+        }
+      },
+    );
+  };
 }
+
+// Utils
+
+const isTenantEntityUpdateEvent = (
+  data: unknown,
+): data is Gql.TenantEntityChangeEvent => {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'typename' in data &&
+    (data.typename === 'UserCreatedEvent' ||
+      data.typename === 'AlertCreatedEvent' ||
+      data.typename === 'AlertDeletedEvent')
+  );
+};

--- a/packages/notifi-node/lib/client/index.ts
+++ b/packages/notifi-node/lib/client/index.ts
@@ -1,8 +1,6 @@
 export * from '../utils';
-
 export * from './NotifiNodeClient';
 export * from './createNotifiService';
-export * from './createSubscriptionClient';
 export * from './subscribeTenantEntityUpdated';
 
 /* NOTE: ⬇ for backwards compatibility (avoid breaking change) */


### PR DESCRIPTION
- [x] Describe the purpose of the change
  
1. Instead of having separated websocket client instances in both `notifi-node` and `notifi-graphql`, now we leverage the same on in `notifi-graphql`. Benefits:
    -  **Single responsibility**: only `notifi-graphql` takes care of webscoket client instance logic
    -  **Remove the vulnerability**: one of the legacy vulnerability is from the deprecated websocket packaged adopted by `notifi-node` --> subscriptions-transport-ws

2. Instead of putting subscription query in different places, we create a new module `lib/gql/subscription` to centrally mange them.

 
- [ ] Create test cases for your changes if needed

- [x] Include the ticket id if possible (Collaborator only)
MVP-5586