### PR TITLE
fix: when env set as 'local', endpoint should be http instead of https

### DIFF
--- a/packages/notifi-frontend-client/lib/configuration/NotifiFrontendConfiguration.ts
+++ b/packages/notifi-frontend-client/lib/configuration/NotifiFrontendConfiguration.ts
@@ -155,10 +155,10 @@ export type FrontendClientConfigFactory<T extends NotifiFrontendConfiguration> =
     args: T extends NotifiConfigWithPublicKeyAndAddress
       ? ConfigFactoryInputPublicKeyAndAddress
       : T extends NotifiConfigWithDelegate
-      ? ConfigFactoryInputDelegated
-      : T extends NotifiConfigWithPublicKey
-      ? ConfigFactoryInputPublicKey
-      : ConfigFactoryInputOidc,
+        ? ConfigFactoryInputDelegated
+        : T extends NotifiConfigWithPublicKey
+          ? ConfigFactoryInputPublicKey
+          : ConfigFactoryInputOidc,
   ) => NotifiFrontendConfiguration;
 
 const evmChains = [
@@ -300,5 +300,5 @@ export const envUrl = (
       url = '://api.stg.notifi.network/gql';
   }
 
-  return `${endpointType === 'websocket' ? 'wss' : 'https'}${url}`;
+  return `${endpointType === 'websocket' ? 'wss' : env === 'Local' ? 'http' : 'https'}${url}`;
 };


### PR DESCRIPTION

- [x] Describe the purpose of the change
As title
> I assume only `Local` env will use `http` . Others are still https, Hope that makes sense. If there is any other cases, please kindly let me know 🙏 CC: @nimesh-notifi 
- [ ] Create test cases for your changes if needed

- [ ] Include the ticket id if possible (Collaborator only)
