### PR TITLE
MVP-6557: Add engines in project package.json to fix vercel preview error

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
     "packages/notifi-react",
     "packages/notifi-react-example-v2",
     "packages/notifi-react-wallet-target-plugin"
-  ]
+  ],
+  "engines": {
+    "node": "22.17.1"
+  }
 }


### PR DESCRIPTION
As title.

> ⚠️ KNOWN ISSUE: CICD failure due to `500 internal error` from Smartlink Action 