### PR TITLE
MVP-6355-patch: support reseting userInput to initial state/  handle edge cases of user inputs

### DIFF
--- a/packages/notifi-react-example-v2/src/components/NotifiSmartLinkExample.tsx
+++ b/packages/notifi-react-example-v2/src/components/NotifiSmartLinkExample.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 
 export const NotifiSmartLinkExample: React.FC = () => {
   const { wallets, selectedWallet } = useWallets();
-  const { authParams } = useNotifiSmartLinkContext();
+  const { authParams, updateActionUserInputs } = useNotifiSmartLinkContext();
   const currentPath = usePathname();
 
   const smartLinkId = React.useMemo(() => {
@@ -62,9 +62,16 @@ export const NotifiSmartLinkExample: React.FC = () => {
             if (!selectedWallet || selectedWallet !== 'metamask') return;
             if (!args.payload.transactions) return;
 
-            await wallets[selectedWallet].sendTransaction(
-              JSON.parse(args.payload.transactions[0].UnsignedTransaction),
-            );
+            const smartLinkIdWithActionId: `${string}:;:${string}` = `${args.smartLinkId}:;:${args.actionId}`;
+
+            try {
+              await wallets[selectedWallet].sendTransaction(
+                JSON.parse(args.payload.transactions[0].UnsignedTransaction),
+              );
+            } finally {
+              /* Reset the user inputs to the initial state */
+              updateActionUserInputs(smartLinkIdWithActionId);
+            }
           }}
         />
       </div>

--- a/packages/notifi-react/lib/components/ActionInputCheckBox.tsx
+++ b/packages/notifi-react/lib/components/ActionInputCheckBox.tsx
@@ -24,9 +24,15 @@ export const ActionInputCheckBox: React.FC<ActionInputCheckBoxProps> = (
   const { updateActionUserInputs, actionDictionary } =
     useNotifiSmartLinkContext();
 
-  const defaultValue = actionDictionary[props.smartLinkIdWithActionId]
-    .userInputs[props.userInputId].userInput.value as boolean;
-  const [value, setValue] = React.useState<boolean>(defaultValue);
+  const [value, setValue] = React.useState<boolean>(false);
+
+  React.useEffect(() => {
+    const value = actionDictionary[props.smartLinkIdWithActionId].userInputs[
+      props.userInputId
+    ].userInput.value as boolean;
+    setValue(value);
+  }, [actionDictionary, props.smartLinkIdWithActionId, props.userInputId]);
+
   const validateAndUpdateActionInputs = (
     e: React.ChangeEvent<HTMLInputElement>,
   ) => {

--- a/packages/notifi-react/lib/components/ActionInputTextBoxNumber.tsx
+++ b/packages/notifi-react/lib/components/ActionInputTextBoxNumber.tsx
@@ -24,9 +24,14 @@ export const ActionInputTextBoxNumber: React.FC<
 > = (props: ActionInputTextBoxNumberProps) => {
   const { updateActionUserInputs, actionDictionary } =
     useNotifiSmartLinkContext();
-  const defaultValue = actionDictionary[props.smartLinkIdWithActionId]
-    .userInputs[props.userInputId].userInput.value as number | '';
-  const [value, setValue] = React.useState<number | ''>(defaultValue);
+  const [value, setValue] = React.useState<number | ''>('');
+
+  React.useEffect(() => {
+    const value = actionDictionary[props.smartLinkIdWithActionId].userInputs[
+      props.userInputId
+    ].userInput.value as number | '';
+    setValue(value);
+  }, [actionDictionary, props.smartLinkIdWithActionId, props.userInputId]);
 
   const validateAndUpdateActionInputs = (
     e: React.ChangeEvent<HTMLInputElement>,

--- a/packages/notifi-react/lib/components/ActionInputTextBoxString.tsx
+++ b/packages/notifi-react/lib/components/ActionInputTextBoxString.tsx
@@ -24,9 +24,14 @@ export const ActionInputTextBoxString: React.FC<
   const [isValid, setIsValid] = React.useState<boolean>(true);
   const { updateActionUserInputs, actionDictionary } =
     useNotifiSmartLinkContext();
-  const defaultValue = actionDictionary[props.smartLinkIdWithActionId]
-    .userInputs[props.userInputId].userInput.value as string;
-  const [value, setValue] = React.useState<string>(defaultValue);
+  const [value, setValue] = React.useState<string>('');
+
+  React.useEffect(() => {
+    const value = actionDictionary[props.smartLinkIdWithActionId].userInputs[
+      props.userInputId
+    ].userInput.value as string | '';
+    setValue(value);
+  }, [actionDictionary, props.smartLinkIdWithActionId, props.userInputId]);
 
   const validateAndUpdateActionInputs = (
     e: React.ChangeEvent<HTMLInputElement>,
@@ -36,7 +41,12 @@ export const ActionInputTextBoxString: React.FC<
     const isPatternValid = new RegExp(
       props.input.constraintType?.pattern || '',
     );
-    const isConstraintMet = isInputValid && isPatternValid.test(input.value);
+    const isConstraintMet = props.input.isRequired
+      ? /* If the input is required, check if the input is valid and the pattern matches */
+        isInputValid && isPatternValid.test(input.value) && input.value !== ''
+      : /* If the input is NOT required, check if the pattern matches or the input is empty */
+        isPatternValid.test(input.value) || input.value === '';
+
     setIsValid(isConstraintMet);
 
     setValue(input.value);
@@ -47,7 +57,7 @@ export const ActionInputTextBoxString: React.FC<
           type: 'TEXTBOX',
           value: input.value,
         },
-        isValid: props.input.isRequired ? isConstraintMet : true,
+        isValid: isConstraintMet,
       },
     });
   };


### PR DESCRIPTION

- **Describe the purpose of the change**  
   - Allows resetting `userInputs` by omitting the `userInput` argument when calling `updateActionUserInputs`. This enables consuming projects to reset input fields to their initial values.  
   - Optimizes `ActionInput` components by addressing certain edge cases.
