### PR TITLE
MVP-6294-patch: Update SmartLinkConfig & SmartLinkAction interface

### DIFF
--- a/packages/notifi-dataplane/lib/types/SmartLinkAction.ts
+++ b/packages/notifi-dataplane/lib/types/SmartLinkAction.ts
@@ -11,12 +11,17 @@ export type ActivateSmartLinkActionInput = {
   authParams: AuthParams;
   inputs: Record<number, SmartLinkActionUserInput>;
 };
-export type SmartLinkActionUserInput = TextBoxUserInput | CheckBoxUserInput;
-type TextBoxUserInput = {
+export type SmartLinkActionUserInput = ActionInputTextBox | ActionInputCheckBox;
+
+type ActionInputBase = {
+  id: string;
+};
+
+type ActionInputTextBox = ActionInputBase & {
   type: 'TEXTBOX';
   value: string | number;
 };
-type CheckBoxUserInput = {
+type ActionInputCheckBox = ActionInputBase & {
   type: 'CHECKBOX';
   value: boolean;
 };

--- a/packages/notifi-frontend-client/lib/models/SmartLinkConfig.ts
+++ b/packages/notifi-frontend-client/lib/models/SmartLinkConfig.ts
@@ -3,6 +3,8 @@ import type { Types } from '@notifi-network/notifi-graphql';
 export type SmartLinkConfig = {
   id: string;
   icon: string;
+  tenantName: string;
+  bannerImgUrl: string;
   blockchainType: Types.BlockchainType;
   name: string;
   description: string;
@@ -25,21 +27,22 @@ export type SmartLinkImg = {
 export type SmartLinkAction = {
   type: 'ACTION';
   id: string;
-  inputs: ActionInput[];
+  inputs: ActionInputParams[];
   label: string /** This is the label that will be displayed on Action button */;
 };
 
-export type ActionInput =
-  | ActionInputTextBox<'NUMBER'>
-  | ActionInputTextBox<'TEXT'>
-  | ActionInputCheckBox;
+export type ActionInputParams =
+  | ActionInputParamsTextBox<'NUMBER'>
+  | ActionInputParamsTextBox<'TEXT'>
+  | ActionInputParamsCheckBox;
 
-type ActionInputBase = {
+type ActionInputBaseParams = {
   isRequired: boolean;
+  id: string;
 };
 
-export type ActionInputTextBox<T extends 'TEXT' | 'NUMBER'> =
-  ActionInputBase & {
+export type ActionInputParamsTextBox<T extends 'TEXT' | 'NUMBER'> =
+  ActionInputBaseParams & {
     type: 'TEXTBOX';
     inputType: T;
     placeholder: T extends 'NUMBER' ? number : string;
@@ -49,7 +52,7 @@ export type ActionInputTextBox<T extends 'TEXT' | 'NUMBER'> =
     suffix?: string;
   };
 
-export type ActionInputCheckBox = ActionInputBase & {
+export type ActionInputParamsCheckBox = ActionInputBaseParams & {
   type: 'CHECKBOX';
   title: string;
 };

--- a/packages/notifi-react/lib/components/ActionInputCheckBox.tsx
+++ b/packages/notifi-react/lib/components/ActionInputCheckBox.tsx
@@ -1,4 +1,4 @@
-import { ActionInputCheckBox as ActionInputCheckBoxType } from '@notifi-network/notifi-frontend-client';
+import { ActionInputParamsCheckBox as ActionInputCheckBoxType } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import React from 'react';
 

--- a/packages/notifi-react/lib/components/ActionInputTextBoxNumber.tsx
+++ b/packages/notifi-react/lib/components/ActionInputTextBoxNumber.tsx
@@ -1,4 +1,4 @@
-import { ActionInputTextBox as ActionInputTextBoxType } from '@notifi-network/notifi-frontend-client';
+import { ActionInputParamsTextBox as ActionInputTextBoxType } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import React from 'react';
 

--- a/packages/notifi-react/lib/components/ActionInputTextBoxString.tsx
+++ b/packages/notifi-react/lib/components/ActionInputTextBoxString.tsx
@@ -1,9 +1,9 @@
-import { ActionInputTextBox } from '@notifi-network/notifi-frontend-client';
+import { ActionInputParamsTextBox } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import React from 'react';
 
 export type ActionInputTextBoxStringProps = {
-  input: ActionInputTextBox<'TEXT'>;
+  input: ActionInputParamsTextBox<'TEXT'>;
   userInputId: number; // TODO: for exec action
   classNames?: {
     container?: string;

--- a/packages/notifi-react/lib/components/NotifiSmartLink.tsx
+++ b/packages/notifi-react/lib/components/NotifiSmartLink.tsx
@@ -6,7 +6,6 @@ import clsx from 'clsx';
 import React from 'react';
 
 import { useNotifiSmartLinkContext } from '../context/NotifiSmartLinkContext';
-import { defaultCopy } from '../utils';
 import { ErrorView, ErrorViewProps } from './ErrorView';
 import { SmartLinkAction, SmartLinkActionProps } from './SmartLinkAction';
 
@@ -75,7 +74,7 @@ export const NotifiSmartLink: React.FC<NotifiSmartLinkProps> = (props) => {
     >
       <img
         className={clsx('notifi-smartlink-banner', props.classNames?.image)}
-        src={smartLinkConfig.icon}
+        src={smartLinkConfig.bannerImgUrl}
       />
       <div className={clsx('notifi-smartlink-name', props.classNames?.name)}>
         <img
@@ -83,10 +82,10 @@ export const NotifiSmartLink: React.FC<NotifiSmartLinkProps> = (props) => {
             'notifi-smartlink-namelogo',
             props.classNames?.nameLogo,
           )}
-          src={props.nameLogoSrc ?? defaultCopy.smartLink.nameLogoSrc}
+          src={smartLinkConfig.icon}
           alt="name-img"
         />
-        <div>{smartLinkConfig.name}</div>
+        <div>{smartLinkConfig.tenantName}</div>
       </div>
       <div className={clsx('notifi-smartlink-title', props.classNames?.title)}>
         {smartLinkConfig.title}

--- a/packages/notifi-react/lib/components/SmartLinkAction.tsx
+++ b/packages/notifi-react/lib/components/SmartLinkAction.tsx
@@ -1,8 +1,8 @@
 import {
   SmartLinkAction as Action,
-  ActionInput,
-  ActionInputCheckBox as ActionInputCheckBoxType,
-  ActionInputTextBox,
+  ActionInputParamsCheckBox as ActionInputCheckBoxType,
+  ActionInputParams,
+  ActionInputParamsTextBox,
 } from '@notifi-network/notifi-frontend-client';
 import clsx from 'clsx';
 import React from 'react';
@@ -92,8 +92,8 @@ export const SmartLinkAction: React.FC<SmartLinkActionProps> = (props) => {
 // Utils
 // TODO: move to utils?
 const isNumberTextBox = (
-  input: ActionInput,
-): input is ActionInputTextBox<'NUMBER'> => {
+  input: ActionInputParams,
+): input is ActionInputParamsTextBox<'NUMBER'> => {
   if (input.type !== 'TEXTBOX') {
     return false;
   }
@@ -101,14 +101,16 @@ const isNumberTextBox = (
 };
 
 const isStringTextBox = (
-  input: ActionInput,
-): input is ActionInputTextBox<'TEXT'> => {
+  input: ActionInputParams,
+): input is ActionInputParamsTextBox<'TEXT'> => {
   if (input.type !== 'TEXTBOX') {
     return false;
   }
   return input.inputType === 'TEXT';
 };
-const isCheckBox = (input: ActionInput): input is ActionInputCheckBoxType => {
+const isCheckBox = (
+  input: ActionInputParams,
+): input is ActionInputCheckBoxType => {
   if (input.type !== 'CHECKBOX') {
     return false;
   }

--- a/packages/notifi-react/lib/context/NotifiSmartLinkContext.tsx
+++ b/packages/notifi-react/lib/context/NotifiSmartLinkContext.tsx
@@ -1,6 +1,6 @@
 import { SmartLinkActionUserInput } from '@notifi-network/notifi-dataplane';
 import {
-  ActionInput,
+  ActionInputParams,
   AuthParams,
   type ExecuteSmartLinkActionArgs,
   type NotifiEnvironment,
@@ -39,7 +39,7 @@ type ActionDictionary = Record<
   string,
   {
     smartLinkId: string;
-    inputParams: ActionInput[];
+    inputParams: ActionInputParams[];
     userInputs: Record<number, SmartLinkActionUserInput>;
   }
 >;
@@ -221,8 +221,8 @@ const getActionDictionary = (
         (acc: Record<number, SmartLinkActionUserInput>, input, id) => {
           const userInput: SmartLinkActionUserInput =
             input.type === 'TEXTBOX'
-              ? { type: 'TEXTBOX', value: input.default }
-              : { type: 'CHECKBOX', value: false };
+              ? { type: 'TEXTBOX', value: input.default, id: input.id }
+              : { type: 'CHECKBOX', value: false, id: input.id };
           acc[id] = userInput;
           return acc;
         },

--- a/packages/notifi-react/lib/utils/constants.ts
+++ b/packages/notifi-react/lib/utils/constants.ts
@@ -112,7 +112,4 @@ export const defaultCopy = {
     inValidErrorMessage: (target: Target) =>
       `Please enter a valid ${target} address`,
   },
-  smartLink: {
-    nameLogoSrc: 'https://dev.notifi.network/images/icon-logomark-default.jpg',
-  },
 };


### PR DESCRIPTION
- Describe the purpose of the change
  Follow-up ticket for #832 
    - New fields for SmartLinkConfig: `tenantName` & `bannerImgUrl`
    - New fields for SmartLinkAction: `id` in inputs

> ⚠️  NOTE:
> - Test needed once BE supports tenantName & bannerImgUrl in SmartLinkConfig
CC: @kai-notifi 