### PR TITLE
MVP-5984: Optimize topic subscription CTAs STAGE --> MAIN

### DIFF
--- a/packages/notifi-frontend-client/__test__/NotifiFrontendClient.test.ts
+++ b/packages/notifi-frontend-client/__test__/NotifiFrontendClient.test.ts
@@ -74,7 +74,7 @@ describe('NotifiFrontendClient Unit Test', () => {
     expect(result.emailTargets![0]!.emailAddress).toBe('tester@notifi.network');
   });
 
-  it('ensureFusionAlerts & deleteAlert & getAlerts', async () => {
+  it('ensureFusionAlerts & deleteAlerts & getAlerts', async () => {
     await login();
 
     const targetGroups = await client.getTargetGroups();
@@ -99,7 +99,7 @@ describe('NotifiFrontendClient Unit Test', () => {
     const alertId = result.alerts![0].id;
 
     // Delete alert
-    await client.deleteAlert({ id: alertId });
+    await client.deleteAlerts({ ids: [alertId] });
 
     // Get alerts
     const alerts = await client.getAlerts();

--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -1076,7 +1076,9 @@ export class NotifiFrontendClient {
     const mutation = await this._service.createFusionAlerts({ input });
     return mutation.createFusionAlerts;
   }
-
+  /**
+   * @deprecated Use `deleteAlerts` instead
+   */
   async deleteAlert({
     id,
   }: Readonly<{
@@ -1087,6 +1089,21 @@ export class NotifiFrontendClient {
     if (result === undefined) {
       throw new Error('Failed to delete alert');
     }
+  }
+
+  async deleteAlerts({
+    ids,
+  }: Readonly<{
+    ids: Array<string>;
+  }>): Promise<Types.DeleteAlertsMutation['deleteAlerts']> {
+    const mutation = await this._service.deleteAlerts({
+      input: { alertIds: ids },
+    });
+    const result = mutation.deleteAlerts;
+    if (result === undefined) {
+      throw new Error('Failed to delete alerts');
+    }
+    return result;
   }
 
   async updateWallets() {

--- a/packages/notifi-graphql/lib/NotifiService.ts
+++ b/packages/notifi-graphql/lib/NotifiService.ts
@@ -243,6 +243,13 @@ export class NotifiService
     return this._typedClient.deleteAlert(variables, headers);
   }
 
+  async deleteAlerts(
+    variables: Generated.DeleteAlertsMutationVariables,
+  ): Promise<Generated.DeleteAlertsMutation> {
+    const headers = this._requestHeaders();
+    return this._typedClient.deleteAlerts(variables, headers);
+  }
+
   async DeleteDirectPushAlert(
     variables: Generated.DeleteDirectPushAlertMutationVariables,
   ): Promise<Generated.DeleteDirectPushAlertMutation> {

--- a/packages/notifi-graphql/lib/gql/fragments/ErrorFragments.gql.ts
+++ b/packages/notifi-graphql/lib/gql/fragments/ErrorFragments.gql.ts
@@ -1,0 +1,36 @@
+import { gql } from 'graphql-request';
+
+export const ErrorFragments = gql`
+  fragment ArgumentErrorFragment on ArgumentError {
+    __typename
+    message
+    paramName
+  }
+
+  fragment ArgumentNullErrorFragment on ArgumentNullError {
+    __typename
+    message
+    paramName
+  }
+
+  fragment ArgumentOutOfRangeErrorFragment on ArgumentOutOfRangeError {
+    __typename
+    message
+    paramName
+  }
+
+  fragment TargetDoesNotExistErrorFragment on TargetDoesNotExistError {
+    __typename
+    message
+  }
+
+  fragment UnexpectedErrorFragment on UnexpectedError {
+    __typename
+    message
+  }
+
+  fragment TargetLimitExceededErrorFragment on TargetLimitExceededError {
+    __typename
+    message
+  }
+`;

--- a/packages/notifi-graphql/lib/gql/mutations/createWebPushTarget.gql.ts
+++ b/packages/notifi-graphql/lib/gql/mutations/createWebPushTarget.gql.ts
@@ -1,5 +1,6 @@
 import { gql } from 'graphql-request';
 
+import { ErrorFragments } from '../fragments/ErrorFragments.gql';
 import { WebPushTargetFragment } from '../fragments/WebPushTargetFragment.gql';
 
 export const CreateWebPushTarget = gql`
@@ -21,14 +22,11 @@ export const CreateWebPushTarget = gql`
         ...WebPushTargetFragment
       }
       errors {
-        ... on TargetLimitExceededError {
-          message
-        }
-        ... on UnexpectedError {
-          message
-        }
+        ...TargetLimitExceededErrorFragment
+        ...UnexpectedErrorFragment
       }
     }
   }
   ${WebPushTargetFragment}
+  ${ErrorFragments}
 `;

--- a/packages/notifi-graphql/lib/gql/mutations/deleteAlerts.gql.ts
+++ b/packages/notifi-graphql/lib/gql/mutations/deleteAlerts.gql.ts
@@ -2,14 +2,11 @@ import { gql } from 'graphql-request';
 
 import { ErrorFragments } from '../fragments/ErrorFragments.gql';
 
-export const CreateFusionAlerts = gql`
-  mutation createFusionAlerts($input: CreateFusionAlertsInput!) {
-    createFusionAlerts(input: $input) {
-      alerts {
-        groupName
-        id
-        name
-        filterOptions
+export const DeleteAlerts = gql`
+  mutation deleteAlerts($input: DeleteAlertsInput!) {
+    deleteAlerts(input: $input) {
+      deleteAlertsResponse {
+        alertsIds
       }
       errors {
         ...ArgumentErrorFragment

--- a/packages/notifi-graphql/lib/gql/mutations/deleteWebPushTarget.gql.ts
+++ b/packages/notifi-graphql/lib/gql/mutations/deleteWebPushTarget.gql.ts
@@ -1,17 +1,16 @@
 import { gql } from 'graphql-request';
 
+import { ErrorFragments } from '../fragments/ErrorFragments.gql';
+
 export const DeleteWebPushTarget = gql`
   mutation deleteWebPushTarget($id: String!) {
     deleteWebPushTarget(input: { id: $id }) {
       success
       errors {
-        ... on TargetDoesNotExistError {
-          message
-        }
-        ... on UnexpectedError {
-          message
-        }
+        ...TargetDoesNotExistErrorFragment
+        ...UnexpectedErrorFragment
       }
     }
   }
+  ${ErrorFragments}
 `;

--- a/packages/notifi-graphql/lib/gql/mutations/updateWebPushTarget.gql.ts
+++ b/packages/notifi-graphql/lib/gql/mutations/updateWebPushTarget.gql.ts
@@ -1,5 +1,6 @@
 import { gql } from 'graphql-request';
 
+import { ErrorFragments } from '../fragments/ErrorFragments.gql';
 import { WebPushTargetFragment } from '../fragments/WebPushTargetFragment.gql';
 
 export const UpdateWebPushTarget = gql`
@@ -16,14 +17,11 @@ export const UpdateWebPushTarget = gql`
         ...WebPushTargetFragment
       }
       errors {
-        ... on TargetDoesNotExistError {
-          message
-        }
-        ... on UnexpectedError {
-          message
-        }
+        ...TargetDoesNotExistErrorFragment
+        ...UnexpectedErrorFragment
       }
     }
   }
   ${WebPushTargetFragment}
+  ${ErrorFragments}
 `;

--- a/packages/notifi-graphql/lib/operations/DeleteAlerts.ts
+++ b/packages/notifi-graphql/lib/operations/DeleteAlerts.ts
@@ -1,0 +1,10 @@
+import {
+  DeleteAlertsMutation,
+  DeleteAlertsMutationVariables,
+} from '../gql/generated';
+
+export type DeleteAlertsService = Readonly<{
+  deleteAlerts: (
+    variables: DeleteAlertsMutationVariables,
+  ) => Promise<DeleteAlertsMutation>;
+}>;

--- a/packages/notifi-graphql/lib/operations/index.ts
+++ b/packages/notifi-graphql/lib/operations/index.ts
@@ -68,3 +68,4 @@ export * from './UpdateWebPushTarget';
 export * from './DeleteWebPushTarget';
 export * from './GetWebPushTargets';
 export * from './LogInByOidc';
+export * from './DeleteAlerts';

--- a/packages/notifi-react/lib/components/TopicStack.tsx
+++ b/packages/notifi-react/lib/components/TopicStack.tsx
@@ -38,7 +38,7 @@ type InputParmValueMetadata = {
 };
 
 export const TopicStack: React.FC<TopicStackProps> = (props) => {
-  const { unsubscribeAlert, getAlertFilterOptions } = useNotifiTopicContext();
+  const { unsubscribeAlerts, getAlertFilterOptions } = useNotifiTopicContext();
   const { getFusionTopic } = useNotifiTenantConfigContext();
   const benchmarkAlert = props.topicStackAlerts[0];
   const userInputOptions = React.useMemo(() => {
@@ -110,9 +110,9 @@ export const TopicStack: React.FC<TopicStackProps> = (props) => {
         )}
         onClick={async () => {
           if (isLoading) return;
-          for (const alert of props.topicStackAlerts) {
-            await unsubscribeAlert(alert.alertName);
-          }
+          const alerts = props.topicStackAlerts.map((alert) => alert.alertName);
+          if (alerts.length === 0) return;
+          await unsubscribeAlerts(alerts);
         }}
       >
         <Icon type="bin" />

--- a/packages/notifi-react/lib/components/TopicStackRowInput.tsx
+++ b/packages/notifi-react/lib/components/TopicStackRowInput.tsx
@@ -103,19 +103,15 @@ export const TopicStackRowInput = <T extends TopicRowCategory>(
               key={id}
               userInputParam={userInputParm}
               topic={benchmarkTopic}
-              onSelectAction={{
-                actionType: 'updateFilterOptions',
-                action: (userInputParmName, option) => {
-                  if (!filterOptionsToBeSubscribed || !filterName) return;
-                  const updatedAlertFilterOptiopns =
-                    getUpdatedAlertFilterOptions(
-                      filterName,
-                      filterOptionsToBeSubscribed,
-                      userInputParmName,
-                      convertOptionValue(option, userInputParm.kind),
-                    );
-                  setFilterOptionsToBeSubscribed(updatedAlertFilterOptiopns);
-                },
+              preventDefault={(userInputParmName, selected) => {
+                if (!filterOptionsToBeSubscribed || !filterName) return;
+                const updatedAlertFilterOptiopns = getUpdatedAlertFilterOptions(
+                  filterName,
+                  filterOptionsToBeSubscribed,
+                  userInputParmName,
+                  convertOptionValue(selected, userInputParm.kind),
+                );
+                setFilterOptionsToBeSubscribed(updatedAlertFilterOptiopns);
               }}
             />
           );


### PR DESCRIPTION
- Describe the purpose of the change
  - [x] Optimize topic options cta reactions #772 
  - [x] MVP-5986: Optimize topic enable/disable toggle #774 
    - notifi-graphql: new deleteAlerts service method
    - notifi-frontend-client & notifi-react: deprecate `deleteAlert` and utilize new method. (topic & unit test)

- [x] Update unit test cases for your changes if needed

## Demo video


https://github.com/user-attachments/assets/773ab7ac-b179-4d3e-a127-16679b4e8353




