### PR TITLE
MVP-6812:  harden NotifiCardModal integration guidance — placement, ambiguity handling, and reopen lifecycle

### DIFF
--- a/ai/skills/notifi-react-integration/SKILL.md
+++ b/ai/skills/notifi-react-integration/SKILL.md
@@ -153,6 +153,57 @@ Implementation guidance:
 - keep the initial version small and working
 - use the existing router, layout, modal, and wallet hooks already present in the project
 
+## NotifiCardModal Entry Placement
+
+When the user wants `NotifiCardModal`, do not only think about provider wiring. Also choose a natural entry surface.
+
+Preferred heuristic:
+
+1. If the app already has a top nav or header utility area, prefer using that area for the modal entry.
+2. Prefer a small icon CTA over adding a large new section or standalone demo block.
+3. Keep the entry close to existing wallet, account, settings, or other utility actions when possible.
+4. Preserve the app's current header structure, spacing, and interaction style.
+
+If there is no clear top nav or header utility surface, fall back to the nearest existing action area instead of inventing a new layout pattern.
+
+## CTA Placement Ambiguity Handling
+
+If the app structure suggests more than one reasonable entry location, do not guess too aggressively.
+
+Guidance:
+
+- if the current UI clearly implies a best placement, proceed with the smallest natural integration
+- if there are multiple plausible locations, ask the user which entry surface they prefer
+- offer a few concrete options instead of asking an open-ended design question
+- if the user has no preference, state the default choice and proceed with the smallest reasonable option
+
+Good question pattern:
+
+- "I found an existing header/top nav. Do you want the Notifi entry as a header utility icon, an icon near wallet/account actions, a profile menu item, or a temporary minimal button while placement is still undecided?"
+
+Do not invent a brand new navigation pattern when existing app structure already provides a natural entry surface.
+
+## Modal Reopen And Readiness
+
+If the host app mounts `NotifiCardModal` inside its own dialog, popover, drawer, or other CTA-triggered shell, do not assume reopen behavior will work automatically.
+
+Guidance:
+
+- reuse the app's existing modal shell when it is already the natural integration surface
+- prefer remounting the Notifi subtree on each open instead of keeping it mounted forever behind an `open` flag
+- if reopen shows an empty modal or inconsistent state, gate the inner `NotifiCardModal` render on Notifi context readiness rather than immediately rendering it
+- use `useNotifiFrontendClientContext` and `useNotifiUserSettingContext` to wait for initialization and authenticated user-setting loading when needed
+- keep this workaround in the host app wrapper layer; do not rewrite the packaged card UI unless there is a stronger product reason
+
+Common failure mode:
+
+- first open works, but reopening after close shows an empty `.notifi-card-modal` container because the host wrapper remount timing does not align with Notifi context readiness
+
+Preferred host-app workaround:
+
+- remount the wrapper on each open
+- if the user is already authenticated, wait until the frontend client is initialized and user-setting loading is complete before rendering `NotifiCardModal`
+
 ## Custom Context Integration Path
 
 Use this when the user wants their own UI instead of `NotifiCardModal`.

--- a/ai/skills/notifi-react-integration/evals/evals.json
+++ b/ai/skills/notifi-react-integration/evals/evals.json
@@ -5,7 +5,7 @@
     {
       "id": 1,
       "prompt": "Help me integrate @notifi-network/notifi-react into my React app. I already have Aptos wallet connectivity, and I want the smallest working NotifiCardModal setup first.",
-      "expected_output": "Chooses the NotifiCardModal path, wires NotifiContextProvider into the existing app structure, reuses the app's existing Aptos wallet state for on-chain auth, adapts signing from the current wallet adapter, and asks for missing runtime values (tenantId, cardId) only when they are required.",
+      "expected_output": "Chooses the NotifiCardModal path, wires NotifiContextProvider into the existing app structure, reuses the app's existing Aptos wallet state for on-chain auth, adapts signing from the current wallet adapter, asks for missing runtime values (tenantId, cardId) only when they are required, prefers an existing header or top-nav entry surface over inventing a disconnected modal trigger, and preserves a normal open-close-reopen modal flow when the card is wrapped by the host app UI.",
       "fixture": {
         "fixture_id": "explorer",
         "path": "ai/eval-fixtures/notifi-react-integration/explorer/fixture.json"

--- a/ai/skills/notifi-react-integration/evals/rubric.md
+++ b/ai/skills/notifi-react-integration/evals/rubric.md
@@ -50,9 +50,9 @@ Did the agent preserve the user's existing app structure, conventions, and depen
 
 Is the generated code likely to compile and work?
 
-- **Pass**: Imports are correct, hook usage follows React rules, types are compatible, and the integration would work with the real SDK.
-- **Partial**: Minor issues (e.g. missing import, small type mismatch) but overall approach is sound.
-- **Fail**: Fundamental errors (e.g. wrong hook, broken component tree, incorrect API usage).
+- **Pass**: Imports are correct, hook usage follows React rules, types are compatible, and the integration would work with the real SDK. If the card is wrapped in a host-app modal shell, open, close, and reopen behavior remains functional.
+- **Partial**: Minor issues (e.g. missing import, small type mismatch) but overall approach is sound, or the integration mostly works but has a lifecycle issue such as flaky reopen behavior.
+- **Fail**: Fundamental errors (e.g. wrong hook, broken component tree, incorrect API usage), or the card opens once but fails on a normal reopen flow.
 
 ### 7. Minimality
 
@@ -62,17 +62,26 @@ Did the agent produce the smallest correct integration without unnecessary extra
 - **Partial**: Slightly over-engineered but nothing harmful.
 - **Fail**: Agent added significant unnecessary code (e.g. full custom UI when card modal was requested, wallet target plugin when not needed).
 
+### 8. Entry Placement And Ambiguity Handling
+
+Did the agent choose a natural `NotifiCardModal` entry surface and handle CTA placement ambiguity well?
+
+- **Pass**: The agent identifies a reasonable existing header, top nav, or utility surface for the entry. If placement is ambiguous, it asks the user a focused question with concrete options instead of guessing.
+- **Partial**: The chosen entry surface is workable but not very natural, or the agent defaults without asking even though multiple placements seem plausible.
+- **Fail**: The agent ignores an obvious existing navigation or utility surface, invents an unrelated entry pattern, or fails to address clear placement ambiguity.
+
 ## Scoring Summary
 
-| Dimension                 | Score | Notes |
-| ------------------------- | ----- | ----- |
-| Path Selection            |       |       |
-| Auth Mode                 |       |       |
-| Provider Placement        |       |       |
-| Required Params Handling  |       |       |
-| Existing App Preservation |       |       |
-| Code Correctness          |       |       |
-| Minimality                |       |       |
+| Dimension                              | Score | Notes |
+| -------------------------------------- | ----- | ----- |
+| Path Selection                         |       |       |
+| Auth Mode                              |       |       |
+| Provider Placement                     |       |       |
+| Required Params Handling               |       |       |
+| Existing App Preservation              |       |       |
+| Code Correctness                       |       |       |
+| Minimality                             |       |       |
+| Entry Placement And Ambiguity Handling |       |       |
 
 **Overall**: Pass / Partial / Fail
 


### PR DESCRIPTION
- Added three new guidance sections to notifi-react-integration/SKILL.md:
  - NotifiCardModal Entry Placement — Prefer top-nav/header utility areas for the modal trigger; fall back to existing action surfaces instead of inventing new layout patterns.
  - CTA Placement Ambiguity Handling — When multiple entry locations are plausible, ask the user a focused question with concrete options rather than guessing.
- Updated evals.json to reflect the new expectations in the eval 1 expected output.
- Added Entry Placement And Ambiguity Handling as dimension 8 in the evaluation rubric, and updated Code Correctness rubric to account for reopen behavior.