### PR TITLE
MVP-5998: clean up dependency/  Optimize github action

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   cypress-run:
+    if: github.repository == 'notifi-network/notifi-sdk-ts'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/unitest.yml
+++ b/.github/workflows/unitest.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'notifi-network/notifi-sdk-ts'
     runs-on: ubuntu-latest
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8347,36 +8347,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@notifi-network/notifi-core": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@notifi-network/notifi-core/-/notifi-core-1.1.2.tgz",
-      "integrity": "sha512-xlRp4SLlMZ3/3FHvhKch6yKfJH0PxkCZFlOlZrlgVBw8/YumnUfLmNxMln9XyARWz2y4ozHdgKAXX+REKuKb1w==",
-      "dev": true,
-      "dependencies": {
-        "@notifi-network/notifi-graphql": "^1.1.2"
-      }
-    },
-    "node_modules/@notifi-network/notifi-core/node_modules/@notifi-network/notifi-graphql": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@notifi-network/notifi-graphql/-/notifi-graphql-1.1.2.tgz",
-      "integrity": "sha512-My7IJ52J/j46D8ZxbPRTTi3m/qv1oUgDozgWd1Y6oIaT4SMrPq5oKe+8XSq8/s5KDD6kyRJ8G4lRUwfAo+Pobw==",
-      "dev": true,
-      "dependencies": {
-        "graphql": "^16.6.0",
-        "graphql-request": "^6.0.0",
-        "graphql-ws": "^5.16.0",
-        "uuid": "^8.3.2"
-      }
-    },
-    "node_modules/@notifi-network/notifi-core/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@notifi-network/notifi-dapp-example": {
       "resolved": "packages/notifi-dapp-example",
       "link": true
@@ -36003,7 +35973,6 @@
         "libphonenumber-js": "^1.10.13"
       },
       "devDependencies": {
-        "@notifi-network/notifi-core": "^1.1.2",
         "@types/dompurify": "^3.0.3",
         "@types/marked": "^5.0.1"
       },

--- a/packages/notifi-react/package.json
+++ b/packages/notifi-react/package.json
@@ -53,7 +53,6 @@
     "libphonenumber-js": "^1.10.13"
   },
   "devDependencies": {
-    "@notifi-network/notifi-core": "^1.1.2",
     "@types/dompurify": "^3.0.3",
     "@types/marked": "^5.0.1"
   },


### PR DESCRIPTION
- Describe the purpose of the change
  - remove legacy dependency notifi-core
  - cypress & jest test cases only run on `notifi-sdk-ts repo
