### PR TITLE
MVP-6027-patch: Move version header logic to notifi-react with fallback to avoid empty values

### DIFF
--- a/packages/notifi-frontend-client/lib/client/clientFactory.ts
+++ b/packages/notifi-frontend-client/lib/client/clientFactory.ts
@@ -36,6 +36,7 @@ export const newNotifiStorage = (config: NotifiFrontendConfiguration) => {
 export const newNotifiService = <T extends { env?: NotifiEnvironment }>(
   config: T,
   gqlClientRequestConfig?: RequestConfig,
+  optionHeaders?: Record<string, string>,
 ) => {
   const url = envUrl(config.env, 'http');
   const wsurl = envUrl(config.env, 'websocket');
@@ -50,7 +51,7 @@ export const newNotifiService = <T extends { env?: NotifiEnvironment }>(
      */
     typeof window !== 'undefined' ? undefined : WebSocket,
   );
-  return new NotifiService(client, subService);
+  return new NotifiService(client, subService, optionHeaders);
 };
 
 export const newDataplaneClient = <T extends { env?: NotifiEnvironment }>(
@@ -66,6 +67,7 @@ export const instantiateFrontendClient = (
   env?: NotifiEnvironment,
   storageOption?: NotifiFrontendConfiguration['storageOption'],
   gqlClientRequestConfig?: RequestConfig, // NOTE: `graphql-request` by default uses XMLHttpRequest API. To adopt fetch API, pass in { fetch: fetch }
+  optionHeaders?: Record<string, string>,
 ): NotifiFrontendClient => {
   let config: NotifiFrontendConfiguration | null = null;
   if ('accountAddress' in params) {
@@ -115,7 +117,11 @@ export const instantiateFrontendClient = (
     throw new Error('ERROR - instantiateFrontendClient: Invalid UserParams');
   }
 
-  const service = newNotifiService(config, gqlClientRequestConfig);
+  const service = newNotifiService(
+    config,
+    gqlClientRequestConfig,
+    optionHeaders,
+  );
   const storage = newNotifiStorage(config);
   return new NotifiFrontendClient(config, service, storage);
 };

--- a/packages/notifi-frontend-client/lib/client/clientFactory.ts
+++ b/packages/notifi-frontend-client/lib/client/clientFactory.ts
@@ -6,6 +6,7 @@ import {
 import { GraphQLClient } from 'graphql-request';
 import WebSocket from 'ws';
 
+import { version } from '../../package.json';
 import {
   NotifiEnvironment,
   NotifiFrontendConfiguration,
@@ -51,6 +52,14 @@ export const newNotifiService = <T extends { env?: NotifiEnvironment }>(
      */
     typeof window !== 'undefined' ? undefined : WebSocket,
   );
+
+  if (!optionHeaders) {
+    optionHeaders = {};
+  }
+  if (!('X-Notifi-Client-Version' in optionHeaders)) {
+    optionHeaders['X-Notifi-Client-Version'] = version;
+  }
+
   return new NotifiService(client, subService, optionHeaders);
 };
 

--- a/packages/notifi-graphql/lib/NotifiService.ts
+++ b/packages/notifi-graphql/lib/NotifiService.ts
@@ -86,6 +86,7 @@ export class NotifiService
   constructor(
     graphQLClient: GraphQLClient,
     private _notifiSubService: NotifiSubscriptionService,
+    private _optionHeaders?: Record<string, string>,
   ) {
     this._typedClient = getSdk(graphQLClient);
   }
@@ -740,6 +741,12 @@ export class NotifiService
 
     if (this._jwt !== undefined) {
       headers['Authorization'] = `Bearer ${this._jwt}`;
+    }
+
+    if (this._optionHeaders) {
+      Object.entries(this._optionHeaders).forEach(([key, value]) => {
+        headers[key] = value;
+      });
     }
 
     return headers;

--- a/packages/notifi-graphql/lib/NotifiService.ts
+++ b/packages/notifi-graphql/lib/NotifiService.ts
@@ -745,7 +745,10 @@ export class NotifiService
 
     if (this._optionHeaders) {
       Object.entries(this._optionHeaders).forEach(([key, value]) => {
-        headers[key] = value;
+        /* Request ID is always set by the notifi-graphql service. */
+        if (!(key === 'X-Request-Id')) {
+          headers[key] = value;
+        }
       });
     }
 

--- a/packages/notifi-react/lib/context/NotifiFrontendClientContext.tsx
+++ b/packages/notifi-react/lib/context/NotifiFrontendClientContext.tsx
@@ -7,6 +7,7 @@ import {
 } from '@notifi-network/notifi-frontend-client';
 import React from 'react';
 
+import { version } from '../../package.json';
 import { loginViaSolanaHardwareWallet } from '../utils';
 
 export type FrontendClientStatus = {
@@ -87,11 +88,16 @@ export const NotifiFrontendClientContextProvider: React.FC<
     isEnabledLoginViaTransaction;
 
   React.useEffect(() => {
+    const optionHeaders = {
+      'X-Notifi-React-Version': version,
+    };
     const frontendClient = instantiateFrontendClient(
       tenantId,
       walletWithSignParams,
       env,
       storageOption,
+      undefined,
+      optionHeaders,
     );
 
     setIsLoading(true);

--- a/packages/notifi-react/lib/context/NotifiFrontendClientContext.tsx
+++ b/packages/notifi-react/lib/context/NotifiFrontendClientContext.tsx
@@ -88,9 +88,8 @@ export const NotifiFrontendClientContextProvider: React.FC<
     isEnabledLoginViaTransaction;
 
   React.useEffect(() => {
-    // TODO: Expose optionHeaders props to the user, so that they can pass custom headers
-    const optionHeaders = {
-      'X-Notifi-React-Version': version,
+    const requestHeaders = {
+      'X-Notifi-Client-Version': version,
     };
     const frontendClient = instantiateFrontendClient(
       tenantId,
@@ -98,7 +97,7 @@ export const NotifiFrontendClientContextProvider: React.FC<
       env,
       storageOption,
       undefined,
-      optionHeaders,
+      requestHeaders,
     );
 
     setIsLoading(true);

--- a/packages/notifi-react/lib/context/NotifiFrontendClientContext.tsx
+++ b/packages/notifi-react/lib/context/NotifiFrontendClientContext.tsx
@@ -88,6 +88,7 @@ export const NotifiFrontendClientContextProvider: React.FC<
     isEnabledLoginViaTransaction;
 
   React.useEffect(() => {
+    // TODO: Expose optionHeaders props to the user, so that they can pass custom headers
     const optionHeaders = {
       'X-Notifi-React-Version': version,
     };


### PR DESCRIPTION
This PR ensures that all outgoing GraphQL requests from the SDK include a consistent and meaningful `X-Notifi-Client-Version` header, even when the source package may vary.

* Moved version control of `X-Notifi-Client-Version` header up to the `notifi-react` layer.
* Introduced a fallback mechanism to prevent the version header from being empty:

  * Use the version of `notifi-react` if available.
  * If not, fall back to `notifi-frontend-client`.
  * If neither is available, fall back to `notifi-graphql`.

This simplifies backend version handling by avoiding the need to track separate versions per package.


