### PR TITLE
MVP-6355-patch4: address UAT feedbacks

### DIFF
--- a/packages/notifi-react/lib/components/ActionInputTextBoxNumber.tsx
+++ b/packages/notifi-react/lib/components/ActionInputTextBoxNumber.tsx
@@ -49,7 +49,6 @@ export const ActionInputTextBoxNumber: React.FC<
     }
     /* If the input is a decimal number and the length of the decimal part is greater than step, remove the last digit */
     const [_, decimalPart] = valueToSet.toString().split('.');
-    console.log({ valueToSet, decimalPart });
     if (decimalPart && decimalPart.length > step && valueToSet !== '') {
       valueToSet = Number(valueToSet.toString().slice(0, -1));
     }
@@ -107,6 +106,9 @@ export const ActionInputTextBoxNumber: React.FC<
           )}
           value={value}
           required={props.input.isRequired}
+          onKeyDown={(e) =>
+            ['e', 'E', '+', '-'].includes(e.key) && e.preventDefault()
+          }
           onChange={validateAndUpdateActionInputs}
         />
         {props.input.suffix ? (

--- a/packages/notifi-react/lib/style/smartlink.css
+++ b/packages/notifi-react/lib/style/smartlink.css
@@ -111,6 +111,7 @@
   font-size: 0.75rem;
   color: var(--notifi-smartlink-action-input-textbox-constraint-prompt-text);
   text-align: right;
+  font-weight: 600;
 }
 
 .notifi-smartlink-action-input-textbox-container {


### PR DESCRIPTION

Address the following two UAT feedbacks:
1. Bold the number input constraint prompt
2. Block character 'e' & 'E' in input type number 