### PR TITLE
MVP-6417-patch: fix Connect.tsx view missing topic display name override fallback mechanism

### DIFF
--- a/packages/notifi-react/lib/components/Connect.tsx
+++ b/packages/notifi-react/lib/components/Connect.tsx
@@ -8,6 +8,7 @@ import {
 } from '../context';
 import { useGlobalStateContext } from '../context/GlobalStateContext';
 import { useConnect } from '../hooks/useConnect';
+import { getFusionEventMetadata } from '../utils';
 import { defaultCopy } from '../utils/constants';
 import { LoadingAnimation } from './LoadingAnimation';
 import { NavHeaderRightCta } from './NavHeader';
@@ -92,9 +93,12 @@ export const Connect: React.FC<ConnectProps> = (props) => {
         });
         return;
       }
+      const fusionEventMetadata = getFusionEventMetadata(topic);
       topicNames.push({
         index: topic.uiConfig.index ?? id,
-        value: topic.uiConfig.name,
+        value:
+          fusionEventMetadata?.uiConfigOverride?.topicDisplayName ??
+          topic.uiConfig.name,
       });
     });
     return [...topicNames, ...topicGroupNames].sort(


### PR DESCRIPTION
This PR addresses an issue where the topic display name override is not applied on the Connect view (`Connect.tsx`) in versions ≤ 7.2.1.