### PR TITLE
MVP-6559: Update Fusion Event identification to use fusionEventId (with legacy support via resolveStringRef) instead of event.name

### DIFF
--- a/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
+++ b/packages/notifi-frontend-client/lib/client/NotifiFrontendClient.ts
@@ -13,7 +13,7 @@ import {
   type TopicMetadata,
 } from '../models';
 import type { NotifiStorage } from '../storage';
-import { notNullOrEmpty, parseTenantConfig } from '../utils';
+import { notNullOrEmpty, parseTenantConfig, resolveStringRef } from '../utils';
 import { areIdsEqual } from '../utils/areIdsEqual';
 import {
   type AlterTargetGroupParams,
@@ -207,14 +207,20 @@ export class NotifiFrontendClient {
     const fusionEventDescriptorMap = new Map<
       string,
       Types.FusionEventDescriptor
-    >(fusionEventDescriptors.map((item) => [item?.name ?? '', item ?? {}]));
+    >(fusionEventDescriptors.map((item) => [item?.id ?? '', item ?? {}]));
 
     fusionEventDescriptorMap.delete('');
 
     const topicMetadatas = tenantConfig.eventTypes.map((eventType) => {
       if (eventType.type === 'fusion') {
         const fusionEventDescriptor = fusionEventDescriptorMap.get(
-          eventType.name,
+          typeof eventType.fusionEventId === 'string'
+            ? eventType.fusionEventId
+            : resolveStringRef(
+                'fetchTenantConfig: Lagacy event - CardConfigItemV1',
+                eventType.fusionEventId,
+                {},
+              ),
         );
         return {
           uiConfig: eventType,

--- a/packages/notifi-react-example-v2/cypress/utils/topic-utils.ts
+++ b/packages/notifi-react-example-v2/cypress/utils/topic-utils.ts
@@ -2,6 +2,7 @@ import {
   FusionEventTopic,
   TopicMetadata,
   parseTenantConfig,
+  resolveStringRef,
 } from '@notifi-network/notifi-frontend-client';
 import { Types } from '@notifi-network/notifi-graphql';
 import { CyHttpMessages } from 'cypress/types/net-stubbing';
@@ -19,7 +20,7 @@ export const getTopicList = (
     throw new Error('No fusion events found in tenant config');
 
   const fusionEventDescriptorMap = new Map<string, Types.FusionEventDescriptor>(
-    fusionEventDescriptors.map((item: any) => [item?.name ?? '', item ?? {}]),
+    fusionEventDescriptors.map((item: any) => [item?.id ?? '', item ?? {}]),
   );
 
   fusionEventDescriptorMap.delete('');
@@ -28,7 +29,13 @@ export const getTopicList = (
     .map((eventType) => {
       if (eventType.type === 'fusion') {
         const fusionEventDescriptor = fusionEventDescriptorMap.get(
-          eventType.name,
+          typeof eventType.fusionEventId === 'string'
+            ? eventType.fusionEventId
+            : resolveStringRef(
+                'fetchTenantConfig: Lagacy event - CardConfigItemV1',
+                eventType.fusionEventId,
+                {},
+              ),
         );
         return {
           uiConfig: eventType,


### PR DESCRIPTION
As title.