### PR TITLE
patch: fix peerDependencies conflict

### DIFF
--- a/packages/notifi-react-wallet-target-plugin/package.json
+++ b/packages/notifi-react-wallet-target-plugin/package.json
@@ -50,8 +50,8 @@
     "@xmtp/xmtp-js": "^11.5.0"
   },
   "peerDependencies": {
-    "@notifi-network/notifi-frontend-client": "^6.0.0",
-    "@notifi-network/notifi-react": "^6.0.0",
+    "@notifi-network/notifi-frontend-client": ">=6.0.0",
+    "@notifi-network/notifi-react": ">=6.0.0",
     "react": "^18"
   },
   "engines": {


### PR DESCRIPTION

- **Describe the purpose of the change**
  The current `peerDependencies` in `notifi-react-wallet-target-plugin` use a strict version range (`^6.0.0`), which blocks monorepo packages from publishing a major update.
  This change relaxes the constraint to `>=6.0.0` to allow compatibility with future major versions.

