### PR TITLE
MVP-5630: allow unread count to be card specific

### DIFF
--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -1351,10 +1351,14 @@ export class NotifiFrontendClient {
     return { pageInfo, nodes };
   }
 
-  async getUnreadNotificationHistoryCount(): Promise<
+  async getUnreadNotificationHistoryCount(
+    cardId?: string,
+  ): Promise<
     Types.GetUnreadNotificationHistoryCountQuery['unreadNotificationHistoryCount']
   > {
-    const query = await this._service.getUnreadNotificationHistoryCount({});
+    const query = await this._service.getUnreadNotificationHistoryCount({
+      cardId,
+    });
     const result = query.unreadNotificationHistoryCount;
     if (!result) {
       throw new Error('Failed to fetch unread notification history count');

--- a/packages/notifi-graphql/lib/gql/queries/getUnreadNotificationHistoryCount.gql.ts
+++ b/packages/notifi-graphql/lib/gql/queries/getUnreadNotificationHistoryCount.gql.ts
@@ -1,8 +1,8 @@
 import { gql } from 'graphql-request';
 
 export const GetUnreadNotificationHistoryCount = gql`
-  query getUnreadNotificationHistoryCount {
-    unreadNotificationHistoryCount {
+  query getUnreadNotificationHistoryCount($cardId: String) {
+    unreadNotificationHistoryCount(input: { cardId: $cardId }) {
       count
     }
   }

--- a/packages/notifi-react-example-v2/src/context/NotifiContextWrapper.tsx
+++ b/packages/notifi-react-example-v2/src/context/NotifiContextWrapper.tsx
@@ -68,9 +68,8 @@ export const NotifiContextWrapper: React.FC<PropsWithChildren> = ({
         if (!walletPublicKey) throw new Error('ERROR: invalid walletPublicKey');
         signMessage = async (message: Uint8Array): Promise<Uint8Array> => {
           const messageString = Buffer.from(message).toString('utf8');
-          const result = await wallets[selectedWallet].signArbitrary(
-            messageString,
-          );
+          const result =
+            await wallets[selectedWallet].signArbitrary(messageString);
           if (!result) throw new Error('ERROR: invalid signature');
           return getBytes(result);
         };

--- a/packages/notifi-react/README.md
+++ b/packages/notifi-react/README.md
@@ -667,6 +667,11 @@ export const MyComponent = () => {
 };
 ```
 
+**Input props**
+
+- **notificationCountPerPage** (Optional): The number of notifications per fetch in the notification history. The default value is `20`.
+- **unreadCountScope** (Optional): The scope can be `card` or `tenant`. The default value is `card`.
+
 **Methods**
 
 - **getHistoryItems**: A function to get the notification history items. This method will update the `historyItems` state. It takes `(initialLoad?: boolean)` as input arguments. If `initialLoad` is `true`, it will clean the existing `historyItem` and fetch the first page of the notification history items. If `initialLoad` is `undefined` or `false`, it will fetch the next page from an existing page cursor. You can use `hasNextPage` to check if there are more pages to fetch.

--- a/packages/notifi-react/lib/context/NotifiContextProvider.tsx
+++ b/packages/notifi-react/lib/context/NotifiContextProvider.tsx
@@ -40,6 +40,7 @@ export const NotifiContextProvider: FC<
           <NotifiTopicContextProvider>
             <NotifiHistoryContextProvider
               notificationCountPerPage={params.notificationCountPerPage}
+              unreadCountScope={params.unreadCountScope}
             >
               <NotifiUserSettingContextProvider>
                 <GlobalStateContextProvider>

--- a/packages/notifi-react/lib/context/NotifiHistoryContext.tsx
+++ b/packages/notifi-react/lib/context/NotifiHistoryContext.tsx
@@ -74,6 +74,9 @@ export const NotifiHistoryContextProvider: FC<
   useEffect(() => {
     // NOTE: Update historyItems & unreadCount when backend state changed
     if (frontendClientStatus.isAuthenticated) {
+      const fusionEventIds = new Set(
+        fusionEventTopics.map((topic) => topic.fusionEventDescriptor.id ?? ''),
+      );
       frontendClient.subscribeNotificationHistoryStateChanged((_data) => {
         frontendClient
           .getFusionNotificationHistory({
@@ -82,23 +85,16 @@ export const NotifiHistoryContextProvider: FC<
             includeRead: isIncludeRead,
           })
           .then((res) => {
-            const existingItemIdMap = new Map(
-              historyItems.map((item) => [item.id, item]),
-            );
-
-            const fusionEventIdMap = new Map(
-              fusionEventTopics.map((topic) => [
-                topic.fusionEventDescriptor.id,
-                topic,
-              ]),
+            const existingItemIds = new Set(
+              historyItems.map((item) => item.id),
             );
 
             const newItems = res?.nodes
               ?.map(parseHistoryItem)
               .filter(
                 (item) =>
-                  !existingItemIdMap.has(item.id) &&
-                  fusionEventIdMap.has(item.fusionEventId),
+                  !existingItemIds.has(item.id) &&
+                  fusionEventIds.has(item.fusionEventId),
               );
 
             if (newItems?.length && newItems.length > 0) {

--- a/packages/notifi-react/lib/context/NotifiHistoryContext.tsx
+++ b/packages/notifi-react/lib/context/NotifiHistoryContext.tsx
@@ -173,9 +173,11 @@ export const NotifiHistoryContextProvider: FC<
       cardConfig
     ) {
       getHistoryItems(true);
-      frontendClient.getUnreadNotificationHistoryCount().then(({ count }) => {
-        setUnreadCount(count);
-      });
+      frontendClient
+        .getUnreadNotificationHistoryCount(cardConfig.id ?? undefined)
+        .then(({ count }) => {
+          setUnreadCount(count);
+        });
     }
   }, [frontendClientStatus, getHistoryItems, cardConfig]);
 


### PR DESCRIPTION
- [x] Describe the purpose of the change
As title

> **DO NOT MERGE** UNDER TEST
> - ~~DEV TEST FAILING: even passing card id, it still responds tenant wise unread count~~
> - ~~GITHUB ACTION FAILING: Not yet on prod.~~
> **20241106 Update:**
>  - ~~PROD TEST FAILING: even passing card id, it still responds tenant wise unread count~~

- [ ] Create test cases for your changes if needed

- [x] Include the ticket id if possible (Collaborator only)
MVP-5630