### PR TITLE
MVP-6087: render System Event entries (WIP/ TBC)

### DIFF
--- a/packages/notifi-react/lib/context/NotifiHistoryContext.tsx
+++ b/packages/notifi-react/lib/context/NotifiHistoryContext.tsx
@@ -155,9 +155,6 @@ export const NotifiHistoryContextProvider: FC<
       //       : '',
       //   ) ?? [],
       // );
-      if (cardEventTypeNames.size === 0) {
-        return;
-      }
       if (!initialLoad && !cursorInfo.hasNextPage) {
         setError(new Error('No more notification history to fetch'));
         return;

--- a/packages/notifi-react/lib/context/NotifiHistoryContext.tsx
+++ b/packages/notifi-react/lib/context/NotifiHistoryContext.tsx
@@ -142,6 +142,7 @@ export const NotifiHistoryContextProvider: FC<
       const cardEventTypeNames = new Set(
         cardConfig?.eventTypes?.map((event) => event.name) ?? [],
       );
+      cardEventTypeNames.add('System User Notifications'); // NOTE: Add "System User Notifications" topic to the list (to receive system events: email verification link sent ... etc)
       // TODO: Use FusionEventId to filter the history items (Blocker: MVP-5101)
       // const cardEventFusionIds = new Set(
       //   cardConfig?.eventTypes?.map((event) =>


### PR DESCRIPTION
- Describe the purpose of the change
As title
The following points need confirmation from the BE team. CC: @kai-notifi  
> Currently, we filter renderable history entries using the topic name (`sourceName`).  
> This approach requires ensuring that `sourceName` ("System User Notification") remains unique moving forward.  

