### PR TITLE
MVP-5956: skip publish.yml action under notifi-sdk-ts repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,12 +7,6 @@ on:
   release:
     types: [released]
   workflow_dispatch:
-  # PR TEST ONLY - Remove before merging
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    if: github.repository != 'notifi-network/notifi-sdk-ts'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -19,10 +20,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: main
-
-      - name: Bail if its the SDK repo
-        if: github.repository == 'notifi-network/notifi-sdk-ts'
-        run: exit 0 # We don't want to publish the SDK repo, and we also want it to be green
 
       - name: Validate Required Variables
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish App
+name: Publish App (@notifi-network/notifi-dapp-example)
 
 on:
   push:
@@ -105,7 +105,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.AWS_REGION || 'us-west-2' }}
-          role-session-name: elixir-${{ github.event_name }}-${{ github.sha }}
+          role-session-name: notifi-dapp-${{ github.event_name }}-${{ github.sha }}
 
       - name: Build App
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,12 @@ on:
   release:
     types: [released]
   workflow_dispatch:
+  # PR TEST ONLY - Remove before merging
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 jobs:
   build:


### PR DESCRIPTION
- Describe the purpose of the change

Rather than only stopping a specific `step`, this change skips the entire `job`.

> **NOTE:** Stopping only the `step` allows the remaining steps to continue running, which causes the action to fail.

- [x] TODO: Revert the last commit "[CICD TEST ONLY (REVERT BEFORE MERGE)](https://github.com/notifi-network/notifi-sdk-ts/pull/770/commits/d84b7b602dba9a79df888a419c2d622660faa3d3)" before merge
