### PR TITLE
chore: enable trailingSlash in next.config.mjs

### DIFF
--- a/packages/notifi-dapp-example/next.config.mjs
+++ b/packages/notifi-dapp-example/next.config.mjs
@@ -28,6 +28,7 @@ let nextConfig = {
 if (args.includes('build')) {
   nextConfig = {
     ...nextConfig,
+    trailingSlash: true,
     /** ⬇ For including static index.html: https://nextjs.org/docs/app/building-your-application/deploying/static-exports */
     output: 'export',
 

--- a/packages/notifi-react-example-v2/next.config.mjs
+++ b/packages/notifi-react-example-v2/next.config.mjs
@@ -38,6 +38,7 @@ let nextConfig = {
 if (args.includes('build')) {
   nextConfig = {
     ...nextConfig,
+    trailingSlash: true,
     /** ⬇ For including static index.html: https://nextjs.org/docs/app/building-your-application/deploying/static-exports */
     output: 'export',
     /** ⬇ For @xmpt/sdk (external bindings wasm files) - Nextjs version >= '^14.2.0'   */


### PR DESCRIPTION
- [x] Describe the purpose of the change

The `trailingSlash` config in `next.config.mjs` generates the the build folder allowing trailingSlash `/` to be end of the url instead of using `.html`. This could be the solution of routing issue. 
@marukohao & @ankush-notifi, you might want to cherry pick this commit to integration repos to see if can fix the routing issue.
