### PR TITLE
MVP-6270-patch: exec packages' tests concurrently / remove unneeded npm test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "npx lerna run build",
     "format": "prettier --config .prettierrc packages/**/lib/**/*.ts* --write",
     "lint": "eslint --ext .ts,.tsx packages/**/lib --fix",
-    "test": "npx lerna run test",
+    "test": "npx lerna run test --concurrency 1",
     "test:node": "npx lerna --scope=@notifi-network/notifi-node run test",
     "test:frontend-client": "npx lerna --scope=@notifi-network/notifi-frontend-client run test",
     "serve-docs": "npm run docs && light-server -s ./docs -p 4000",

--- a/packages/notifi-dapp-example/package.json
+++ b/packages/notifi-dapp-example/package.json
@@ -20,7 +20,6 @@
     "url": "git+https://github.com/notifi-network/notifi-sdk-ts.git"
   },
   "scripts": {
-    "test": "echo \"WARN: no test specified\" && exit 0",
     "dev": "next dev",
     "build:next": "next build",
     "start": "next start",

--- a/packages/notifi-dataplane/package.json
+++ b/packages/notifi-dataplane/package.json
@@ -18,8 +18,7 @@
     "build": "npm run clean && npm run compile",
     "compile": "tsup lib/index.ts --format cjs,esm --dts --clean",
     "clean": "rimraf ./dist",
-    "prepublishOnly": "npm run build",
-    "test": "echo \"WARN: no test specified\" && exit 0"
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@notifi-network/notifi-graphql": "^6.0.0"

--- a/packages/notifi-graphql/package.json
+++ b/packages/notifi-graphql/package.json
@@ -18,7 +18,6 @@
     "build": "npm run clean && npm run compile",
     "compile": "graphql-codegen  && tsup lib/index.ts --format cjs,esm --dts --clean",
     "clean": "rimraf ./dist && rimraf ./lib/gql/generated.ts",
-    "test": "echo \"WARN: no test needed\" && exit 0",
     "prepublishOnly": "npm run build"
   },
   "repository": {

--- a/packages/notifi-node-sample/package.json
+++ b/packages/notifi-node-sample/package.json
@@ -10,8 +10,7 @@
     "url": "git+https://github.com/notifi-network/notifi-sdk-ts.git"
   },
   "scripts": {
-    "dev": "nodemon lib/index.ts",
-    "test": "echo \"WARN: no test specified\" && exit 0"
+    "dev": "nodemon lib/index.ts"
   },
   "dependencies": {
     "@notifi-network/notifi-node": "^6.0.0",

--- a/packages/notifi-react-wallet-target-plugin/package.json
+++ b/packages/notifi-react-wallet-target-plugin/package.json
@@ -39,8 +39,7 @@
     "compile": "tsup lib/index.ts --sourcemap --format cjs,esm --dts --clean --external react",
     "format": "prettier --config .prettierrc **/*.ts --write",
     "lint": "eslint .",
-    "prepublishOnly": "npm run build",
-    "test": "echo \"WARN: no test specified\" && exit 0"
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@xmtp/consent-proof-signature": "^0.1.2",

--- a/packages/notifi-react/package.json
+++ b/packages/notifi-react/package.json
@@ -38,7 +38,6 @@
     "compile": "tsup lib/index.ts --sourcemap --format cjs,esm --dts --clean --external react",
     "format": "prettier --config .prettierrc **/*.ts --write",
     "lint": "eslint .",
-    "test": "echo \"WARN: no test specified\" && exit 0",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/notifi-solana-hw-login/package.json
+++ b/packages/notifi-solana-hw-login/package.json
@@ -18,7 +18,6 @@
     "build": "npm run clean && npm run compile",
     "compile": "tsup lib/index.ts --format cjs,esm --dts --clean",
     "clean": "rimraf ./dist",
-    "test": "echo \"WARN: no test specified\" && exit 0",
     "prepublishOnly": "npm run build"
   },
   "repository": {

--- a/packages/notifi-wallet-provider/package.json
+++ b/packages/notifi-wallet-provider/package.json
@@ -29,8 +29,7 @@
     "clean": "rimraf ./dist",
     "compile": "tsup lib/index.ts --sourcemap --format cjs,esm --dts --clean --external react",
     "format": "prettier --config .prettierrc **/*.ts --write",
-    "lint": "eslint .",
-    "test": "echo \"WARN: no test specified\" && exit 0"
+    "lint": "eslint ."
   },
   "bugs": {
     "url": "https://github.com/notifi-network/notifi-sdk-ts/issues"


### PR DESCRIPTION
- Describe the purpose of the change
As title
