### PR TITLE
MVP-6295: Support sendTransaction for EVM chains in notifi-wallet-provider

### DIFF
--- a/packages/notifi-react-example-v2/src/app/notifi/smart-link-example/page.tsx
+++ b/packages/notifi-react-example-v2/src/app/notifi/smart-link-example/page.tsx
@@ -2,10 +2,12 @@
 
 import { NotifiSmartLink } from '@notifi-network/notifi-react';
 import '@notifi-network/notifi-react/dist/index.css';
+import { useWallets } from '@notifi-network/notifi-wallet-provider';
 import React from 'react';
 
 export default function NotifiSmartLinkExample() {
   const [smartLinkId, setSmartLinkId] = React.useState<string>();
+  const { wallets, selectedWallet } = useWallets();
   return (
     <div>
       <input
@@ -21,9 +23,42 @@ export default function NotifiSmartLinkExample() {
           smartLinkId={smartLinkId}
           actionHandler={async (args) => {
             console.log('actionHandler', args);
+            console.log({ selectedWallet });
+            if (!selectedWallet) return;
+            if ('sendTransaction' in wallets[selectedWallet]) {
+              // TODO: Below only for test sending transaction, need remove
+              // if (selectedWallet === 'metamask') {
+              //   wallets[selectedWallet].sendTransaction({
+              //     from: wallets[selectedWallet].walletKeys?.hex,
+              //     to: wallets[selectedWallet].walletKeys?.hex,
+              //   });
+              // }
+
+              // TODO: Impl executeAction (Payload is {} for now)
+              const { payload } = args;
+              const encodedTxs = payload.transactions;
+              // TODO: Serialize the transaction
+              if (!encodedTxs) return;
+              for (const encodedTx of encodedTxs) {
+                const wa = wallets[selectedWallet];
+                const { blockchainType, UnsignedTransaction } = encodedTx;
+                const serializedTx = serializeTx(UnsignedTransaction);
+                if (selectedWallet === 'metamask') {
+                  // TODO: Sign the transaction
+                  await wallets[selectedWallet].sendTransaction(serializedTx);
+                }
+              }
+            }
           }}
         />
       ) : null}
     </div>
   );
 }
+
+// Utils
+
+const serializeTx = (encodedTx: string): object => {
+  // TODO: Implement the serialization logic
+  return {};
+};

--- a/packages/notifi-react-example-v2/src/app/notifi/smart-link-example/page.tsx
+++ b/packages/notifi-react-example-v2/src/app/notifi/smart-link-example/page.tsx
@@ -27,27 +27,27 @@ export default function NotifiSmartLinkExample() {
             if (!selectedWallet) return;
             if ('sendTransaction' in wallets[selectedWallet]) {
               // TODO: Below only for test sending transaction, need remove
-              // if (selectedWallet === 'metamask') {
-              //   wallets[selectedWallet].sendTransaction({
-              //     from: wallets[selectedWallet].walletKeys?.hex,
-              //     to: wallets[selectedWallet].walletKeys?.hex,
-              //   });
-              // }
+              if (selectedWallet === 'metamask') {
+                wallets[selectedWallet].sendTransaction({
+                  from: wallets[selectedWallet].walletKeys?.hex,
+                  to: wallets[selectedWallet].walletKeys?.hex,
+                });
+              }
 
               // TODO: Impl executeAction (Payload is {} for now)
-              const { payload } = args;
-              const encodedTxs = payload.transactions;
-              // TODO: Serialize the transaction
-              if (!encodedTxs) return;
-              for (const encodedTx of encodedTxs) {
-                const wa = wallets[selectedWallet];
-                const { blockchainType, UnsignedTransaction } = encodedTx;
-                const serializedTx = serializeTx(UnsignedTransaction);
-                if (selectedWallet === 'metamask') {
-                  // TODO: Sign the transaction
-                  await wallets[selectedWallet].sendTransaction(serializedTx);
-                }
-              }
+              // const { payload } = args;
+              // const encodedTxs = payload.transactions;
+              // Serialize the transaction
+              // if (!encodedTxs) return;
+              // for (const encodedTx of encodedTxs) {
+              //   const wa = wallets[selectedWallet];
+              //   const { blockchainType, UnsignedTransaction } = encodedTx;
+              //   const serializedTx = serializeTx(UnsignedTransaction);
+              //   if (selectedWallet === 'metamask') {
+              //     // TODO: Sign the transaction
+              //     await wallets[selectedWallet].sendTransaction(serializedTx);
+              //   }
+              // }
             }
           }}
         />

--- a/packages/notifi-wallet-provider/lib/context/NotifiWallets.tsx
+++ b/packages/notifi-wallet-provider/lib/context/NotifiWallets.tsx
@@ -14,17 +14,13 @@ import { useWagmiWallet } from '../hooks/useWagmiWallet';
 import { useXion } from '../hooks/useXion';
 import {
   BinanceWallet,
-  CoinbaseWallet,
-  KeplrWallet,
-  MetamaskWallet,
-  OKXWallet,
-  PhantomWallet,
-  RabbyWallet,
-  RainbowWallet,
-  WalletConnectWallet,
+  EvmWallet, // CoinbaseWallet,
+  KeplrWallet, // MetamaskWallet,
+  // OKXWallet,
+  PhantomWallet, // RabbyWallet,
+  // RainbowWallet,
   Wallets,
-  XionWallet,
-  ZerionWallet,
+  XionWallet, // ZerionWallet,
 } from '../types';
 import { getWalletsFromLocalStorage } from '../utils/localStorageUtils';
 import { NotifiWagmiProvider } from './WagmiProvider';
@@ -46,17 +42,17 @@ const WalletContext = createContext<WalletContextType>({
     console.log('Not implemented');
   },
   wallets: {
-    metamask: {} as MetamaskWallet, // intentionally empty initial object
-    keplr: {} as KeplrWallet, // intentionally empty initial object
-    coinbase: {} as CoinbaseWallet, // intentionally empty initial object
-    rabby: {} as RabbyWallet, // intentionally empty initial object
-    rainbow: {} as RainbowWallet, // intentionally empty initial object
-    zerion: {} as ZerionWallet, // intentionally empty initial object
-    okx: {} as OKXWallet, // intentionally empty initial object
-    binance: {} as BinanceWallet, // intentionally empty initial object
-    walletconnect: {} as WalletConnectWallet, // intentionally empty initial object
-    xion: {} as XionWallet, // intentionally empty initial object
-    phantom: {} as PhantomWallet, // intentionally empty initial object
+    metamask: {} as EvmWallet,
+    keplr: {} as KeplrWallet,
+    coinbase: {} as EvmWallet,
+    rabby: {} as EvmWallet,
+    rainbow: {} as EvmWallet,
+    zerion: {} as EvmWallet,
+    okx: {} as EvmWallet,
+    binance: {} as BinanceWallet, // TODO: migrate to EvmWallet & useInjectedWallet
+    walletconnect: {} as EvmWallet,
+    xion: {} as XionWallet,
+    phantom: {} as PhantomWallet,
   },
   error: null,
   isLoading: false,
@@ -91,8 +87,8 @@ const NotifiWallet: React.FC<PropsWithChildren> = ({ children }) => {
     }, durationInMs ?? 5000);
   };
 
-  const keplr = useKeplr(setIsLoading, throwError, selectWallet);
-  const binance = useBinance(setIsLoading, throwError, selectWallet);
+  /* Wallet instances */
+  /* - Wagmi wallet instances */
   const walletConnect = useWagmiWallet(
     setIsLoading,
     throwError,
@@ -105,6 +101,8 @@ const NotifiWallet: React.FC<PropsWithChildren> = ({ children }) => {
     selectWallet,
     'coinbase',
   );
+
+  /* - Injected wallet instances */
   const metamask = useInjectedWallet(
     setIsLoading,
     throwError,
@@ -130,42 +128,51 @@ const NotifiWallet: React.FC<PropsWithChildren> = ({ children }) => {
     selectWallet,
     'rainbow',
   );
+
+  /* - Independent unusable instance - (TODO: should try to migrate to using browser native integration to lighten pkg weight)  */
   const xion = useXion(setIsLoading, throwError, selectWallet, 'xion');
 
+  /* - Browser native integration instances */
+  const keplr = useKeplr(setIsLoading, throwError, selectWallet);
+  const binance = useBinance(setIsLoading, throwError, selectWallet); // TODO: migrate to EvmWallet & useInjectedWallet
   const phantom = usePhantom(setIsLoading, throwError, selectWallet);
 
   const wallets: Wallets = {
-    metamask: new MetamaskWallet(
+    metamask: new EvmWallet(
       metamask.isWalletInstalled,
       metamask.walletKeys,
       metamask.signArbitrary,
       metamask.connectWallet,
       metamask.disconnectWallet,
       metamask.websiteURL,
+      metamask.sendTransaction,
     ),
-    coinbase: new CoinbaseWallet(
+    coinbase: new EvmWallet(
       coinbase.isWalletInstalled,
       coinbase.walletKeys,
       coinbase.signArbitrary,
       coinbase.connectWallet,
       coinbase.disconnectWallet,
       coinbase.websiteURL,
+      coinbase.sendTransaction,
     ),
-    rabby: new RabbyWallet(
+    rabby: new EvmWallet(
       rabby.isWalletInstalled,
       rabby.walletKeys,
       rabby.signArbitrary,
       rabby.connectWallet,
       rabby.disconnectWallet,
       rabby.websiteURL,
+      rabby.sendTransaction,
     ),
-    walletconnect: new WalletConnectWallet(
+    walletconnect: new EvmWallet(
       walletConnect.isWalletInstalled,
       walletConnect.walletKeys,
       walletConnect.signArbitrary,
       walletConnect.connectWallet,
       walletConnect.disconnectWallet,
       walletConnect.websiteURL,
+      walletConnect.sendTransaction,
     ),
     binance: new BinanceWallet(
       binance.isWalletInstalled,
@@ -174,30 +181,34 @@ const NotifiWallet: React.FC<PropsWithChildren> = ({ children }) => {
       binance.connectWallet,
       binance.disconnectWallet,
       binance.websiteURL,
+      binance.sendTransaction,
     ),
-    okx: new OKXWallet(
+    okx: new EvmWallet(
       okx.isWalletInstalled,
       okx.walletKeys,
       okx.signArbitrary,
       okx.connectWallet,
       okx.disconnectWallet,
       okx.websiteURL,
+      okx.sendTransaction,
     ),
-    rainbow: new RainbowWallet(
+    rainbow: new EvmWallet(
       rainbow.isWalletInstalled,
       rainbow.walletKeys,
       rainbow.signArbitrary,
       rainbow.connectWallet,
       rainbow.disconnectWallet,
       rainbow.websiteURL,
+      rainbow.sendTransaction,
     ),
-    zerion: new ZerionWallet(
+    zerion: new EvmWallet(
       zerion.isWalletInstalled,
       zerion.walletKeys,
       zerion.signArbitrary,
       zerion.connectWallet,
       zerion.disconnectWallet,
       zerion.websiteURL,
+      zerion.sendTransaction,
     ),
     keplr: new KeplrWallet(
       keplr.isKeplrInstalled,

--- a/packages/notifi-wallet-provider/lib/context/NotifiWallets.tsx
+++ b/packages/notifi-wallet-provider/lib/context/NotifiWallets.tsx
@@ -14,13 +14,11 @@ import { useWagmiWallet } from '../hooks/useWagmiWallet';
 import { useXion } from '../hooks/useXion';
 import {
   BinanceWallet,
-  EvmWallet, // CoinbaseWallet,
-  KeplrWallet, // MetamaskWallet,
-  // OKXWallet,
-  PhantomWallet, // RabbyWallet,
-  // RainbowWallet,
+  EvmWallet,
+  KeplrWallet,
+  PhantomWallet,
   Wallets,
-  XionWallet, // ZerionWallet,
+  XionWallet,
 } from '../types';
 import { getWalletsFromLocalStorage } from '../utils/localStorageUtils';
 import { NotifiWagmiProvider } from './WagmiProvider';

--- a/packages/notifi-wallet-provider/lib/hooks/useBinance.ts
+++ b/packages/notifi-wallet-provider/lib/hooks/useBinance.ts
@@ -148,6 +148,32 @@ export const useBinance = (
     },
     [walletKeys?.hex],
   );
+  // TODO: define the type of transactions
+  const sendTransaction = async (transaction: object) => {
+    let txHash: string | undefined;
+    if (!provider || !walletKeys) {
+      handleWalletNotExists('Sign Arbitrary');
+      return;
+    }
+    try {
+      txHash = await provider.request?.({
+        method: 'eth_sendTransaction',
+        params: [transaction],
+      });
+    } catch (e) {
+      errorHandler(
+        new Error(
+          'useInjectedWallet-sendTransaction: Failed to send transaction',
+        ),
+        5000,
+      );
+      console.error(e);
+    } finally {
+      loadingHandler(false);
+    }
+    // TODO: add validator for txHash
+    return txHash as `0x${string}` | undefined;
+  };
 
   return {
     walletKeys,
@@ -156,6 +182,7 @@ export const useBinance = (
     signArbitrary,
     disconnectWallet,
     websiteURL: walletsWebsiteLink[walletName],
+    sendTransaction,
   };
 };
 

--- a/packages/notifi-wallet-provider/lib/hooks/useInjectedWallet.ts
+++ b/packages/notifi-wallet-provider/lib/hooks/useInjectedWallet.ts
@@ -144,6 +144,28 @@ export const useInjectedWallet = (
     },
     [walletKeys?.hex],
   );
+  // TODO: define the type of transactions
+  const sendTransaction = async (transaction: object) => {
+    let txHash: string | undefined;
+    try {
+      txHash = await provider.request?.({
+        method: 'eth_sendTransaction',
+        params: [transaction],
+      });
+    } catch (e) {
+      errorHandler(
+        new Error(
+          'useInjectedWallet-sendTransaction: Failed to send transaction',
+        ),
+        5000,
+      );
+      console.error(e);
+    } finally {
+      loadingHandler(false);
+    }
+    // TODO: add validator for txHash
+    return txHash as `0x${string}` | undefined;
+  };
 
   return {
     walletKeys,
@@ -151,6 +173,7 @@ export const useInjectedWallet = (
     connectWallet,
     signArbitrary,
     disconnectWallet,
+    sendTransaction,
     websiteURL: walletsWebsiteLink[walletName],
   };
 };

--- a/packages/notifi-wallet-provider/lib/hooks/useWagmiWallet.ts
+++ b/packages/notifi-wallet-provider/lib/hooks/useWagmiWallet.ts
@@ -1,6 +1,13 @@
 import converter from 'bech32-converting';
 import { useCallback, useEffect, useState } from 'react';
-import { useAccount, useConnect, useDisconnect, useSignMessage } from 'wagmi';
+import {
+  useAccount,
+  useConnect,
+  useDisconnect,
+  useSendTransaction,
+  useSignMessage,
+} from 'wagmi';
+import { SendTransactionArgs, SendTransactionResult } from 'wagmi/actions';
 
 import { MetamaskWalletKeys, Wallets } from '../types';
 import {
@@ -20,6 +27,8 @@ export const useWagmiWallet = (
 
   const { disconnect } = useDisconnect();
   const { signMessageAsync } = useSignMessage();
+  // TODO: figure out config
+  const { sendTransactionAsync } = useSendTransaction();
   const { address, isConnected: isWalletConnected, connector } = useAccount();
   const { connect, connectors } = useConnect();
 
@@ -125,6 +134,21 @@ export const useWagmiWallet = (
     },
     [walletKeys?.hex],
   );
+  const sendTransaction = async (transaction: SendTransactionArgs) => {
+    let result: SendTransactionResult | undefined;
+    try {
+      result = await sendTransactionAsync(transaction);
+    } catch (e) {
+      errorHandler(
+        new Error('useWagmi-sendTransaction: Failed to send transaction'),
+        5000,
+      );
+      console.error(e);
+    } finally {
+      loadingHandler(false);
+    }
+    return result?.hash;
+  };
 
   return {
     walletKeys,
@@ -133,5 +157,6 @@ export const useWagmiWallet = (
     signArbitrary,
     disconnectWallet,
     websiteURL: walletsWebsiteLink[walletName],
+    sendTransaction,
   };
 };

--- a/packages/notifi-wallet-provider/lib/types.ts
+++ b/packages/notifi-wallet-provider/lib/types.ts
@@ -30,7 +30,7 @@ export type WalletKeysBase = {
   grantee: string; //TODO: specifically for Xion now, make it generic pattern, checking the format
 };
 
-export type MetamaskWalletKeys = PickKeys<WalletKeysBase, 'bech32' | 'hex'>;
+export type MetamaskWalletKeys = PickKeys<WalletKeysBase, 'bech32' | 'hex'>; // TODO: rename to EvmWalletKeys
 export type KeplrWalletKeys = PickKeys<WalletKeysBase, 'bech32' | 'base64'>;
 export type XionWalletKeys = PickKeys<
   WalletKeysBase,
@@ -53,7 +53,7 @@ export abstract class NotifiWallet {
     | XionSignMessage
     | PhantomSignMessage;
   // TODO: Impl sendTransaction for Keplr and Xion
-  abstract sendTransaction?: any;
+  abstract sendTransaction?: EvmSendTransaction;
   abstract connect?: () => Promise<Partial<WalletKeysBase> | null>;
   abstract disconnect?: () => void;
   abstract websiteURL: string;
@@ -67,27 +67,16 @@ export type NotifiWalletStorage = {
 export type PickKeys<T, K extends keyof T> = Pick<T, K>;
 export type MetamaskSignMessage = (
   message: string,
-) => Promise<`0x${string}` | undefined>;
+) => Promise<`0x${string}` | undefined>; // TODO: rename to EvmSignMessage
 
 export type MetamaskSendTransaction = (
   transaction: object[],
 ) => Promise<`0x${string}` | undefined>;
+
 export type EvmSendTransaction = (
   transaction: any, // TODO: Two types 1. raw payload 2. Wagmi wrapped payload
 ) => Promise<`0x${string}` | undefined>;
 
-// export class MetamaskWallet implements NotifiWallet {
-//   constructor(
-//     public isInstalled: boolean,
-//     public walletKeys: MetamaskWalletKeys | null,
-//     public signArbitrary: MetamaskSignMessage,
-//     public connect: () => Promise<MetamaskWalletKeys | null>,
-//     public disconnect: () => void,
-//     public websiteURL: string,
-//     public sendTransaction: MetamaskSendTransaction,
-//   ) {}
-// }
-// TODO: Refactor to has EVM chain base
 export class EvmWallet implements NotifiWallet {
   constructor(
     public isInstalled: boolean,
@@ -111,14 +100,6 @@ export class BinanceWallet implements NotifiWallet {
     public sendTransaction: MetamaskSendTransaction,
   ) {}
 }
-
-// TODO: Consolidate WagmiWallet and MetamaskWallet
-// export class CoinbaseWallet extends WagmiWallet {}
-// export class WalletConnectWallet extends WagmiWallet {}
-// export class RabbyWallet extends MetamaskWallet {}
-// export class ZerionWallet extends MetamaskWallet {}
-// export class OKXWallet extends MetamaskWallet {}
-// export class RainbowWallet extends MetamaskWallet {}
 
 export type KeplrSignMessage = (
   message: string | Uint8Array,

--- a/packages/notifi-wallet-provider/lib/types.ts
+++ b/packages/notifi-wallet-provider/lib/types.ts
@@ -1,6 +1,7 @@
 import type { Keplr, StdSignature } from '@keplr-wallet/types';
 import { Connection, Transaction } from '@solana/web3.js';
 import { BrowserProvider, Eip1193Provider } from 'ethers';
+import { SendTransactionArgs } from 'wagmi/actions';
 
 import { PhantomProvider } from './utils/solana.type';
 
@@ -51,6 +52,8 @@ export abstract class NotifiWallet {
     | MetamaskSignMessage
     | XionSignMessage
     | PhantomSignMessage;
+  // TODO: Impl sendTransaction for Keplr and Xion
+  abstract sendTransaction?: any;
   abstract connect?: () => Promise<Partial<WalletKeysBase> | null>;
   abstract disconnect?: () => void;
   abstract websiteURL: string;
@@ -66,7 +69,26 @@ export type MetamaskSignMessage = (
   message: string,
 ) => Promise<`0x${string}` | undefined>;
 
-export class MetamaskWallet implements NotifiWallet {
+export type MetamaskSendTransaction = (
+  transaction: object[],
+) => Promise<`0x${string}` | undefined>;
+export type EvmSendTransaction = (
+  transaction: any, // TODO: Two types 1. raw payload 2. Wagmi wrapped payload
+) => Promise<`0x${string}` | undefined>;
+
+// export class MetamaskWallet implements NotifiWallet {
+//   constructor(
+//     public isInstalled: boolean,
+//     public walletKeys: MetamaskWalletKeys | null,
+//     public signArbitrary: MetamaskSignMessage,
+//     public connect: () => Promise<MetamaskWalletKeys | null>,
+//     public disconnect: () => void,
+//     public websiteURL: string,
+//     public sendTransaction: MetamaskSendTransaction,
+//   ) {}
+// }
+// TODO: Refactor to has EVM chain base
+export class EvmWallet implements NotifiWallet {
   constructor(
     public isInstalled: boolean,
     public walletKeys: MetamaskWalletKeys | null,
@@ -74,15 +96,29 @@ export class MetamaskWallet implements NotifiWallet {
     public connect: () => Promise<MetamaskWalletKeys | null>,
     public disconnect: () => void,
     public websiteURL: string,
+    public sendTransaction: EvmSendTransaction,
   ) {}
 }
-export class CoinbaseWallet extends MetamaskWallet {}
-export class RabbyWallet extends MetamaskWallet {}
-export class ZerionWallet extends MetamaskWallet {}
-export class OKXWallet extends MetamaskWallet {}
-export class RainbowWallet extends MetamaskWallet {}
-export class BinanceWallet extends MetamaskWallet {}
-export class WalletConnectWallet extends MetamaskWallet {}
+
+export class BinanceWallet implements NotifiWallet {
+  constructor(
+    public isInstalled: boolean,
+    public walletKeys: MetamaskWalletKeys | null,
+    public signArbitrary: MetamaskSignMessage,
+    public connect: () => Promise<MetamaskWalletKeys | null>,
+    public disconnect: () => void,
+    public websiteURL: string,
+    public sendTransaction: MetamaskSendTransaction,
+  ) {}
+}
+
+// TODO: Consolidate WagmiWallet and MetamaskWallet
+// export class CoinbaseWallet extends WagmiWallet {}
+// export class WalletConnectWallet extends WagmiWallet {}
+// export class RabbyWallet extends MetamaskWallet {}
+// export class ZerionWallet extends MetamaskWallet {}
+// export class OKXWallet extends MetamaskWallet {}
+// export class RainbowWallet extends MetamaskWallet {}
 
 export type KeplrSignMessage = (
   message: string | Uint8Array,
@@ -131,15 +167,15 @@ export class PhantomWallet implements NotifiWallet {
 }
 
 export type Wallets = {
-  metamask: MetamaskWallet;
+  metamask: EvmWallet;
   keplr: KeplrWallet;
-  coinbase: CoinbaseWallet;
-  rabby: RabbyWallet;
-  rainbow: RainbowWallet;
-  zerion: ZerionWallet;
-  okx: OKXWallet;
+  coinbase: EvmWallet;
+  rabby: EvmWallet;
+  rainbow: EvmWallet;
+  zerion: EvmWallet;
+  okx: EvmWallet;
   binance: BinanceWallet;
-  walletconnect: WalletConnectWallet;
+  walletconnect: EvmWallet;
   xion: XionWallet;
   phantom: PhantomWallet;
 };


### PR DESCRIPTION
- Describe the purpose of the change

This adds `sendTransaction` method support in notifi-wallet-provider. (Only Support EVM as MVP)
Under test, once done, merge and publish a canary version.