### PR TITLE
MVP-6434-patch: handle legacy `WalletWithSignParams` type

### DIFF
--- a/packages/notifi-frontend-client/lib/configuration/Deprecated.ts
+++ b/packages/notifi-frontend-client/lib/configuration/Deprecated.ts
@@ -1,4 +1,6 @@
+import { LoginParams } from '../client';
 import { isEvmBlockchain } from '../models';
+import { UserParams } from './Auth';
 import { NotifiFrontendConfiguration } from './Client';
 import { NotifiEnvironment } from './Env';
 
@@ -98,6 +100,9 @@ export type FrontendClientConfigFactory<T extends NotifiFrontendConfiguration> =
           ? ConfigFactoryInputPublicKey
           : ConfigFactoryInputOidc,
   ) => NotifiFrontendConfiguration;
+
+/**@deprecated Legacy type only for backward compatibility. Use `LoginParamsWithUserParams` in `notifi-react` instead. */
+export type WalletWithSignParams = LoginParams & UserParams;
 
 /**@deprecated No longer need to use configFactory, use instantiateFrontendClient instead */
 const configFactoryPublicKey: FrontendClientConfigFactory<

--- a/packages/notifi-react/README.md
+++ b/packages/notifi-react/README.md
@@ -41,7 +41,7 @@ _Environment_
 #### Prerequisites (**IMPORTANT**)
 
 - To use `NotifiCardModal`, you need to wrap your component with `NotifiContextProvider` first.
-- Notifi supports both `on-chain` and `off-chain` authentication. The authentication method differs based on the `WalletWithSignParams` [props](https://github.com/notifi-network/notifi-sdk-ts/blob/1457d642900b8969abb8f1ad353aaeb7059a6946/packages/notifi-react/lib/context/NotifiFrontendClientContext.tsx#L49) passed to the `NotifiContextProvider`.
+- Notifi supports both `on-chain` and `off-chain` authentication. The authentication method differs based on the `LoginParamsWithUserParams` [type](https://github.com/notifi-network/notifi-sdk-ts/blob/55b6d24c90d962e5ae4e20508015904754edbf0f/packages/notifi-react/lib/context/NotifiFrontendClientContext.tsx#L56) passed to the `NotifiContextProvider`.
   - For `on-chain` authentication, `walletBlockchain='<blockchain>'`, `signMessage` callback function, and the respective `wallet keys or addresses` for the `blockchain` are required. The common EVM blockchain example is shown above.
   - For `off-chain` authentication, `walletBlockchain='OFF_CHAIN'`, `signIn` callback function, and `userAccount` are required. `userAccount` can be any user-related unique identifier derived from a JWT token. The Google off-chain OIDC authentication example is shown below.
 


### PR DESCRIPTION
- Add deprecated `WalletWithSignParams` type back in frontend-client for backward compatibility
- Update doc related to this legacy type