### PR TITLE
MVP-5934: 1-step tg verify: update cypress test cicd/ optimize & debug/ update documentation

### DIFF
--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -45,7 +45,7 @@ import {
   ensureEmail,
   ensureSlack,
   ensureSms,
-  ensureTelegram, // ensureTelegramDefault,
+  ensureTelegram,
   ensureWeb3,
   ensureWebhook,
   renewTelegram,

--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -999,6 +999,9 @@ export class NotifiFrontendClient {
     return createMutation.createTargetGroup;
   }
 
+  /**
+   * @description !IMPORTANT: the id arguments (telegramId, discordId, slackId, walletId) is the self-defined identity (only within notifi BE). This is NEITHER the user name NOR the user id of associated platform.
+   */
   async renewTargetGroup({
     name,
     emailAddress,

--- a/packages/notifi-frontend-client/lib/client/ensureTarget.ts
+++ b/packages/notifi-frontend-client/lib/client/ensureTarget.ts
@@ -104,31 +104,6 @@ export const ensureSms = ensureTarget(
   (arg: Types.SmsTargetFragmentFragment | undefined) => arg?.phoneNumber,
 );
 
-// TODO: move to deprecated section
-/** @deprecated Use renewTelegram instead */
-export const ensureTelegram = ensureTarget(
-  async (service: Operations.CreateTelegramTargetService, value: string) => {
-    const mutation = await service.createTelegramTarget({
-      name: value.toLowerCase(),
-      value: value.toLowerCase(),
-    });
-
-    const result = mutation.createTelegramTarget;
-    if (result === undefined) {
-      throw new Error('Failed to create telegramTarget');
-    }
-
-    return result;
-  },
-  async (service: Operations.GetTelegramTargetsService) => {
-    const query = await service.getTelegramTargets({});
-    return query.telegramTarget;
-  },
-  (arg: Types.TelegramTargetFragmentFragment | undefined) =>
-    arg?.telegramId?.toLowerCase(),
-  (value) => value.toLowerCase(),
-);
-
 export const renewTelegram = ensureTarget(
   // Create telegram target function
   async (service: Operations.CreateTelegramTargetService, value: string) => {
@@ -277,3 +252,27 @@ export const ensureWebhook = async (
 
   return created.id;
 };
+
+/** @deprecated Use renewTelegram instead */
+export const ensureTelegram = ensureTarget(
+  async (service: Operations.CreateTelegramTargetService, value: string) => {
+    const mutation = await service.createTelegramTarget({
+      name: value.toLowerCase(),
+      value: value.toLowerCase(),
+    });
+
+    const result = mutation.createTelegramTarget;
+    if (result === undefined) {
+      throw new Error('Failed to create telegramTarget');
+    }
+
+    return result;
+  },
+  async (service: Operations.GetTelegramTargetsService) => {
+    const query = await service.getTelegramTargets({});
+    return query.telegramTarget;
+  },
+  (arg: Types.TelegramTargetFragmentFragment | undefined) =>
+    arg?.telegramId?.toLowerCase(),
+  (value) => value.toLowerCase(),
+);

--- a/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
+++ b/packages/notifi-frontend-client/lib/models/SubscriptionCardConfig.ts
@@ -1,4 +1,8 @@
-// TODO: Import from library rather than copy / paste
+/**
+ * TODO: Reform tenant config
+ * - Deprecated unused types
+ * - increment version (TBD) - (ex. CardConfigItemV2)
+ *  */
 import { Types as Gql, Types } from '@notifi-network/notifi-graphql';
 
 import { CardConfigType } from '../client';

--- a/packages/notifi-react-example-v2/cypress/component/NotifiCardModal.cy.tsx
+++ b/packages/notifi-react-example-v2/cypress/component/NotifiCardModal.cy.tsx
@@ -118,7 +118,7 @@ describe('NotifiCardModal First Time User Test', () => {
       cy.wait('@gqlUpdateUserSettingsMutation'); // --> Update FTU stage to land on FtuTargetEdit.tsx
 
       // #2 - FTU Target List view (FtuTargetList.tsx)
-      //   * Check wether all active contact info are displayed
+      //   * Check wether all active contact info are correctly rendered
       const enabledContacts = objectKeys(cardConfig.contactInfo).filter(
         (contact) => cardConfig.contactInfo[contact].active,
       );
@@ -133,11 +133,7 @@ describe('NotifiCardModal First Time User Test', () => {
         .should('be.disabled');
 
       for (const contact of enabledContacts) {
-        if (
-          contact === 'email' ||
-          contact === 'sms' ||
-          contact === 'telegram'
-        ) {
+        if (contact === 'email' || contact === 'sms') {
           cy.get(
             `[data-cy="notifi-target-input-${
               contact === 'sms' ? 'phoneNumber' : contact

--- a/packages/notifi-react/README.md
+++ b/packages/notifi-react/README.md
@@ -125,108 +125,93 @@ const NotifiCard = () => {
 
 <br/><br/>
 
-# Advanced Customized Implementation
+# Customize NotifiCardModal component
 
-The style of the `NotifiCardModal` is fully customizable. There are two approaches to customize the card style:
-<br/><br/>
+`NotifiCardModal` is fully customizable using **global CSS overrides** and **optional properties**.
 
-## Customizing the Card Styling
+<br/>
 
-#### **Global CSS override (_Recommended_)**
+## Global CSS overrides
 
 By overriding the default CSS classes, we can style the elements in the card.
 [Default CSS Classes are found here.](https://github.com/notifi-network/notifi-sdk-ts/tree/main/packages/notifi-react/lib/style)
 
-_Example_
-
-```tsx
-import '@/styles/notifi/index.css';
-```
-
-#### **Custom CSS class**
-
-You can pass in custom CSS classes to the `NotifiCardModal` component.
-
-> **NOTE** Before implementing, please review the `classNames` property structure in the `NotifiCardModal` component.
-> View the `classNames` [structure here.](https://github.com/notifi-network/notifi-sdk-ts/blob/main/packages/notifi-react/lib/components/NotifiCardModal.tsx#L39)
+Before overriding the CSS classes, we need to adopt the default style of the `NotifiCardModal` component. To do this, we need to import the default CSS file from the `@notifi-network/notifi-react` package like below.
 
 _Example_
 
 ```tsx
-const YourComponent = () => {
-  // ...
-  const customClassName: NotifiCardModalProps['classNames'] = {
-    container: 'custom-card-modal-container',
-  };
-
-  return (
-    <>
-      {/*  ... */}
-      <NotifiCardModal classNames={customClassName} />
-      {/*  ... */}
-    </>
-  );
-};
+import '@notifi-network/notifi-react/dist/index.css';
 ```
+
+> - Make sure this import is placed at the top level of the component file. [complete example](https://github.com/notifi-network/notifi-sdk-ts/blob/97280b625ef133811d176fbb8add73f6b3f7bd44/packages/notifi-react-example-v2/src/components/OidcGoogle.tsx#L9)
+>   Find the overrideable CSS classes [here](https://github.com/notifi-network/notifi-sdk-ts/tree/97280b625ef133811d176fbb8add73f6b3f7bd44/packages/notifi-react/lib/style)
 
 <br/><br/>
 
-## Customizing the Card Copy
+## Other Optional Properties
 
-The copy text in the `NotifiCardModal` is fully customizable by inserting the custom copy text object to the `NotifiCardModal` component.
+`NotifiCardModal` component provides the following additional optional properties to customize the card even further:
 
-**Common Example 1: Customizing the destination separator**
+- [darkMode](#adjusting-card-color-scheme---darkmode)
+- [globalCtas](#additional-optional-cta-call-to-action---globalctas)
+- [copy](#customizing-the-card-copy---copy)
+- [classNames](#embedding-custom-css-classes-in-components---classnames)
 
-Destination (Target) input separator copy customization as seen below:  
-![](https://i.imgur.com/Rxld99Q.png)
+> Check out the [NotifiCardModalProps type documentation ](https://docs.notifi.network/notifi-sdk-ts/notifi-react/types/NotifiCardModalProps.html) to know more details
 
-> **NOTE** Before implementing, please review the `copy` property structure in the `NotifiCardModal` component.
-> View the `copy` [structure here](https://github.com/notifi-network/notifi-sdk-ts/blob/main/packages/notifi-react/lib/components/NotifiCardModal.tsx#L32)
+<br/>
 
-_Example code_
+#### Adjusting card color scheme - `darkMode`
+
+The `darkMode` property allows you to switch the card color scheme between light and dark mode.
+
+> Default scheme: `light` (light mode)
+
+**Example**
 
 ```tsx
-const YourComponent = () => {
-  // ...
-  const { frontendClientStatus } = useNotifiFrontendClientContext();
-  const customCopy: NotifiCardModalProps['copy'] = {
-    Ftu: {
-      FtuTargetEdit: {
-        TargetInputs: {
-          inputSeparators: {
-            email: 'OR',
-            sms: 'OR',
-            telegram: 'OR',
-          },
-        },
-      },
-    },
-    Inbox: {
-      InboxConfigTargetEdit: {
-        TargetInputs: {
-          inputSeparators: {
-            email: 'OR',
-            sms: 'OR',
-            telegram: 'OR',
-          },
-        },
-      },
-    },
-  };
-
-  return (
-    <>
-      {/*  ... */}
-      <NotifiCardModal copy={customCopy} />
-      {/*  ... */}
-    </>
-  );
-};
+<NotifiCardModal darkMode />
 ```
 
-<br/><br/>
+<br/>
 
-**Common Example 2: Customizing the Connect view footer**
+#### Additional optional CTA (Call to Action) - `globalCtas`
+
+The `globalCtas` property allows to add certain supported CTAs to the card. Now it supports `onClose` CTA.
+
+**Example**
+
+```tsx
+// ...
+const [isCardModalOpen, setIsCardModalOpen] = useState(false);
+
+// ...
+
+{
+  isCardModalOpen ? (
+    <NotifiCardModal
+      globalCtas={{ onClose: () => setIsCardModalOpen(false) }}
+    />
+  ) : null;
+}
+```
+
+**NOTE**
+
+The `onClose` function enables the close-icon on the card. We are passing a callback function here to update the local state and close the modal.
+
+![close-icon-preview](https://github.com/user-attachments/assets/79de998f-9807-45cc-a4d7-583e6298d2e7)
+
+<br/>
+
+#### Customizing the card copy - `copy`
+
+The `copy` property allows you to customize the card's default copy.
+
+There are many customizable copy sections in the NotifiCardModal component. Check out the [NotifiCardModalProps type documentation ](https://docs.notifi.network/notifi-sdk-ts/notifi-react/types/NotifiCardModalProps.html) to know more details
+
+**Common Example: Customizing the Connect view footer**
 
 Connect view footer preview as seen below:
 
@@ -273,31 +258,33 @@ const YourComponent = () => {
 
 > - Checkout the example project [codebase](https://github.com/notifi-network/notifi-sdk-ts/blob/main/packages/notifi-react-example-v2/src/app/notifi/components-example/page.tsx)
 
-<br/><br/>
+<br/>
 
-**Common Example 3: Adding the Close Icon on the Card**
+#### Embedding custom CSS classes in components - `classNames`
 
-Close Icon preview as seen below:
+You can pass in custom CSS classes to the `NotifiCardModal` component.
+Check out the `classNames` property in [NotifiCardModalProps type documentation ](https://docs.notifi.network/notifi-sdk-ts/notifi-react/types/NotifiCardModalProps.html) to know the className customizable components.
 
-![close-icon-preview](https://github.com/user-attachments/assets/79de998f-9807-45cc-a4d7-583e6298d2e7)
-
-_Example code_
+_Example_
 
 ```tsx
 const YourComponent = () => {
-  const [isCardModalOpen, setIsCardModalOpen] = React.useState(false);
+  // ...
+  const customClassName: NotifiCardModalProps['classNames'] = {
+    container: 'custom-card-modal-container', // This will add 'custom-card-modal-container' class to the card modal container
+  };
 
   return (
     <>
-      <NotifiCardModal
-        globalCtas={{ onClose: () => setIsCardModalOpen(false) }}
-        // The onClose function enables the close-icon on the card
-        // We are passing a callback function here to update the local state and close the modal
-      />
+      {/*  ... */}
+      <NotifiCardModal classNames={customClassName} />
+      {/*  ... */}
     </>
   );
 };
 ```
+
+<br/><br/>
 
 # Custom Integration
 

--- a/packages/notifi-react/README.md
+++ b/packages/notifi-react/README.md
@@ -575,6 +575,9 @@ export const MyComponent = () => {
 
 - **renewTargetGroup**: A function to update the backend target state according to the targetInputs.
 
+  - **Update single target**: passing `singleTargetRenewArgs` as an argument. **NOTE**: This action does not require updating `targetInputs` manually. `targetInputs` will be updated automatically once `renewTargetGroup` is called successfully.
+  - **Update all targets**: all targets will be updated according to the `targetInputs` state w/o passing any argument.
+
 - **TargetGroupId**: The target group id which is the argument to call `renewTargetGroup` function.
 
 - **targetData**: The target data which is the current state of the targets in the backend.

--- a/packages/notifi-react/lib/components/Connect.tsx
+++ b/packages/notifi-react/lib/components/Connect.tsx
@@ -76,7 +76,6 @@ export const Connect: React.FC<ConnectProps> = (props) => {
   );
 
   const topicLists = React.useMemo(() => {
-    // TODO: Move to NotifiTenantConfigContext when somewhere else needs this
     const topicGroupNames: { index: number; value: string }[] = [];
     const topicNames: { index: number; value: string }[] = [];
     fusionEventTopics.forEach((topic, id) => {

--- a/packages/notifi-react/lib/components/LoadingGlobal.tsx
+++ b/packages/notifi-react/lib/components/LoadingGlobal.tsx
@@ -10,7 +10,7 @@ export type LoadingGlobalProps = {
 
 export const LoadingGlobal: React.FC = () => {
   const { globalLoading } = useGlobalStateContext();
-  // TODO: Confirm style and impl
+  // NOTE: Not being used by far. Currently no global loading state for NotifiCardModal
   return (
     <div>
       {globalLoading.loadingData ? <h1>{globalLoading.loadingData}</h1> : null}

--- a/packages/notifi-react/lib/components/NotifiCardModal.tsx
+++ b/packages/notifi-react/lib/components/NotifiCardModal.tsx
@@ -22,15 +22,6 @@ import { Inbox, InboxProps } from './Inbox';
 import { LoadingGlobalProps } from './LoadingGlobal';
 import { NavHeaderRightCta } from './NavHeader';
 
-export type NotifiInputFieldsText = {
-  label?: {
-    email?: string;
-    sms?: string;
-    telegram?: string;
-  };
-  placeholderText?: { email?: string; sms?: string; telegram?: string };
-};
-
 export type NotifiCardModalProps = Readonly<{
   copy?: {
     ErrorGlobal?: ErrorViewProps['copy'];

--- a/packages/notifi-react/lib/components/TargetInputField.tsx
+++ b/packages/notifi-react/lib/components/TargetInputField.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import React, { useMemo } from 'react';
 
-import { Icon, IconType } from '../assets/Icons';
 import { FormTarget, useNotifiTargetContext } from '../context';
 import { defaultCopy } from '../utils/constants';
 

--- a/packages/notifi-react/lib/components/TargetInputField.tsx
+++ b/packages/notifi-react/lib/components/TargetInputField.tsx
@@ -46,17 +46,13 @@ export const TargetInputField: React.FC<TargetInputFieldProps> = (props) => {
         return targetInputs.email;
       case 'phoneNumber':
         return targetInputs.phoneNumber;
-      case 'telegram':
-        return targetInputs.telegram;
     }
   }, [props.targetType, targetInputs]);
 
   const inputPlaceholder =
     (props.copy?.placeholder ?? props.targetType === 'email')
       ? defaultCopy.inputFields.email
-      : props.targetType === 'phoneNumber'
-        ? defaultCopy.inputFields.phoneNumber
-        : defaultCopy.inputFields.telegram;
+      : defaultCopy.inputFields.phoneNumber;
 
   const isTargetValid = (targetInput: string) => {
     if (targetInput === '' || !props.validateRegex) {

--- a/packages/notifi-react/lib/components/TargetList.tsx
+++ b/packages/notifi-react/lib/components/TargetList.tsx
@@ -84,9 +84,6 @@ export const TargetList: React.FC<TargetListProps> = (props) => {
             targetListItemArgs.iconType = 'telegram';
             targetListItemArgs.label =
               props.copy?.telegram ?? defaultCopy.targetList.telegram;
-            // targetListItemArgs.message = {
-            //   beforeVerify: 'Verify your Telegram account',
-            // };
             targetListItemArgs.targetCtaType = 'link';
             break;
           case 'discord':

--- a/packages/notifi-react/lib/components/TargetList.tsx
+++ b/packages/notifi-react/lib/components/TargetList.tsx
@@ -38,7 +38,6 @@ export const TargetList: React.FC<TargetListProps> = (props) => {
   const { cardConfig } = useNotifiTenantConfigContext();
 
   const targetListItemArgsList = React.useMemo(() => {
-    // TODO: Move to custom hook when it gets too complex
     const order = [
       'email',
       'phoneNumber',

--- a/packages/notifi-react/lib/components/TargetListItemToggle.tsx
+++ b/packages/notifi-react/lib/components/TargetListItemToggle.tsx
@@ -142,8 +142,6 @@ export const TargetListItemToggle: React.FC<TargetListItemToggleProps> = (
             type: 'cta',
             message: 'Remove',
             onClick: async () => {
-              // TODO: Remove this after adding documentation: 1. single target subscription always sync with with targetData. 2. targetInput & multiple target subscription.
-              // updateTargetInputs(props.target, false); // TODO: remove
               renewTargetGroup({
                 target: props.target as ToggleTarget,
                 value: false,

--- a/packages/notifi-react/lib/components/TargetListItemToggle.tsx
+++ b/packages/notifi-react/lib/components/TargetListItemToggle.tsx
@@ -70,7 +70,6 @@ export const TargetListItemToggle: React.FC<TargetListItemToggleProps> = (
       )}
     >
       {/* ICON/ LABEL / USERNAME */}
-      {/* {JSON.stringify(props.targetInfo)} */}
       <div className="notifi-target-list-item-content">
         <div
           className={clsx(

--- a/packages/notifi-react/lib/components/TopicList.tsx
+++ b/packages/notifi-react/lib/components/TopicList.tsx
@@ -38,7 +38,6 @@ export const TopicList: React.FC<TopicListProps> = (props) => {
   const parentComponent = props.parentComponent ?? 'ftu';
   const { fusionEventTopics } = useNotifiTenantConfigContext();
 
-  // TODO: Move this to a hook
   const topicRows = React.useMemo(() => {
     const fusionEventTopicGroups: Record<string, TopicGroupRowMetadata> = {};
     const fusionEventStandaloneTopics: TopicStandaloneRowMetadata[] = [];

--- a/packages/notifi-react/lib/context/NotifiTargetContext.tsx
+++ b/packages/notifi-react/lib/context/NotifiTargetContext.tsx
@@ -121,7 +121,6 @@ const isFormTargetRenewArgs = (
   args: TargetRenewArgs,
 ): args is FormTargetRenewArgs => {
   return formTargets.includes(args.target as FormTarget);
-  // return args.target === 'email' || args.target === 'phoneNumber';
 };
 
 const isToggleTargetRenewArgs = (
@@ -390,7 +389,7 @@ export const NotifiTargetContextProvider: FC<
           phoneNumber: !targetData.phoneNumber
             ? undefined
             : targetData.phoneNumber,
-          telegramId: !targetData.telegram.useTelegram ? 'Default' : undefined,
+          telegramId: targetData.telegram.useTelegram ? 'Default' : undefined,
           discordId: targetData.discord.useDiscord ? 'Default' : undefined,
           slackId: targetData.slack.useSlack ? 'Default' : undefined,
           walletId: targetData.wallet.useWallet ? 'Default' : undefined,
@@ -420,7 +419,6 @@ export const NotifiTargetContextProvider: FC<
             ...data,
             [`${target}Id`]: value ? 'Default' : undefined,
           };
-          console.log({ data });
         }
       }
 

--- a/packages/notifi-react/lib/context/NotifiTargetContext.tsx
+++ b/packages/notifi-react/lib/context/NotifiTargetContext.tsx
@@ -16,6 +16,7 @@ import React, {
 } from 'react';
 
 import { useTargetWallet } from '../hooks/useTargetWallet';
+import { formTargets, toggleTargets } from '../utils';
 import { useNotifiFrontendClientContext } from './NotifiFrontendClientContext';
 
 export type TargetGroupInput = {
@@ -35,20 +36,10 @@ export type TargetDocument = {
   targetData: TargetData;
 };
 
-// TODO: refactor ex. formTargets = [email, phoneNumber]; toggleTargets = [discord, slack, telegram, wallet];
-export type Target =
-  | 'email'
-  | 'phoneNumber'
-  | 'telegram'
-  | 'discord'
-  | 'slack'
-  | 'wallet';
+export type Target = FormTarget | ToggleTarget;
 
-export type FormTarget = Extract<Target, 'email' | 'phoneNumber'>;
-export type ToggleTarget = Extract<
-  Target,
-  'discord' | 'slack' | 'wallet' | 'telegram'
->;
+export type FormTarget = (typeof formTargets)[number];
+export type ToggleTarget = (typeof toggleTargets)[number];
 
 export type TargetInputFromValue = { value: string; error?: string };
 type TargetInputForm = Record<FormTarget, TargetInputFromValue>;
@@ -129,18 +120,14 @@ type TargetRenewArgs = FormTargetRenewArgs | ToggleTargetRenewArgs;
 const isFormTargetRenewArgs = (
   args: TargetRenewArgs,
 ): args is FormTargetRenewArgs => {
-  return args.target === 'email' || args.target === 'phoneNumber';
+  return formTargets.includes(args.target as FormTarget);
+  // return args.target === 'email' || args.target === 'phoneNumber';
 };
 
 const isToggleTargetRenewArgs = (
   args: TargetRenewArgs,
 ): args is ToggleTargetRenewArgs => {
-  return (
-    args.target === 'slack' ||
-    args.target === 'wallet' ||
-    args.target === 'discord' ||
-    args.target === 'telegram'
-  );
+  return toggleTargets.includes(args.target as ToggleTarget);
 };
 
 export type NotifiTargetContextType = {
@@ -354,11 +341,8 @@ export const NotifiTargetContextProvider: FC<
   }, [toggleTargetAvailability]);
 
   const unVerifiedTargets = useMemo(() => {
-    const {
-      email: emailInfoPrompt,
-      phoneNumber: phoneNumberInfoPrompt,
-      // telegram: telegramInfoPrompt,
-    } = targetInfoPrompts;
+    const { email: emailInfoPrompt, phoneNumber: phoneNumberInfoPrompt } =
+      targetInfoPrompts;
 
     const unConfirmedTargets = {
       email: emailInfoPrompt?.infoPrompt.type === 'cta',

--- a/packages/notifi-react/lib/context/NotifiTargetContext.tsx
+++ b/packages/notifi-react/lib/context/NotifiTargetContext.tsx
@@ -601,13 +601,20 @@ export const NotifiTargetContextProvider: FC<
 
   const refreshTelegramTarget = useCallback(
     async (telegramTarget?: Types.TelegramTargetFragmentFragment) => {
-      if (!!telegramTarget && !telegramTarget.isConfirmed) {
-        updateTargetInfoPrompt('telegram', {
-          type: 'cta',
-          message: 'Set Up',
-          onClick: () => window.open(telegramTarget.confirmationUrl, '_blank'),
-        });
-        setTargetData((prev) => ({
+      if (!!telegramTarget) {
+        const infoPrompt: TargetInfoPrompt = telegramTarget.isConfirmed
+          ? {
+              type: 'message',
+              message: 'Verified',
+            }
+          : {
+              type: 'cta',
+              message: 'Set Up',
+              onClick: () =>
+                window.open(telegramTarget.confirmationUrl, '_blank'),
+            };
+        updateTargetInfoPrompt('telegram', infoPrompt);
+        return setTargetData((prev) => ({
           ...prev,
           telegram: {
             useTelegram: true,
@@ -615,21 +622,15 @@ export const NotifiTargetContextProvider: FC<
             isAvailable: toggleTargetAvailability?.telegram ?? true,
           },
         }));
-      } else if (!!telegramTarget && telegramTarget.isConfirmed) {
-        updateTargetInfoPrompt('telegram', {
-          type: 'message',
-          message: 'Verified',
-        });
-      } else {
-        setTargetData((prev) => ({
-          ...prev,
-          telegram: {
-            useTelegram: false,
-            isAvailable: toggleTargetAvailability?.telegram ?? true,
-          },
-        }));
-        updateTargetInfoPrompt('telegram', null);
       }
+      setTargetData((prev) => ({
+        ...prev,
+        telegram: {
+          useTelegram: false,
+          isAvailable: toggleTargetAvailability?.telegram ?? true,
+        },
+      }));
+      updateTargetInfoPrompt('telegram', null);
     },
     [],
   );

--- a/packages/notifi-react/lib/context/NotifiTargetContext.tsx
+++ b/packages/notifi-react/lib/context/NotifiTargetContext.tsx
@@ -603,7 +603,6 @@ export const NotifiTargetContextProvider: FC<
 
   const refreshTelegramTarget = useCallback(
     async (telegramTarget?: Types.TelegramTargetFragmentFragment) => {
-      // TODO: Refactor - extract telegram target not exist case
       if (!!telegramTarget && !telegramTarget.isConfirmed) {
         updateTargetInfoPrompt('telegram', {
           type: 'cta',

--- a/packages/notifi-react/lib/hooks/useTargetListItem.tsx
+++ b/packages/notifi-react/lib/hooks/useTargetListItem.tsx
@@ -45,7 +45,7 @@ export const useTargetListItem = (input: {
     targetData[input.target];
     const targetInfo = targetInfoPrompts[input.target];
     switch (input.target) {
-      // TODO: Refactor
+      // TODO: Refactor (remove redundant code)
       case 'telegram':
         return (
           !!targetInfo &&
@@ -76,6 +76,7 @@ export const useTargetListItem = (input: {
   }, [input.target, targetData, cardConfig, targetInfoPrompts]);
 
   const signupCtaProps: TargetCtaProps = React.useMemo(() => {
+    // TODO: Refactor (remove redundant code)
     const defaultCtaProps: TargetCtaProps = {
       type: 'button',
       targetInfoPrompt: {
@@ -87,7 +88,6 @@ export const useTargetListItem = (input: {
 
     switch (input.target) {
       case 'email':
-        // case 'telegram':
         return {
           ...defaultCtaProps,
           type: 'button',

--- a/packages/notifi-react/lib/hooks/useTargetListItem.tsx
+++ b/packages/notifi-react/lib/hooks/useTargetListItem.tsx
@@ -35,48 +35,23 @@ export const useTargetListItem = (input: {
   const {
     targetDocument: { targetData, targetInputs, targetInfoPrompts },
     renewTargetGroup,
-    updateTargetInputs,
   } = useNotifiTargetContext();
+
   const isRemoveButtonAvailable = React.useMemo(() => {
     const isTargetRemovable = !!cardConfig?.isContactInfoRequired
       ? hasValidTargetMoreThan(targetData, 1)
       : true;
 
-    targetData[input.target];
     const targetInfo = targetInfoPrompts[input.target];
-    switch (input.target) {
-      // TODO: Refactor (remove redundant code)
-      case 'telegram':
-        return (
-          !!targetInfo &&
-          targetInfo.infoPrompt.message !== 'Set Up' &&
-          isTargetRemovable
-        );
-      case 'discord':
-        return (
-          !!targetInfo &&
-          targetInfo.infoPrompt.message !== 'Set Up' &&
-          isTargetRemovable
-        );
-      case 'slack':
-        return (
-          !!targetInfo &&
-          targetInfo.infoPrompt.message !== 'Set Up' &&
-          isTargetRemovable
-        );
-      case 'wallet':
-        return (
-          !!targetInfo &&
-          targetInfo.infoPrompt.message !== 'Sign Wallet' &&
-          isTargetRemovable
-        );
-      default:
-        return !!targetInfo && isTargetRemovable;
-    }
+    const removableTargetExists = !!targetInfo && isTargetRemovable;
+    const isTargetSignedUp = (signupMessage: string) =>
+      !['Set Up', 'Sign Wallet'].includes(signupMessage);
+    return (
+      removableTargetExists && isTargetSignedUp(targetInfo.infoPrompt.message)
+    );
   }, [input.target, targetData, cardConfig, targetInfoPrompts]);
 
   const signupCtaProps: TargetCtaProps = React.useMemo(() => {
-    // TODO: Refactor (remove redundant code)
     const defaultCtaProps: TargetCtaProps = {
       type: 'button',
       targetInfoPrompt: {
@@ -90,7 +65,6 @@ export const useTargetListItem = (input: {
       case 'email':
         return {
           ...defaultCtaProps,
-          type: 'button',
           targetInfoPrompt: {
             type: 'cta',
             message: 'Save',
@@ -109,13 +83,10 @@ export const useTargetListItem = (input: {
         return {
           ...defaultCtaProps,
           isCtaDisabled: !targetData[input.target].isAvailable,
-          type: 'button',
           targetInfoPrompt: {
             type: 'cta',
             message: 'Set Up',
             onClick: async () => {
-              // TODO: Remove this after adding documentation: 1. single target subscription always sync with with targetData. 2. targetInput & multiple target subscription.
-              // await updateTargetInputs(props.target, true);
               const targetGroup = await renewTargetGroup({
                 target: input.target as ToggleTarget,
                 value: true,
@@ -138,13 +109,10 @@ export const useTargetListItem = (input: {
         return {
           ...defaultCtaProps,
           isCtaDisabled: !targetData[input.target].isAvailable,
-          type: 'button',
           targetInfoPrompt: {
             type: 'cta',
             message: 'Set Up',
             onClick: async () => {
-              // TODO: Remove this after adding documentation: 1. single target subscription always sync with with targetData. 2. targetInput & multiple target subscription.
-              // await updateTargetInputs(props.target, true);
               const targetGroup = await renewTargetGroup({
                 target: input.target as ToggleTarget,
                 value: true,
@@ -168,13 +136,10 @@ export const useTargetListItem = (input: {
         return {
           ...defaultCtaProps,
           isCtaDisabled: !targetData[input.target].isAvailable,
-          type: 'button',
           targetInfoPrompt: {
             type: 'cta',
             message: 'Sign Wallet',
             onClick: async () => {
-              // TODO: Remove this after adding documentation: 1. single target subscription always sync with with targetData. 2. targetInput & multiple target subscription.
-              // await updateTargetInputs(props.target, true);
               const targetGroup = await renewTargetGroup({
                 target: input.target as ToggleTarget,
                 value: true,
@@ -188,8 +153,7 @@ export const useTargetListItem = (input: {
                 walletTargetId &&
                 walletTargetSenderAddress
               ) {
-                // TODO: Remove unused variable
-                const _updatedWeb3Target = await signCoinbaseSignature(
+                await signCoinbaseSignature(
                   walletTargetId,
                   walletTargetSenderAddress,
                 );
@@ -201,12 +165,10 @@ export const useTargetListItem = (input: {
         return {
           ...defaultCtaProps,
           isCtaDisabled: !targetData[input.target].isAvailable,
-          type: 'button',
           targetInfoPrompt: {
             type: 'cta',
             message: 'Set Up',
             onClick: async () => {
-              await updateTargetInputs(input.target, true);
               const targetGroup = await renewTargetGroup({
                 target: input.target as ToggleTarget,
                 value: true,
@@ -221,10 +183,7 @@ export const useTargetListItem = (input: {
       default:
         return defaultCtaProps;
     }
-  }, [
-    input.target,
-    targetInputs /* renewTargetGroup, updateTargetInputs, signCoinbaseSignature */, //TODO: econsider the dependency
-  ]);
+  }, [input.target, targetInputs, renewTargetGroup, signCoinbaseSignature]);
 
   const classifiedTargetListItemMessage: ClassifiedTargetListItemMessage | null =
     React.useMemo(() => {

--- a/packages/notifi-react/lib/hooks/useTargetListItem.tsx
+++ b/packages/notifi-react/lib/hooks/useTargetListItem.tsx
@@ -57,7 +57,10 @@ export const useTargetListItem = (input: {
       targetInfoPrompt: {
         type: 'cta',
         message: 'Signup',
-        onClick: async () => console.log('Default Signup placeHolder'),
+        onClick: async () => {
+          const errorMsg = `ERROR: No signup action defined for target: ${input.target}`;
+          console.error(errorMsg);
+        },
       },
     };
 

--- a/packages/notifi-react/lib/utils/constants.ts
+++ b/packages/notifi-react/lib/utils/constants.ts
@@ -12,14 +12,6 @@ export const defaultCopy = {
     email: 'Enter your email address',
     phoneNumber: 'Phone Number',
   },
-  inputToggles: {
-    discord: 'Discord DM Bot',
-    slack: 'Slack',
-    wallet: 'Wallet Alerts',
-    discordUnavailable: 'Discord unavailable',
-    slackUnavailable: 'Slack unavailable',
-    walletUnavailable: 'Only available for Coinbase Wallet',
-  },
   ftu: {
     headerTitles: {
       ftuTargetEdit: 'How do you want to be notified?',

--- a/packages/notifi-react/lib/utils/constants.ts
+++ b/packages/notifi-react/lib/utils/constants.ts
@@ -11,7 +11,6 @@ export const defaultCopy = {
   inputFields: {
     email: 'Enter your email address',
     phoneNumber: 'Phone Number',
-    telegram: 'Telegram ID',
   },
   inputToggles: {
     discord: 'Discord DM Bot',

--- a/packages/notifi-react/lib/utils/target.ts
+++ b/packages/notifi-react/lib/utils/target.ts
@@ -1,6 +1,7 @@
 import { objectKeys } from '@notifi-network/notifi-frontend-client';
 
-import {
+// NOTE: Only import "type" to avoid circular dependency
+import type {
   CtaInfo,
   FormTarget,
   MessageInfo,
@@ -10,6 +11,14 @@ import {
   TargetInputs,
   ToggleTarget,
 } from '../context';
+
+export const formTargets = ['email', 'phoneNumber'] as const;
+export const toggleTargets = [
+  'discord',
+  'slack',
+  'telegram',
+  'wallet',
+] as const;
 
 export const reformatSignatureForWalletTarget = (
   signature: Uint8Array | string,
@@ -93,15 +102,8 @@ export const isFormTarget = (target: Target): target is FormTarget => {
   return supportedFormTargets.includes(target);
 };
 
-export const isToggleTarget = (target: Target): target is ToggleTarget => {
-  const supportedToggleTargets: Target[] = [
-    'discord',
-    'slack',
-    'wallet',
-    'telegram',
-  ];
-  return supportedToggleTargets.includes(target);
-};
+export const isToggleTarget = (target: Target): target is ToggleTarget =>
+  toggleTargets.includes(target as ToggleTarget);
 
 export const getWalletTargetSignMessage = (
   address: string,
@@ -110,9 +112,7 @@ export const getWalletTargetSignMessage = (
 ) =>
   `Coinbase Wallet Messaging subscribe\nAddress: ${address}\nPartner Address: ${senderAddress}\nNonce: ${nonce}`;
 
-export const getTargetValidateRegex = (
-  target: Extract<Target, 'email' | 'phoneNumber'>,
-) => {
+export const getTargetValidateRegex = (target: FormTarget) => {
   switch (target) {
     case 'email':
       return new RegExp('^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$');

--- a/packages/notifi-react/lib/utils/target.ts
+++ b/packages/notifi-react/lib/utils/target.ts
@@ -11,14 +11,6 @@ import {
   ToggleTarget,
 } from '../context';
 
-// TODO: Deprecate this method
-export const formatTelegramForSubscription = (telegramId: string) => {
-  if (telegramId.startsWith('@')) {
-    return telegramId.slice(1);
-  }
-  return telegramId;
-};
-
 export const reformatSignatureForWalletTarget = (
   signature: Uint8Array | string,
 ) => {
@@ -124,8 +116,6 @@ export const getTargetValidateRegex = (
   switch (target) {
     case 'email':
       return new RegExp('^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$');
-    // case 'telegram':
-    //   return new RegExp('.{5,}');
     case 'phoneNumber':
       return undefined;
     default:

--- a/packages/notifi-solana-hw-login/README.md
+++ b/packages/notifi-solana-hw-login/README.md
@@ -1,81 +1,18 @@
-# `@notifi/notifi-solana-hw-login`
+# Notifi Solana Hardware Login Plugin
 
-This package is a requirement for users integrating `@notifi/notifi-react-card` with the Solana blockchain. It provides the bindings necessary for logging in with a Solana hardware wallet.
+This package is a requirement for users integrating `@notifi/notifi-react` with the Solana blockchain. It provides the bindings necessary for logging in with a Solana hardware wallet. Example below:
 
 ```tsx
-import {
-  NotifiContext,
-  NotifiInputFieldsText,
-  NotifiInputSeparators,
-  NotifiSubscriptionCard,
-} from '@notifi-network/notifi-react-card';
-import '@notifi-network/notifi-react-card/dist/index.css';
 import { MemoProgramHardwareLoginPlugin } from '@notifi-network/notifi-solana-hw-login';
-import { useConnection, useWallet } from '@solana/wallet-adapter-react';
-import React from 'react';
 
-import './NotifiCard.css';
+// ...
 
-export const NotifiCard: React.FC = () => {
-  const { connection } = useConnection();
-  const { wallet, sendTransaction, signMessage } = useWallet();
-  const adapter = wallet?.adapter;
-  const publicKey = adapter?.publicKey?.toBase58() ?? null;
-
-  const hwLoginPlugin = useMemo(() => {
-    return new MemoProgramHardwareLoginPlugin({
-      walletPublicKey: publicKey ?? '',
-      connection,
-      sendTransaction,
-    });
-  }, [publicKey, connection, sendTransaction]);
-
-  if (publicKey === null || signMessage === undefined) {
-    // publicKey is required
-    return null;
-  }
-
-  const inputLabels: NotifiInputFieldsText = {
-    label: {
-      email: 'Email',
-      sms: 'Text Message',
-      telegram: 'Telegram',
-    },
-    placeholderText: {
-      email: 'Email',
-    },
-  };
-
-  const inputSeparators: NotifiInputSeparators = {
-    smsSeparator: {
-      content: 'OR',
-    },
-    emailSeparator: {
-      content: 'OR',
-    },
-    telegramSeparator: {
-      content: 'OR',
-    },
-  };
-
-  return (
-    <div className="container">
-      <NotifiContext
-        dappAddress="<YOUR OWN DAPP ADDRESS HERE>"
-        walletBlockchain="SOLANA"
-        env="Development"
-        walletPublicKey={publicKey}
-        hardwareLoginPlugin={hwLoginPlugin}
-        signMessage={signMessage}
-      >
-        <NotifiSubscriptionCard
-          darkMode
-          inputLabels={inputLabels}
-          inputSeparators={inputSeparators}
-          cardId="<YOUR OWN CARD ID HERE>"
-        />
-      </NotifiContext>
-    </div>
-  );
-};
+<NotifiContextProvider
+  // other props
+  hardwareLoginPlugin={solanaHardwareLoginPlugin} // If your dapp wants to support Solana hardware wallets, add this prop
+>
+  {/* Your components here */}
+</NotifiContextProvider>;
 ```
+
+For more comprehensive examples, see the `notifi-react-example-v2` package's [NotifiContextWrapper.tsx](https://github.com/notifi-network/notifi-sdk-ts/blob/97280b625ef133811d176fbb8add73f6b3f7bd44/packages/notifi-react-example-v2/src/context/NotifiContextWrapper.tsx#L184)


### PR DESCRIPTION
### Describe the purpose of the change
  The last ticket of sdk4 m2 for UAT - content as title. The video attached herewith 


### Demo video 
https://github.com/user-attachments/assets/f601699f-5094-4ed5-9560-36ca3818d2e2




### IMPORTANT NOTE
- ~~TG verification will not not go through until endpoint supports it CC: @kai-notifi~~
- 250112 update: ready on dev. Prod is not ready. DO NOT MERGE before bing ready on prod.

> Canary version: [4.0.2-alpha.24](https://www.npmjs.com/package/@notifi-network/notifi-react/v/4.0.2-alpha.24)

### TODO
- [ ]  After BE ready & UAT, merge M1 PR ( #751 ) to main and publish a `Canary fallback version`: this version will have new target flow with 2-step TG verification 
- [ ] Create new PR for 1-step TG verify flow (`stage-new-target-flow-m2` -> `main`). Merge it and release official major version `v5.0.0`
- [ ] Update Typedoc site




- [x] Create test cases for your changes if needed
