### PR TITLE
MVP-5744-1: Refrom NotifiEventEmitter

### DIFF
--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -1280,9 +1280,9 @@ export class NotifiFrontendClient {
 
   removeEventListener<K extends keyof NotifiEmitterEvents>(
     event: K,
-    callBack: (...args: NotifiEmitterEvents[K]) => void,
+    id: string,
   ) {
-    return this._service.removeEventListener(event, callBack);
+    return this._service.removeEventListener(event, id);
   }
 
   async getUserSettings(): Promise<Types.GetUserSettingsQuery['userSettings']> {

--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -1,4 +1,8 @@
-import { NotifiEmitterEvents, Types } from '@notifi-network/notifi-graphql';
+import {
+  EventListenerOutputs,
+  NotifiEmitterEvents,
+  Types,
+} from '@notifi-network/notifi-graphql';
 import { NotifiService } from '@notifi-network/notifi-graphql';
 
 import {
@@ -1274,8 +1278,15 @@ export class NotifiFrontendClient {
   addEventListener<K extends keyof NotifiEmitterEvents>(
     event: K,
     callBack: (...args: NotifiEmitterEvents[K]) => void,
-  ) {
-    return this._service.addEventListener(event, callBack);
+    onError?: (error: unknown) => void,
+    onCompleted?: () => void,
+  ): EventListenerOutputs {
+    return this._service.addEventListener(
+      event,
+      callBack,
+      onError,
+      onCompleted,
+    );
   }
 
   removeEventListener<K extends keyof NotifiEmitterEvents>(

--- a/packages/notifi-graphql/lib/NotifiEventEmitter.ts
+++ b/packages/notifi-graphql/lib/NotifiEventEmitter.ts
@@ -1,28 +1,13 @@
-import { Client as WebSocketClient } from 'graphql-ws';
 import {
   StateChangedEvent,
   TenantActiveAlertChangeEvent,
 } from './gql/generated';
 
 /** IMPORTANT: the guidelines to remove the event listener:
- * 1. For status events (NotifiWebSocketStatusEvents or NotifiSubscriptionStatusEvents), calling removeEventListener will remove the listener.
- * 2. For graphql subscription events (NotifiSubscriptionEvents), calling removeEventListener will not unsubscribe the subscription. additionally, you need to call subscription.unsubscribe() to remove the subscription.
+ * Calling removeEventListener will not unsubscribe the subscription.
+ * Additionally, you need to call subscription.unsubscribe() to remove the subscription.
  */
-export type NotifiEmitterEvents = NotifiWebSocketStatusEvents &
-  NotifiSubscriptionEvents &
-  NotifiSubscriptionStatusEvents;
-
-export type NotifiWebSocketStatusEvents = {
-  wsConnecting: [];
-  wsConnected: [WebSocketClient];
-  wsClosed: [unknown]; // ⬅ The argument is actually the websocket `CloseEvent`, but to avoid bundling DOM typings because the client can run in Node env too, you should assert the websocket type during implementation. https://the-guild.dev/graphql/ws/docs/modules/client#eventclosedlistener
-  wsError: [Error];
-};
-
-export type NotifiSubscriptionStatusEvents = {
-  gqlSubscriptionError: [Error];
-  gqlComplete: [];
-};
+export type NotifiEmitterEvents = NotifiSubscriptionEvents;
 
 export type NotifiSubscriptionEvents = {
   tenantActiveAlertChanged: [TenantActiveAlertChangeEvent];
@@ -35,26 +20,35 @@ export type EventCallback<
 > = (...args: T[K]) => void;
 
 export class NotifiEventEmitter<T extends Record<string, Array<any>>> {
-  private listeners: { [K in keyof T]?: Array<EventCallback<T, K>> } = {};
+  private listeners: { [K in keyof T]?: Record<string, EventCallback<T, K>> } =
+    {};
 
-  on<K extends keyof T>(event: K, listener: EventCallback<T, K>): void {
+  on<K extends keyof T>(
+    event: K,
+    listener: EventCallback<T, K>,
+    id: string,
+  ): void {
+    console.log('listening', event, this.listeners, id);
     if (!this.listeners[event]) {
-      this.listeners[event] = [];
+      this.listeners[event] = {};
     }
-    this.listeners[event]!.push(listener);
+    (this.listeners[event] as Record<string, EventCallback<T, K>>)[id] =
+      listener;
   }
 
-  off<K extends keyof T>(event: K, listener: EventCallback<T, K>): void {
-    if (!this.listeners[event]) return;
-    this.listeners[event] = this.listeners[event]!.filter(
-      (l) => l !== listener,
-    );
+  off<K extends keyof T>(event: K, id: string): void {
+    if (!this.listeners[event]?.[id]) return;
+
+    delete (this.listeners[event] as Record<string, EventCallback<T, K>>)[id];
   }
 
-  emit<K extends keyof T>(event: K, ...args: T[K]): void {
-    if (!this.listeners[event]) return;
-    for (const listener of this.listeners[event]!) {
-      listener(...args);
+  emit<K extends keyof T>(event: K, id: string, ...args: T[K]): void {
+    if (!this.listeners[event]?.[id]) return;
+    console.log('emitting', event, this.listeners);
+    if (this.listeners[event]?.[id]) {
+      (this.listeners[event] as Record<string, EventCallback<T, K>>)[id](
+        ...args,
+      );
     }
   }
 }

--- a/packages/notifi-graphql/lib/NotifiEventEmitter.ts
+++ b/packages/notifi-graphql/lib/NotifiEventEmitter.ts
@@ -28,7 +28,7 @@ export class NotifiEventEmitter<T extends Record<string, Array<any>>> {
     listener: EventCallback<T, K>,
     id: string,
   ): void {
-    console.log('listening', event, this.listeners, id);
+    console.log('listening', { id, event, listeners: this.listeners });
     if (!this.listeners[event]) {
       this.listeners[event] = {};
     }
@@ -37,6 +37,7 @@ export class NotifiEventEmitter<T extends Record<string, Array<any>>> {
   }
 
   off<K extends keyof T>(event: K, id: string): void {
+    console.log('removing', { id, event, listeners: this.listeners });
     if (!this.listeners[event]?.[id]) return;
 
     delete (this.listeners[event] as Record<string, EventCallback<T, K>>)[id];
@@ -44,7 +45,7 @@ export class NotifiEventEmitter<T extends Record<string, Array<any>>> {
 
   emit<K extends keyof T>(event: K, id: string, ...args: T[K]): void {
     if (!this.listeners[event]?.[id]) return;
-    console.log('emitting', event, this.listeners);
+    console.log('emitting', { id, event, listeners: this.listeners });
     if (this.listeners[event]?.[id]) {
       (this.listeners[event] as Record<string, EventCallback<T, K>>)[id](
         ...args,

--- a/packages/notifi-graphql/lib/NotifiService.ts
+++ b/packages/notifi-graphql/lib/NotifiService.ts
@@ -474,7 +474,7 @@ export class NotifiService
   addEventListener<T extends keyof NotifiEmitterEvents>(
     event: T,
     callBack: (...args: NotifiEmitterEvents[T]) => void,
-  ): Subscription | null {
+  ): { id: string; subscription: Subscription | null } {
     return this._notifiSubService.addEventListener(event, callBack);
   }
   /**
@@ -484,9 +484,9 @@ export class NotifiService
    */
   removeEventListener<T extends keyof NotifiEmitterEvents>(
     event: T,
-    callBack: (...args: NotifiEmitterEvents[T]) => void,
+    id: string,
   ) {
-    return this._notifiSubService.removeEventListener(event, callBack);
+    return this._notifiSubService.removeEventListener(event, id);
   }
 
   async getUserSettings(

--- a/packages/notifi-graphql/lib/NotifiService.ts
+++ b/packages/notifi-graphql/lib/NotifiService.ts
@@ -4,7 +4,10 @@ import { v4 as uuid } from 'uuid';
 
 import { version } from '../package.json';
 import { NotifiEmitterEvents } from './NotifiEventEmitter';
-import { NotifiSubscriptionService } from './NotifiSubscriptionService';
+import {
+  EventListenerOutputs,
+  NotifiSubscriptionService,
+} from './NotifiSubscriptionService';
 import { stateChangedSubscriptionQuery } from './gql';
 import * as Generated from './gql/generated';
 import { getSdk } from './gql/generated';
@@ -474,8 +477,15 @@ export class NotifiService
   addEventListener<T extends keyof NotifiEmitterEvents>(
     event: T,
     callBack: (...args: NotifiEmitterEvents[T]) => void,
-  ): { id: string; subscription: Subscription | null } {
-    return this._notifiSubService.addEventListener(event, callBack);
+    onError?: (error: unknown) => void,
+    onComplete?: () => void,
+  ): EventListenerOutputs {
+    return this._notifiSubService.addEventListener(
+      event,
+      callBack,
+      onError,
+      onComplete,
+    );
   }
   /**
    * @important To remove event listener, check the README.md of `notifi-node` or `notifi-frontend-client` package for more details.

--- a/packages/notifi-node/lib/client/NotifiNodeClient.ts
+++ b/packages/notifi-node/lib/client/NotifiNodeClient.ts
@@ -4,6 +4,7 @@ import {
   PublishFusionMessageResponse,
 } from '@notifi-network/notifi-dataplane';
 import {
+  EventListenerOutputs,
   Types as Gql,
   NotifiEmitterEvents,
   NotifiService,
@@ -112,12 +113,14 @@ export class NotifiNodeClient {
   addEventListener<T extends keyof NotifiEmitterEvents>(
     event: T,
     callBack: (...args: NotifiEmitterEvents[T]) => void,
-  ) {
+    onError?: (error: unknown) => void,
+    onComplete?: () => void,
+  ): EventListenerOutputs {
     if (this.clientState.status !== 'initialized')
       throw new Error(
         'notifi-node - addEventListener: Client not initialized, call initialize() first',
       );
-    return this.service.addEventListener(event, callBack);
+    return this.service.addEventListener(event, callBack, onError, onComplete);
   }
   /**
    * @important To remove event listener, check the README.md of `notifi-node` or `notifi-frontend-client` package for more details.

--- a/packages/notifi-node/lib/client/NotifiNodeClient.ts
+++ b/packages/notifi-node/lib/client/NotifiNodeClient.ts
@@ -126,10 +126,10 @@ export class NotifiNodeClient {
    */
   removeEventListener<T extends keyof NotifiEmitterEvents>(
     event: T,
-    callBack: (...args: NotifiEmitterEvents[T]) => void,
+    id: string,
   ) {
     this.isClientValid('removeEventListener');
-    return this.service.removeEventListener(event, callBack);
+    return this.service.removeEventListener(event, id);
   }
 
   /** NOTE: throw if client is not initialized */

--- a/packages/notifi-react/lib/context/NotifiHistoryContext.tsx
+++ b/packages/notifi-react/lib/context/NotifiHistoryContext.tsx
@@ -73,7 +73,11 @@ export const NotifiHistoryContextProvider: FC<
   const isInitialLoaded = React.useRef(false);
 
   const currentSubscription =
-    React.useRef<ReturnType<NotifiFrontendClient['addEventListener']>>(null);
+    React.useRef<
+      ReturnType<
+        NotifiFrontendClient['subscribeNotificationHistoryStateChanged']
+      >
+    >(null);
 
   useEffect(() => {
     // NOTE: Update historyItems & unreadCount when backend state changed

--- a/packages/notifi-react/lib/context/NotifiTargetContext.tsx
+++ b/packages/notifi-react/lib/context/NotifiTargetContext.tsx
@@ -239,7 +239,7 @@ export const NotifiTargetContextProvider: FC<
   };
 
   const currentSubscription =
-    React.useRef<ReturnType<NotifiFrontendClient['addEventListener']>>(null);
+    React.useRef<ReturnType<NotifiFrontendClient['addEventListener']>>();
 
   useEffect(() => {
     //NOTE: target change listener when window is refocused
@@ -282,9 +282,14 @@ export const NotifiTargetContextProvider: FC<
 
     return () => {
       // window.removeEventListener('focus', handler);
-      currentSubscription.current?.unsubscribe();
-      currentSubscription.current = null;
-      frontendClient.removeEventListener('stateChanged', handler);
+      const { id, subscription } = currentSubscription.current ?? {};
+      if (!id || !subscription) return;
+      // currentSubscription.current?.unsubscribe();
+      // currentSubscription.current = null;
+      // frontendClient.removeEventListener('stateChanged', handler);
+      subscription.unsubscribe();
+      currentSubscription.current = undefined;
+      frontendClient.removeEventListener('stateChanged', id);
     };
   }, [frontendClientStatus.isAuthenticated]);
 


### PR DESCRIPTION


- [x] Describe the purpose of the change
  - Reform NotifiEventEmitter to assign each listener an id
  - Deprecate SubscriptionStatusEvent & WebsocketStatusEvent
  - Add ability to handle subscription error in addEventListener

- [ ] Create test cases for your changes if needed

- [x] Include the ticket id if possible (Collaborator only)
MVP-5744